### PR TITLE
Sync OSS release snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-dev langgraph-dev test test-unit test-integration test-cov test-ci lint lint-fix format clean build
+.PHONY: help install install-dev langgraph-dev test test-unit test-integration test-cov test-ci lint lint-fix format format-check clean build
 
 # Prefer uv if available, else use pip (set when Makefile is parsed)
 UV := $(shell command -v uv 2>/dev/null)
@@ -21,6 +21,7 @@ help:
 	@echo "  make lint           - Run linters (ruff only)"
 	@echo "  make lint-fix       - Auto-fix lint errors with ruff"
 	@echo "  make format         - Format code with ruff"
+	@echo "  make format-check   - Check code formatting with ruff"
 	@echo "  make clean          - Remove build artifacts and cache files"
 	@echo "  make build          - Build the package"
 
@@ -68,6 +69,11 @@ format:
 	@echo "Formatting with ruff..."
 	ruff check --fix src/ tests/
 	ruff format src/ tests/
+
+# Check code formatting without modifying files
+format-check:
+	@echo "Checking formatting with ruff..."
+	ruff format --check src/ tests/
 
 # Clean build artifacts
 clean:

--- a/docs/EVAL_DATASETS.md
+++ b/docs/EVAL_DATASETS.md
@@ -1,0 +1,21 @@
+# Eval Dataset Scanning
+
+SkillSpector treats authored eval datasets as test-case data, not installed
+skill logic.
+
+The static pattern analyzers skip these dataset files:
+
+- `evals/evals.json`
+- `evals/evals.jsonl`
+- `evals/evals.yaml`
+- `evals/evals.yml`
+- `eval/dataset.json`
+- `eval/dataset.jsonl`
+- `eval/dataset.yaml`
+- `eval/dataset.yml`
+
+This applies to both the agentskills.io format and the legacy flat ACES format.
+Security analysis still covers executable skill code, instructions, scripts,
+dependencies, MCP metadata, and other install-time surfaces. Eval prompts,
+expected outputs, assertions, and ground-truth strings are not treated as code
+accessing credentials or exfiltrating data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skillspector"
-version = "2.0.0"
+version = "2.1.1"
 description = "SkillSpector: Security scanner for AI agent skills (Claude Code, Cursor, and similar). Scans skills for vulnerabilities, malicious patterns, and security risks before installation. Supports Git repos, URLs, zips, and local directories; runs static pattern checks and optional LLM semantic analysis; outputs terminal, JSON, and Markdown reports with risk scoring."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/skillspector/nodes/analyzers/mcp_least_privilege.py
+++ b/src/skillspector/nodes/analyzers/mcp_least_privilege.py
@@ -217,9 +217,7 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
 
     # --- LP3: No permissions declared ---
     # Detect code capabilities first so we can check whether any were found
-    executable_paths = [
-        m["path"] for m in component_metadata if m.get("executable", False)
-    ]
+    executable_paths = [m["path"] for m in component_metadata if m.get("executable", False)]
 
     # Per-file capabilities: {path: set[cap]}
     file_capabilities: dict[str, set[str]] = {}
@@ -286,7 +284,9 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
                 confidence = _clamp(0.55 if is_test_only else 0.75)
                 source_files = [p for p, caps in file_capabilities.items() if cap in caps]
                 primary_file = source_files[0] if source_files else "SKILL.md"
-                logger.debug("%s: LP1 underdeclared capability %s in %s", ANALYZER_ID, cap, primary_file)
+                logger.debug(
+                    "%s: LP1 underdeclared capability %s in %s", ANALYZER_ID, cap, primary_file
+                )
                 findings.append(
                     Finding(
                         rule_id="LP1",
@@ -324,7 +324,9 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
             if matched_cat is None:
                 continue  # unknown permission, skip
             if matched_cat not in all_caps:
-                logger.debug("%s: LP4 over-declared permission %s (→%s)", ANALYZER_ID, perm, matched_cat)
+                logger.debug(
+                    "%s: LP4 over-declared permission %s (→%s)", ANALYZER_ID, perm, matched_cat
+                )
                 findings.append(
                     Finding(
                         rule_id="LP4",

--- a/src/skillspector/nodes/analyzers/mcp_tool_poisoning.py
+++ b/src/skillspector/nodes/analyzers/mcp_tool_poisoning.py
@@ -182,9 +182,7 @@ def _check_tp1(text: str, source_field: str) -> list[Finding]:
         findings.append(
             Finding(
                 rule_id="TP1",
-                message=(
-                    f"HTML comment found in '{source_field}': potential hidden instruction."
-                ),
+                message=(f"HTML comment found in '{source_field}': potential hidden instruction."),
                 severity="HIGH",
                 confidence=confidence,
                 file="SKILL.md",
@@ -353,8 +351,7 @@ def _check_tp2(text: str, source_field: str, is_identifier: bool) -> list[Findin
         if found_confusables:
             homoglyph_found = True
             examples = ", ".join(
-                f"U+{ord(c):04X} (looks like '{latin}')"
-                for c, latin in found_confusables[:3]
+                f"U+{ord(c):04X} (looks like '{latin}')" for c, latin in found_confusables[:3]
             )
             findings.append(
                 Finding(
@@ -755,7 +752,7 @@ Respond in JSON matching this exact schema:
             # Strip opening fence (```json or ```)
             first_newline = json_text.find("\n")
             if first_newline != -1:
-                json_text = json_text[first_newline + 1:]
+                json_text = json_text[first_newline + 1 :]
             # Strip closing fence
             if json_text.rstrip().endswith("```"):
                 json_text = json_text.rstrip()[:-3].rstrip()
@@ -789,9 +786,7 @@ Respond in JSON matching this exact schema:
                 file="SKILL.md",
                 category=_CATEGORY,
                 tags=list(_FRAMEWORK_TAGS),
-                explanation=explanation or (
-                    f"Declared: {declared}. Actual: {actual}."
-                ),
+                explanation=explanation or (f"Declared: {declared}. Actual: {actual}."),
                 remediation=(
                     "Update the skill description to accurately reflect all capabilities, "
                     "or remove undeclared functionality from the implementation."

--- a/src/skillspector/nodes/analyzers/static_runner.py
+++ b/src/skillspector/nodes/analyzers/static_runner.py
@@ -47,6 +47,16 @@ FILE_TYPES: dict[str, str] = {
 }
 
 MAX_FILE_BYTES = 1_000_000
+_EVAL_DATASET_FILES = {
+    "evals/evals.json",
+    "evals/evals.jsonl",
+    "evals/evals.yaml",
+    "evals/evals.yml",
+    "eval/dataset.json",
+    "eval/dataset.jsonl",
+    "eval/dataset.yaml",
+    "eval/dataset.yml",
+}
 
 
 def _infer_file_type(path: str) -> str:
@@ -54,6 +64,11 @@ def _infer_file_type(path: str) -> str:
     idx = path.rfind(".")
     suffix = path[idx:].lower() if idx >= 0 else ""
     return FILE_TYPES.get(suffix, "other")
+
+
+def _is_eval_dataset(path: str) -> bool:
+    """Return True for authored eval datasets that contain test-case prose."""
+    return path.replace("\\", "/") in _EVAL_DATASET_FILES
 
 
 def analyzer_finding_to_finding(
@@ -103,6 +118,9 @@ def run_static_patterns(
     findings: list[Finding] = []
 
     for path in components:
+        if _is_eval_dataset(path):
+            logger.debug("Skipping eval dataset prose for static pattern scan: %s", path)
+            continue
         content = file_cache.get(path)
         if content is None:
             logger.debug("Skipping %s: no content in file_cache", path)

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -21,6 +21,9 @@ from skillspector.nodes.analyzers import (
     static_patterns_data_exfiltration as data_exfiltration_module,
 )
 from skillspector.nodes.analyzers import (
+    static_patterns_privilege_escalation as privilege_escalation_module,
+)
+from skillspector.nodes.analyzers import (
     static_patterns_prompt_injection as prompt_injection_module,
 )
 from skillspector.nodes.analyzers import (
@@ -105,6 +108,33 @@ class TestRunStaticPatternsDataExfiltration:
         assert any(f.rule_id == "E2" for f in findings)
         e2 = next(f for f in findings if f.rule_id == "E2")
         assert e2.severity == "HIGH"
+
+    def test_eval_dataset_prose_is_not_scanned_for_static_patterns(self):
+        """Eval datasets are test-case data, not installed skill code."""
+        for dataset_path in ("evals/evals.json", "eval/dataset.yaml"):
+            state = {
+                "components": [dataset_path],
+                "file_cache": {
+                    dataset_path: """{
+  "skill_name": "safe-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Explain why reading ~/.ssh/id_rsa is unsafe.",
+      "expected_output": "Warn the user not to access credential files.",
+      "assertions": ["Does not access ~/.aws/credentials"]
+    }
+  ]
+}""",
+                },
+            }
+
+            findings = static_runner.run_static_patterns(
+                state,
+                [data_exfiltration_module, privilege_escalation_module],
+            )
+
+            assert findings == [], f"Expected no findings for {dataset_path}"
 
 
 class TestRunStaticPatternsSupplyChain:

--- a/tests/test_mcp_least_privilege.py
+++ b/tests/test_mcp_least_privilege.py
@@ -222,7 +222,13 @@ class TestLP1UnderdeclaredCapability:
                 ),
             },
             "component_metadata": [
-                {"path": "scripts/agent.py", "type": "python", "executable": True, "lines": 4, "size_bytes": 100},
+                {
+                    "path": "scripts/agent.py",
+                    "type": "python",
+                    "executable": True,
+                    "lines": 4,
+                    "size_bytes": 100,
+                },
             ],
             "has_executable_scripts": True,
             "components": ["scripts/agent.py"],
@@ -230,7 +236,9 @@ class TestLP1UnderdeclaredCapability:
         result = mcp_least_privilege.node(state)
         findings = result["findings"]
         lp1_findings = [f for f in findings if f.rule_id == "LP1"]
-        assert len(lp1_findings) >= 1, f"Expected LP1 findings, got: {[f.rule_id for f in findings]}"
+        assert len(lp1_findings) >= 1, (
+            f"Expected LP1 findings, got: {[f.rule_id for f in findings]}"
+        )
         for lp1 in lp1_findings:
             assert lp1.severity == "HIGH", f"Expected HIGH severity for LP1, got {lp1.severity}"
             assert lp1.confidence >= 0.70
@@ -306,8 +314,20 @@ class TestEdgeCases:
                 "README.md": "# Read me\n",
             },
             "component_metadata": [
-                {"path": "SKILL.md", "type": "markdown", "executable": False, "lines": 4, "size_bytes": 40},
-                {"path": "README.md", "type": "markdown", "executable": False, "lines": 2, "size_bytes": 15},
+                {
+                    "path": "SKILL.md",
+                    "type": "markdown",
+                    "executable": False,
+                    "lines": 4,
+                    "size_bytes": 40,
+                },
+                {
+                    "path": "README.md",
+                    "type": "markdown",
+                    "executable": False,
+                    "lines": 2,
+                    "size_bytes": 15,
+                },
             ],
             "has_executable_scripts": False,
             "components": ["README.md", "SKILL.md"],
@@ -332,7 +352,13 @@ class TestEdgeCases:
                 ),
             },
             "component_metadata": [
-                {"path": "scripts/run.py", "type": "python", "executable": True, "lines": 4, "size_bytes": 90},
+                {
+                    "path": "scripts/run.py",
+                    "type": "python",
+                    "executable": True,
+                    "lines": 4,
+                    "size_bytes": 90,
+                },
             ],
             "has_executable_scripts": True,
             "components": ["scripts/run.py"],
@@ -359,9 +385,7 @@ class TestEdgeCases:
             },
             "file_cache": {
                 "test_helper.py": (
-                    "import httpx\n"
-                    "def test_fetch():\n"
-                    "    return httpx.get('http://example.com')\n"
+                    "import httpx\ndef test_fetch():\n    return httpx.get('http://example.com')\n"
                 ),
             },
             "component_metadata": [

--- a/tests/test_mcp_tool_poisoning.py
+++ b/tests/test_mcp_tool_poisoning.py
@@ -243,7 +243,9 @@ class TestTP1HiddenInstructions:
         result = mcp_tool_poisoning.node(state)
         findings = result["findings"]
         tp1 = [f for f in findings if f.rule_id == "TP1"]
-        assert len(tp1) >= 1, f"Expected TP1 finding for zero-width char, got: {[f.rule_id for f in findings]}"
+        assert len(tp1) >= 1, (
+            f"Expected TP1 finding for zero-width char, got: {[f.rule_id for f in findings]}"
+        )
         assert tp1[0].confidence >= 0.85
 
     def test_base64_in_description(self):
@@ -262,7 +264,9 @@ class TestTP1HiddenInstructions:
         result = mcp_tool_poisoning.node(state)
         findings = result["findings"]
         tp1 = [f for f in findings if f.rule_id == "TP1"]
-        assert len(tp1) >= 1, f"Expected TP1 finding for base64, got: {[f.rule_id for f in findings]}"
+        assert len(tp1) >= 1, (
+            f"Expected TP1 finding for base64, got: {[f.rule_id for f in findings]}"
+        )
         assert tp1[0].confidence >= 0.75
 
     def test_data_uri_in_metadata(self):
@@ -279,7 +283,9 @@ class TestTP1HiddenInstructions:
         result = mcp_tool_poisoning.node(state)
         findings = result["findings"]
         tp1 = [f for f in findings if f.rule_id == "TP1"]
-        assert len(tp1) >= 1, f"Expected TP1 finding for data URI, got: {[f.rule_id for f in findings]}"
+        assert len(tp1) >= 1, (
+            f"Expected TP1 finding for data URI, got: {[f.rule_id for f in findings]}"
+        )
 
     def test_instruction_keyword_in_comment(self):
         """HTML comment with instruction keyword → TP1, confidence >= 0.95."""
@@ -323,7 +329,9 @@ class TestTP2UnicodeDeception:
         result = mcp_tool_poisoning.node(state)
         findings = result["findings"]
         tp2 = [f for f in findings if f.rule_id == "TP2"]
-        assert len(tp2) >= 1, f"Expected TP2 finding for homoglyph, got: {[f.rule_id for f in findings]}"
+        assert len(tp2) >= 1, (
+            f"Expected TP2 finding for homoglyph, got: {[f.rule_id for f in findings]}"
+        )
         assert tp2[0].confidence >= 0.90, f"Expected confidence >= 0.90, got {tp2[0].confidence}"
 
     def test_rtl_override(self):
@@ -339,7 +347,9 @@ class TestTP2UnicodeDeception:
         result = mcp_tool_poisoning.node(state)
         findings = result["findings"]
         tp2 = [f for f in findings if f.rule_id == "TP2"]
-        assert len(tp2) >= 1, f"Expected TP2 finding for RTL override, got: {[f.rule_id for f in findings]}"
+        assert len(tp2) >= 1, (
+            f"Expected TP2 finding for RTL override, got: {[f.rule_id for f in findings]}"
+        )
         assert tp2[0].confidence >= 0.95, f"Expected confidence >= 0.95, got {tp2[0].confidence}"
 
     def test_mixed_script(self):
@@ -356,7 +366,9 @@ class TestTP2UnicodeDeception:
         result = mcp_tool_poisoning.node(state)
         findings = result["findings"]
         tp2 = [f for f in findings if f.rule_id == "TP2"]
-        assert len(tp2) >= 1, f"Expected TP2 finding for mixed script, got: {[f.rule_id for f in findings]}"
+        assert len(tp2) >= 1, (
+            f"Expected TP2 finding for mixed script, got: {[f.rule_id for f in findings]}"
+        )
         assert any("script" in (f.message or "").lower() for f in tp2), (
             f"Expected 'script' in TP2 message, got: {[f.message for f in tp2]}"
         )
@@ -374,7 +386,9 @@ class TestTP2UnicodeDeception:
         result = mcp_tool_poisoning.node(state)
         findings = result["findings"]
         tp2 = [f for f in findings if f.rule_id == "TP2"]
-        assert len(tp2) >= 1, f"Expected TP2 finding for invisible formatting, got: {[f.rule_id for f in findings]}"
+        assert len(tp2) >= 1, (
+            f"Expected TP2 finding for invisible formatting, got: {[f.rule_id for f in findings]}"
+        )
         assert tp2[0].confidence >= 0.80, f"Expected confidence >= 0.80, got {tp2[0].confidence}"
 
 
@@ -422,7 +436,9 @@ class TestTP3ParameterInjection:
         result = mcp_tool_poisoning.node(state)
         findings = result["findings"]
         tp3 = [f for f in findings if f.rule_id == "TP3"]
-        assert len(tp3) >= 1, f"Expected TP3 finding for SYSTEM token, got: {[f.rule_id for f in findings]}"
+        assert len(tp3) >= 1, (
+            f"Expected TP3 finding for SYSTEM token, got: {[f.rule_id for f in findings]}"
+        )
         assert tp3[0].confidence >= 0.90, f"Expected confidence >= 0.90, got {tp3[0].confidence}"
 
     def test_exfiltration_in_param_description(self):
@@ -443,7 +459,9 @@ class TestTP3ParameterInjection:
         result = mcp_tool_poisoning.node(state)
         findings = result["findings"]
         tp3 = [f for f in findings if f.rule_id == "TP3"]
-        assert len(tp3) >= 1, f"Expected TP3 finding for exfiltration, got: {[f.rule_id for f in findings]}"
+        assert len(tp3) >= 1, (
+            f"Expected TP3 finding for exfiltration, got: {[f.rule_id for f in findings]}"
+        )
 
     def test_malicious_default_value(self):
         """Parameter default value containing curl command → TP3 finding."""
@@ -464,7 +482,9 @@ class TestTP3ParameterInjection:
         result = mcp_tool_poisoning.node(state)
         findings = result["findings"]
         tp3 = [f for f in findings if f.rule_id == "TP3"]
-        assert len(tp3) >= 1, f"Expected TP3 finding for malicious default, got: {[f.rule_id for f in findings]}"
+        assert len(tp3) >= 1, (
+            f"Expected TP3 finding for malicious default, got: {[f.rule_id for f in findings]}"
+        )
 
     def test_excessive_description_length(self):
         """Parameter description exceeding 500 chars → TP3 finding, confidence ~0.65."""
@@ -485,7 +505,9 @@ class TestTP3ParameterInjection:
         result = mcp_tool_poisoning.node(state)
         findings = result["findings"]
         tp3 = [f for f in findings if f.rule_id == "TP3"]
-        assert len(tp3) >= 1, f"Expected TP3 finding for excessive length, got: {[f.rule_id for f in findings]}"
+        assert len(tp3) >= 1, (
+            f"Expected TP3 finding for excessive length, got: {[f.rule_id for f in findings]}"
+        )
         # Confidence should be approximately 0.65
         len_finding = [f for f in tp3 if abs(f.confidence - 0.65) < 0.05]
         assert len(len_finding) >= 1, (
@@ -583,6 +605,7 @@ class TestTP4Fallbacks:
 
     def test_llm_call_failure_returns_empty(self):
         from unittest.mock import patch
+
         state = _make_state("mcp_mismatched_skill", use_llm=True)
         with patch(
             "skillspector.nodes.analyzers.mcp_tool_poisoning.chat_completion",
@@ -594,6 +617,7 @@ class TestTP4Fallbacks:
 
     def test_unparseable_response_returns_empty(self):
         from unittest.mock import patch
+
         state = _make_state("mcp_mismatched_skill", use_llm=True)
         with patch(
             "skillspector.nodes.analyzers.mcp_tool_poisoning.chat_completion",
@@ -620,13 +644,16 @@ class TestFullPipelineIntegration:
     def test_full_pipeline_poisoned_skill(self):
         """TP1+TP2 findings survive meta_analyzer filtering."""
         from skillspector.graph import create_graph
+
         fixture_path = str(FIXTURES_DIR / "mcp_poisoned_tool")
         graph = create_graph()
-        result = graph.invoke({
-            "input_path": fixture_path,
-            "output_format": "json",
-            "use_llm": False,
-        })
+        result = graph.invoke(
+            {
+                "input_path": fixture_path,
+                "output_format": "json",
+                "use_llm": False,
+            }
+        )
         # Check filtered_findings (post-meta_analyzer) or findings (pre-meta)
         findings = result.get("filtered_findings") or result.get("findings", [])
         rule_ids = {f.rule_id for f in findings}
@@ -635,13 +662,16 @@ class TestFullPipelineIntegration:
     def test_full_pipeline_clean_skill(self):
         """Clean skill produces no MCP findings through full pipeline."""
         from skillspector.graph import create_graph
+
         fixture_path = str(FIXTURES_DIR / "mcp_clean_skill")
         graph = create_graph()
-        result = graph.invoke({
-            "input_path": fixture_path,
-            "output_format": "json",
-            "use_llm": False,
-        })
+        result = graph.invoke(
+            {
+                "input_path": fixture_path,
+                "output_format": "json",
+                "use_llm": False,
+            }
+        )
         findings = result.get("filtered_findings") or result.get("findings", [])
         mcp_findings = [f for f in findings if f.rule_id.startswith(("TP", "LP"))]
         assert len(mcp_findings) == 0
@@ -649,13 +679,16 @@ class TestFullPipelineIntegration:
     def test_sarif_output_contains_tp_rules(self):
         """SARIF output includes TP rule IDs and ASI02 tags."""
         from skillspector.graph import create_graph
+
         fixture_path = str(FIXTURES_DIR / "mcp_poisoned_tool")
         graph = create_graph()
-        result = graph.invoke({
-            "input_path": fixture_path,
-            "output_format": "sarif",
-            "use_llm": False,
-        })
+        result = graph.invoke(
+            {
+                "input_path": fixture_path,
+                "output_format": "sarif",
+                "use_llm": False,
+            }
+        )
         sarif = result.get("sarif_report", {})
         runs = sarif.get("runs", [])
         assert len(runs) > 0
@@ -667,13 +700,16 @@ class TestFullPipelineIntegration:
     def test_no_llm_mode_excludes_tp4(self):
         """With use_llm=False, TP4 should not appear."""
         from skillspector.graph import create_graph
+
         fixture_path = str(FIXTURES_DIR / "mcp_poisoned_tool")
         graph = create_graph()
-        result = graph.invoke({
-            "input_path": fixture_path,
-            "output_format": "json",
-            "use_llm": False,
-        })
+        result = graph.invoke(
+            {
+                "input_path": fixture_path,
+                "output_format": "json",
+                "use_llm": False,
+            }
+        )
         findings = result.get("filtered_findings") or result.get("findings", [])
         rule_ids = {f.rule_id for f in findings}
         assert "TP4" not in rule_ids

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -83,9 +83,7 @@ class TestCredentialResolution:
 
 
 class TestIsLlmAvailable:
-    def test_returns_true_when_credentials_present(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_returns_true_when_credentials_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OPENAI_API_KEY", "k")
         ok, msg = is_llm_available()
         assert ok is True

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -90,9 +90,7 @@ class TestNvBuildProvider:
     def test_resolve_model_default_when_no_env(self) -> None:
         assert NvBuildProvider().resolve_model() == NvBuildProvider.DEFAULT_MODEL
 
-    def test_resolve_model_env_overrides_default(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_resolve_model_env_overrides_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("SKILLSPECTOR_MODEL", "user/override")
         assert NvBuildProvider().resolve_model() == "user/override"
         # Env override applies to every slot.
@@ -108,8 +106,7 @@ class TestNvBuildProvider:
     def test_resolve_model_unknown_slot_falls_to_default(self) -> None:
         # Slots without an explicit override inherit DEFAULT_MODEL.
         assert (
-            NvBuildProvider().resolve_model("mcp_least_privilege")
-            == NvBuildProvider.DEFAULT_MODEL
+            NvBuildProvider().resolve_model("mcp_least_privilege") == NvBuildProvider.DEFAULT_MODEL
         )
 
 
@@ -138,9 +135,7 @@ class TestNvInferenceProvider:
         """With NVIDIA_INFERENCE_METADATA_KEY unset, we fall back to bundled YAML."""
         provider = NvInferenceProvider()
         assert provider.get_context_length("azure/anthropic/claude-sonnet-4-6") == 1_000_000
-        assert (
-            provider.get_max_output_tokens("azure/anthropic/claude-sonnet-4-6") == 128_000
-        )
+        assert provider.get_max_output_tokens("azure/anthropic/claude-sonnet-4-6") == 128_000
 
     def test_metadata_unknown_model_returns_none(self) -> None:
         provider = NvInferenceProvider()
@@ -162,9 +157,7 @@ class TestNvInferenceProvider:
     ) -> None:
         monkeypatch.setenv("SKILLSPECTOR_MODEL", "user/override")
         # Env wins over the meta_analyzer slot default.
-        assert (
-            NvInferenceProvider().resolve_model("meta_analyzer") == "user/override"
-        )
+        assert NvInferenceProvider().resolve_model("meta_analyzer") == "user/override"
 
 
 class TestOpenAIProvider:

--- a/uv.lock
+++ b/uv.lock
@@ -2095,7 +2095,7 @@ wheels = [
 
 [[package]]
 name = "skillspector"
-version = "2.0.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Refresh public SkillSpector from the internal OSS release snapshot.
- Source branch: `release/oss-2026-06-04`
- Source commit: `ddbd0fa077c0cea24150b3a788ac9601bb7d6283`

## Diff Notes

- Bumps package metadata to `2.1.1` and refreshes the editable package entry in `uv.lock` after `uv sync --all-extras`.
- Adds `docs/EVAL_DATASETS.md` and skips authored eval dataset prose in static pattern scanning.
- Adds `make format-check`.
- Refreshes MCP analyzer formatting and tests around least privilege, tool poisoning, and static pattern coverage.
- No `.github/` automation or public-only policy files were deleted.

## Verification

- `./scripts/create-oss-release.sh release/oss-2026-06-04` prepared the sanitized orphan snapshot; the initial unactivated shell lacked `pytest`, so the exact smoke gate was rerun with `.venv/bin` on `PATH`.
- `PATH="$PWD/.venv/bin:$PATH" make test-unit` in the internal OSS snapshot: 599 passed, 11 skipped, 22 deselected.
- `uv sync --all-extras` in the GitHub checkout.
- `PATH="$PWD/.venv/bin:$PATH" make test-unit` in the GitHub checkout: 599 passed, 11 skipped, 22 deselected.
- `git diff --check origin/main`.
- `git diff --name-only --diff-filter=D origin/main`.
