### PR TITLE
ci: add GitHub Actions workflow (lint, unit tests, DCO)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+jobs:
+  lint-and-test:
+    name: Lint & Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    # Windows is excluded: the test suite has known path-separator failures
+    # in build_context that are out of scope for this workflow.
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Lint with ruff
+        run: uv run ruff check src/ tests/
+
+      - name: Check formatting with ruff
+        run: uv run ruff format --check src/ tests/
+
+      - name: Run unit tests
+        run: uv run pytest -m "not integration"
+
+      - name: Run unit tests with coverage
+        run: uv run pytest -m "not integration" --cov=src/skillspector --cov-report=term-missing
+
+  dco:
+    name: DCO Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify DCO sign-off on all commits
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          MISSING=$(git log --pretty=format:"%H %s" "${BASE}..${HEAD}" | while read -r sha msg; do
+            if ! git log -1 --format="%B" "$sha" | grep -q "^Signed-off-by:"; then
+              echo "  $sha: $msg"
+            fi
+          done)
+          if [ -n "$MISSING" ]; then
+            echo "The following commits are missing Signed-off-by trailers:"
+            echo "$MISSING"
+            echo ""
+            echo "Please add a DCO sign-off (git commit -s) to all commits."
+            exit 1
+          fi
+          echo "All commits have DCO sign-off."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ on:
   push:
     branches: ["main"]
 
+# Least privilege: these jobs only read the repo; no write scopes are needed.
+permissions:
+  contents: read
+
+# Cancel superseded runs when new commits are pushed to the same ref.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-and-test:
     name: Lint & Test (Python ${{ matrix.python-version }})
@@ -36,7 +45,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        # Pinned to a full commit SHA (third-party action); comment tracks the tag.
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -49,9 +59,6 @@ jobs:
 
       - name: Check formatting with ruff
         run: uv run ruff format --check src/ tests/
-
-      - name: Run unit tests
-        run: uv run pytest -m "not integration"
 
       - name: Run unit tests with coverage
         run: uv run pytest -m "not integration" --cov=src/skillspector --cov-report=term-missing
@@ -69,14 +76,19 @@ jobs:
         run: |
           BASE=${{ github.event.pull_request.base.sha }}
           HEAD=${{ github.event.pull_request.head.sha }}
-          MISSING=$(git log --pretty=format:"%H %s" "${BASE}..${HEAD}" | while read -r sha msg; do
+          # Iterate SHAs directly rather than piping `git log` into `while read`:
+          # `git log` does not print a trailing newline after the final record,
+          # so a read-loop silently skips the last commit — and for a one-commit
+          # PR (the common case) the body never runs at all, letting an unsigned
+          # commit pass. A for-loop over the SHA list checks every commit.
+          status=0
+          for sha in $(git log --format=%H "${BASE}..${HEAD}"); do
             if ! git log -1 --format="%B" "$sha" | grep -q "^Signed-off-by:"; then
-              echo "  $sha: $msg"
+              echo "  missing Signed-off-by: $sha $(git log -1 --format=%s "$sha")"
+              status=1
             fi
-          done)
-          if [ -n "$MISSING" ]; then
-            echo "The following commits are missing Signed-off-by trailers:"
-            echo "$MISSING"
+          done
+          if [ "$status" -ne 0 ]; then
             echo ""
             echo "Please add a DCO sign-off (git commit -s) to all commits."
             exit 1


### PR DESCRIPTION
Closes #58

## What

Adds `.github/workflows/ci.yml`: on `pull_request`/`push` to `main`, runs on `ubuntu-latest` across Python 3.12 and 3.13 — `ruff check`, `ruff format --check`, and `pytest -m "not integration"` (unit tests only; integration tests call real LLMs and need secrets, so they're excluded). A separate `dco` job enforces the `Signed-off-by` requirement from CONTRIBUTING.md.

## Note

Proposal — the repo currently has no public workflows and NVIDIA may run CI internally. Happy to adjust or close if you prefer internal-only CI, want Codecov, etc. (The suite has known Windows-only path-separator failures in `build_context`, which is why CI targets Linux only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)