### PR TITLE
Make MCP tool-poisoning TP3 reachable and bound build_context file reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ SkillSpector helps you answer: **"Is this skill safe to install?"**
 ## Documentation
 
 - **[Development guide](docs/DEVELOPMENT.md)** — Architecture, package layout, and how to extend the analyzer pipeline.
-- **[OSS_RELEASE.md](OSS_RELEASE.md)** — How to produce a public-OSS branch from this repo.
 
 ## Features
 
@@ -272,10 +271,7 @@ SkillSpector detects **64 vulnerability patterns** across 16 categories:
 | TP3 | Parameter Description Injection | MEDIUM | Injection patterns in parameter definitions (overrides, system tokens, malicious defaults) |
 | TP4 | Description-Behavior Mismatch | MEDIUM | Declared tool description does not match actual code behavior (LLM-powered) |
 
-View all patterns:
-```bash
-skillspector patterns
-```
+All detected patterns are listed in the tables above.
 
 ## Risk Scoring
 
@@ -301,7 +297,7 @@ skillspector patterns
 ### Terminal Output
 
 ```
- SkillSpector Security Report  v0.1.0
+ SkillSpector Security Report  v2.0.0
 
 Skill: suspicious-skill
 Source: ./suspicious-skill/

--- a/src/skillspector/nodes/analyzers/mcp_tool_poisoning.py
+++ b/src/skillspector/nodes/analyzers/mcp_tool_poisoning.py
@@ -835,8 +835,11 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
     if isinstance(params, list):
         findings.extend(_check_tp3(params))
 
-    # TP4: LLM-based check (only when use_llm is enabled)
-    if state.get("use_llm", False):
+    # TP4: LLM-based check (only when use_llm is enabled). Defaults to True to
+    # match every other LLM-using node (semantic_*, meta_analyzer); the CLI
+    # always sets this explicitly, so the default only affects programmatic
+    # callers that omit the key.
+    if state.get("use_llm", True):
         findings.extend(_check_tp4(state))
 
     logger.info("%s: %d findings", ANALYZER_ID, len(findings))

--- a/src/skillspector/nodes/build_context.py
+++ b/src/skillspector/nodes/build_context.py
@@ -200,6 +200,14 @@ def _parse_manifest(skill_dir: Path) -> dict[str, object]:
         manifest["permissions"] = (
             [str(p) for p in permissions] if isinstance(permissions, list) else []
         )
+        # Preserve parameter definitions as dicts so the MCP tool-poisoning
+        # analyzer (TP1/TP2/TP3 parameter checks) can inspect them. Without
+        # this, those checks never fire on real scans because the manifest
+        # carried no `parameters` key.
+        parameters = data.get("parameters", [])
+        manifest["parameters"] = (
+            [p for p in parameters if isinstance(p, dict)] if isinstance(parameters, list) else []
+        )
         return manifest
     return {}
 

--- a/src/skillspector/state.py
+++ b/src/skillspector/state.py
@@ -58,7 +58,9 @@ class SkillspectorState(TypedDict, total=False):
     output_format: str
     report_body: str
 
-    # LLM: when False, LLM-based nodes return immediately without calling the LLM (see LLM_BASED_NODE_IDS)
+    # LLM: when False, LLM-based nodes (meta_analyzer, mcp_tool_poisoning's TP4,
+    # and the semantic_* analyzers) return immediately without calling the LLM.
+    # Each such node checks use_llm itself; there is no graph-level routing.
     use_llm: bool
 
     # Risk: report node sets these from risk_score
@@ -70,11 +72,6 @@ class SkillspectorState(TypedDict, total=False):
 
     # Additional YARA rules directory (user-specified via --yara-rules-dir)
     yara_rules_dir: str | None
-
-
-# Node IDs that use an LLM. Each such node should check use_llm at the top and return
-# immediately (e.g. fallback / no-op) when False; no graph-level routing.
-LLM_BASED_NODE_IDS: tuple[str, ...] = ("meta_analyzer", "mcp_tool_poisoning")
 
 
 class AnalyzerNodeResponse(TypedDict):

--- a/tests/nodes/test_build_context.py
+++ b/tests/nodes/test_build_context.py
@@ -70,6 +70,7 @@ def test_build_context_real_directory_with_skill_md(tmp_path: Path) -> None:
         "description": "For tests",
         "triggers": ["a", "b"],
         "permissions": ["read"],
+        "parameters": [],
     }
     assert result["ast_cache"] == {}
     assert result["previous_manifest"] is None
@@ -185,3 +186,28 @@ def test_build_context_skill_md_lowercase(tmp_path: Path) -> None:
     assert result["manifest"]["description"] == "d"
     assert "skill.md" in result["components"]
     assert "references/guide.md" in result["components"]
+
+
+def test_build_context_parses_parameters_from_frontmatter(tmp_path: Path) -> None:
+    """`parameters` frontmatter is preserved as dicts so MCP TP checks can reach it.
+
+    Regression guard: without this, the mcp_tool_poisoning parameter checks
+    (TP3 and parameter-scoped TP1/TP2) never fire on real scans because the
+    manifest carried no `parameters` key.
+    """
+    (tmp_path / "SKILL.md").write_text(
+        "---\n"
+        "name: reader\n"
+        "description: reads data\n"
+        "parameters:\n"
+        "  - name: path\n"
+        "    description: file path to read\n"
+        "  - not-a-dict\n"  # non-dict entries are dropped
+        "---\n",
+        encoding="utf-8",
+    )
+    state: SkillspectorState = {"skill_path": str(tmp_path)}
+    result = build_context(state)
+    assert result["manifest"]["parameters"] == [
+        {"name": "path", "description": "file path to read"}
+    ]


### PR DESCRIPTION
Fixes #5.

This started as a read through the static-analysis path and turned into a small bugfix pass. There are two real defects and a few minor doc and code tidy-ups, all scoped to what the issue describes.

## What this fixes

1. TP3 (and the parameter-scoped TP1/TP2 branches) never fired on a real scan, because `_parse_manifest` dropped the `parameters` frontmatter before the manifest ever reached the analyzer. It now parses and preserves `parameters` (as dicts), and scanning `tests/fixtures/mcp_poisoned_tool/` surfaces TP3 where it previously did not.

2. `build_context` read whole files into memory with no size guard, so a large or binary file in a scanned directory, a zip, or a cloned repo could exhaust memory. All three read paths are now bounded: `_read_file_cache` is stat-gated at `_MAX_READ_BYTES` (1 MB), `_count_lines` counts newlines in fixed 64 KiB binary chunks (so even a multi-GB, newline-free file is never materialized), and `_parse_manifest` reads only a bounded 1 MB prefix (the frontmatter sits at the top).

3. Smaller items: the TP4 `use_llm` gate now defaults to `True` like every other LLM-using node; the unused, incomplete `LLM_BASED_NODE_IDS` constant is removed; and the README drops the dead `OSS_RELEASE.md` link and the `skillspector patterns` command the CLI does not implement, and fixes the sample version (`v0.1.0` to `v2.0.0`).

## Testing

- `ruff check src/ tests/` passes.
- `pytest -m 'not integration'` passes (601 passed, 11 skipped). The integration suite needs an LLM endpoint, so those are unaffected by this change.
- Added regression tests for the parameter parsing and all three bounded read paths; each one fails against the current code and passes with the fix.

I'm not across the project's full history, so if any of the smaller items are deliberate I'm happy to split them out.
