### PR TITLE
Sync OSS release snapshot to 2.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skillspector"
-version = "2.1.1"
+version = "2.1.2"
 description = "SkillSpector: Security scanner for AI agent skills (Claude Code, Cursor, and similar). Scans skills for vulnerabilities, malicious patterns, and security risks before installation. Supports Git repos, URLs, zips, and local directories; runs static pattern checks and optional LLM semantic analysis; outputs terminal, JSON, and Markdown reports with risk scoring."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2095,7 +2095,7 @@ wheels = [
 
 [[package]]
 name = "skillspector"
-version = "2.1.1"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Refresh public SkillSpector from the internal OSS release snapshot.
- Source branch: `release/oss-2026-06-09`
- Source commit: `6be28f274abcb274720d1f4906cec00bf15cb934`

## Diff Notes

- Bump the package version in `pyproject.toml` from `2.1.1` to `2.1.2`.
- Refresh the editable `skillspector` package metadata in `uv.lock` from `2.1.1` to `2.1.2`.

## Verification

- `./scripts/create-oss-release.sh release/oss-2026-06-09` created the sanitized orphan branch and reached the required `make test-unit` gate; the first local run stopped because the active pyenv environment did not expose `pytest`.
- `uv lock` on the internal release branch aligned `uv.lock` with `pyproject.toml`.
- `uv run make test-unit` on the internal release branch: 600 passed, 11 skipped, 22 deselected.
- `uv sync --all-extras` and `PATH=.venv/bin:$PATH make test-unit` in the GitHub checkout: 600 passed, 11 skipped, 22 deselected.
