### PR TITLE
Sync OSS release snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,4 +99,3 @@ build: clean
 docker-build:
 	docker build -t skillspector .
 
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skillspector"
-version = "2.1.3"
+version = "2.1.4"
 description = "SkillSpector: Security scanner for AI agent skills (Claude Code, Cursor, and similar). Scans skills for vulnerabilities, malicious patterns, and security risks before installation. Supports Git repos, URLs, zips, and local directories; runs static pattern checks and optional LLM semantic analysis; outputs terminal, JSON, and Markdown reports with risk scoring."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "skillspector"
-version = "2.1.3"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Refresh public SkillSpector from internal OSS release branch `release/oss-2026-06-13`.
- Source commit: `a2a659364f9a5a72dafa71f56098b51f1ef2e9d5`.

## Diff Notes

- Bump package metadata from `2.1.3` to `2.1.4` in `pyproject.toml`.
- Bump the editable package entry from `2.1.3` to `2.1.4` in `uv.lock`.
- Drop one trailing blank line from the generated `Makefile`.

## Verification

- `PYENV_VERSION=3.13.12 PYTHONPATH=src ./scripts/create-oss-release.sh release/oss-2026-06-13` (includes `make test-unit`: 600 passed, 11 skipped, 22 deselected).
- `PYENV_VERSION=3.13.12 PYTHONPATH=src pytest -m "not integration" tests/` in the GitHub checkout (600 passed).

## Notes

- The release script was run with `PYTHONPATH=src` so pytest imports the generated source tree rather than a previously installed `skillspector` package.