### PR TITLE
security(meta_analyzer): preserve high-severity static findings from LLM suppression

### DIFF
--- a/src/skillspector/models.py
+++ b/src/skillspector/models.py
@@ -101,6 +101,9 @@ class Finding:
             "remediation": self.remediation,
             "code_snippet": self.code_snippet or self.context,
             "intent": self.intent,
+            # Tags surface markers like "llm-unconfirmed" (a high-severity static
+            # finding the LLM filter did not confirm but which is preserved anyway).
+            "tags": list(self.tags),
         }
 
     def __str__(self) -> str:

--- a/src/skillspector/nodes/meta_analyzer.py
+++ b/src/skillspector/nodes/meta_analyzer.py
@@ -266,6 +266,14 @@ class LLMMetaAnalyzer(LLMAnalyzerBase):
 
     # -- Apply filter (keyed by file + rule_id + start/end_line) -------------
 
+    # Severities that must never be silently dropped by LLM filtering.
+    # Because the LLM receives attacker-controlled skill content, a prompt-injection
+    # payload could cause it to omit or deny a real CRITICAL/HIGH static finding.
+    # For these severities a false-negative (hiding a real vulnerability) is far
+    # worse than a false-positive, so we keep the original static finding regardless
+    # of what the LLM says and mark it "llm-unconfirmed" via the tags field.
+    _HIGH_SEVERITY_FLOOR = frozenset({"CRITICAL", "HIGH"})
+
     def apply_filter(
         self,
         findings: list[Finding],
@@ -279,6 +287,15 @@ class LLMMetaAnalyzer(LLMAnalyzerBase):
         is included in the key when provided but falls back to ``None`` so
         callers that omit it still match.  Falls back to coarse
         ``(file, rule_id)`` keying for LLM responses that omit ``start_line``.
+
+        Severity-gated floor (security invariant)
+        ------------------------------------------
+        CRITICAL and HIGH static findings are **always** kept in the output even
+        if the LLM did not confirm them.  When the LLM omits or denies such a
+        finding the original static finding is preserved unchanged and the tag
+        ``"llm-unconfirmed"`` is appended so consumers can distinguish it from
+        LLM-validated findings.  MEDIUM and LOW findings continue to be filtered
+        by the LLM as before (false-positive reduction).
         """
         _enrichment = tuple[str, str, float]
         confirmed_granular: dict[tuple[str, str, int, int | None], _enrichment] = {}
@@ -323,6 +340,37 @@ class LLMMetaAnalyzer(LLMAnalyzerBase):
             elif coarse_key in confirmed_coarse:
                 expl, rem, conf = confirmed_coarse[coarse_key]
             else:
+                # Security: CRITICAL/HIGH static findings must survive LLM filtering.
+                # A prompt-injection payload in the scanned skill could cause the LLM
+                # to deny or omit a real high-severity finding; silently dropping it
+                # would be a false-negative in a security gate.  Keep the original
+                # finding and tag it so consumers know it was not LLM-validated.
+                if f.severity in self._HIGH_SEVERITY_FLOOR:
+                    unconfirmed_tags = list(f.tags)
+                    if "llm-unconfirmed" not in unconfirmed_tags:
+                        unconfirmed_tags.append("llm-unconfirmed")
+                    result.append(
+                        Finding(
+                            rule_id=f.rule_id,
+                            message=f.message,
+                            severity=f.severity,
+                            confidence=f.confidence,
+                            file=f.file,
+                            start_line=f.start_line,
+                            end_line=f.end_line,
+                            remediation=f.remediation or get_remediation(f.rule_id),
+                            tags=unconfirmed_tags,
+                            context=f.context,
+                            matched_text=f.matched_text,
+                            category=getattr(f, "category", None),
+                            pattern=getattr(f, "pattern", None),
+                            finding=getattr(f, "finding", None),
+                            explanation=getattr(f, "explanation", None),
+                            code_snippet=getattr(f, "code_snippet", None) or f.context,
+                            intent=None,
+                        )
+                    )
+                # MEDIUM/LOW: preserve existing behaviour (LLM may filter as false-positive).
                 continue
             result.append(
                 Finding(

--- a/tests/nodes/test_llm_analyzer_base.py
+++ b/tests/nodes/test_llm_analyzer_base.py
@@ -1086,6 +1086,193 @@ class TestLLMMetaAnalyzerApplyFilter:
 
 
 # ---------------------------------------------------------------------------
+# LLMMetaAnalyzer.apply_filter — severity-gated suppression floor
+#
+# Security invariant: CRITICAL and HIGH static findings must survive LLM
+# filtering even if the LLM (operating on attacker-controlled skill content)
+# omits or denies them.  MEDIUM/LOW findings are still filtered normally.
+# ---------------------------------------------------------------------------
+
+
+class TestApplyFilterSeverityFloor:
+    """Tests for the severity-gated suppression floor in apply_filter.
+
+    Verifies that CRITICAL/HIGH static findings are never silently dropped
+    by the LLM filter (adversarial prompt-injection defence), while MEDIUM/LOW
+    findings continue to be filtered as before.
+    """
+
+    MODEL = "nvidia/openai/gpt-oss-120b"
+
+    def _make_finding(
+        self,
+        rule_id: str,
+        severity: str,
+        file: str = "skill.md",
+        line: int = 1,
+        tags: list[str] | None = None,
+    ) -> Finding:
+        return Finding(
+            rule_id=rule_id,
+            message=f"original message for {rule_id}",
+            severity=severity,
+            confidence=0.8,
+            file=file,
+            start_line=line,
+            tags=tags or [],
+        )
+
+    @patch(MOCK_PATCH_TARGET, _mock_get_chat_model)
+    def test_critical_unconfirmed_kept_with_llm_unconfirmed_tag(self) -> None:
+        """A CRITICAL static finding NOT confirmed by the LLM must be kept.
+
+        The finding must appear in the output with its original severity and
+        message, and the tag 'llm-unconfirmed' must be present to let consumers
+        know it was not LLM-validated (and may represent an adversarial suppression).
+        """
+        analyzer = LLMMetaAnalyzer(model=self.MODEL)
+        finding = self._make_finding("CRIT-001", "CRITICAL", line=10)
+        batch = Batch(file_path="skill.md", content="code", findings=[finding])
+        # LLM response: is_vulnerability=False — the LLM denies the finding
+        llm_items = [
+            {
+                "pattern_id": "CRIT-001",
+                "start_line": 10,
+                "is_vulnerability": False,
+                "confidence": 0.2,
+                "_file": "skill.md",
+            }
+        ]
+        result = analyzer.apply_filter([finding], [(batch, llm_items)])
+
+        assert len(result) == 1, "CRITICAL finding must NOT be dropped by LLM filtering"
+        kept = result[0]
+        assert kept.severity == "CRITICAL"
+        assert kept.rule_id == "CRIT-001"
+        assert kept.message == "original message for CRIT-001"
+        assert kept.confidence == 0.8  # original confidence preserved
+        assert "llm-unconfirmed" in kept.tags
+
+    @patch(MOCK_PATCH_TARGET, _mock_get_chat_model)
+    def test_high_unconfirmed_kept_with_llm_unconfirmed_tag(self) -> None:
+        """A HIGH static finding NOT confirmed by the LLM must be kept.
+
+        Same invariant as CRITICAL: the original finding is preserved and
+        tagged 'llm-unconfirmed'.
+        """
+        analyzer = LLMMetaAnalyzer(model=self.MODEL)
+        finding = self._make_finding("HIGH-001", "HIGH", line=5)
+        batch = Batch(file_path="skill.md", content="code", findings=[finding])
+        # LLM response: finding completely omitted (empty list) — simulates
+        # a prompt-injection payload making the LLM silently drop the finding
+        llm_items: list[dict] = []
+        result = analyzer.apply_filter([finding], [(batch, llm_items)])
+
+        assert len(result) == 1, "HIGH finding must NOT be dropped by LLM filtering"
+        kept = result[0]
+        assert kept.severity == "HIGH"
+        assert kept.rule_id == "HIGH-001"
+        assert kept.message == "original message for HIGH-001"
+        assert kept.confidence == 0.8  # original confidence preserved
+        assert "llm-unconfirmed" in kept.tags
+
+    @patch(MOCK_PATCH_TARGET, _mock_get_chat_model)
+    def test_medium_unconfirmed_still_dropped(self) -> None:
+        """A MEDIUM static finding NOT confirmed by the LLM must still be dropped.
+
+        The severity floor only applies to CRITICAL/HIGH.  MEDIUM and LOW
+        findings remain subject to normal LLM filtering (false-positive reduction).
+        """
+        analyzer = LLMMetaAnalyzer(model=self.MODEL)
+        finding = self._make_finding("MED-001", "MEDIUM", line=3)
+        batch = Batch(file_path="skill.md", content="code", findings=[finding])
+        llm_items = [
+            {
+                "pattern_id": "MED-001",
+                "start_line": 3,
+                "is_vulnerability": False,
+                "confidence": 0.1,
+                "_file": "skill.md",
+            }
+        ]
+        result = analyzer.apply_filter([finding], [(batch, llm_items)])
+
+        assert len(result) == 0, "MEDIUM finding must be dropped when LLM does not confirm it"
+
+    @patch(MOCK_PATCH_TARGET, _mock_get_chat_model)
+    def test_low_unconfirmed_still_dropped(self) -> None:
+        """A LOW static finding NOT confirmed by the LLM must still be dropped."""
+        analyzer = LLMMetaAnalyzer(model=self.MODEL)
+        finding = self._make_finding("LOW-001", "LOW", line=7)
+        batch = Batch(file_path="skill.md", content="code", findings=[finding])
+        llm_items: list[dict] = []  # LLM omits the finding entirely
+        result = analyzer.apply_filter([finding], [(batch, llm_items)])
+
+        assert len(result) == 0, "LOW finding must be dropped when LLM does not confirm it"
+
+    @patch(MOCK_PATCH_TARGET, _mock_get_chat_model)
+    def test_critical_confirmed_uses_llm_enrichment(self) -> None:
+        """A CRITICAL finding confirmed by the LLM is still enriched as before.
+
+        The floor does not interfere with the normal happy path: when the LLM
+        confirms a CRITICAL/HIGH finding, the enriched version (with LLM
+        explanation/remediation/confidence) is used and 'llm-unconfirmed' is
+        NOT added.
+        """
+        analyzer = LLMMetaAnalyzer(model=self.MODEL)
+        finding = self._make_finding("CRIT-002", "CRITICAL", line=20)
+        batch = Batch(file_path="skill.md", content="code", findings=[finding])
+        llm_items = [
+            {
+                "pattern_id": "CRIT-002",
+                "start_line": 20,
+                "is_vulnerability": True,
+                "confidence": 0.95,
+                "explanation": "LLM-confirmed dangerous pattern",
+                "remediation": "Remove immediately",
+                "_file": "skill.md",
+            }
+        ]
+        result = analyzer.apply_filter([finding], [(batch, llm_items)])
+
+        assert len(result) == 1
+        kept = result[0]
+        assert kept.severity == "CRITICAL"
+        assert kept.rule_id == "CRIT-002"
+        assert kept.explanation == "LLM-confirmed dangerous pattern"
+        assert kept.confidence == 0.95
+        assert "llm-unconfirmed" not in kept.tags
+
+    @patch(MOCK_PATCH_TARGET, _mock_get_chat_model)
+    def test_llm_unconfirmed_tag_not_duplicated(self) -> None:
+        """If the original finding already has 'llm-unconfirmed' in its tags,
+        apply_filter must not append it again."""
+        analyzer = LLMMetaAnalyzer(model=self.MODEL)
+        finding = self._make_finding(
+            "CRIT-003", "CRITICAL", line=1, tags=["llm-unconfirmed", "existing-tag"]
+        )
+        batch = Batch(file_path="skill.md", content="code", findings=[finding])
+        llm_items: list[dict] = []  # LLM omits finding
+        result = analyzer.apply_filter([finding], [(batch, llm_items)])
+
+        assert len(result) == 1
+        assert result[0].tags.count("llm-unconfirmed") == 1
+
+    @patch(MOCK_PATCH_TARGET, _mock_get_chat_model)
+    def test_llm_unconfirmed_tag_surfaced_in_to_dict(self) -> None:
+        """The 'llm-unconfirmed' marker must be visible in the JSON output
+        (Finding.to_dict), so consumers can see a high-severity finding the LLM
+        did not confirm."""
+        analyzer = LLMMetaAnalyzer(model=self.MODEL)
+        finding = self._make_finding("CRIT-004", "CRITICAL", line=1)
+        batch = Batch(file_path="skill.md", content="code", findings=[finding])
+        result = analyzer.apply_filter([finding], [(batch, [])])
+
+        assert len(result) == 1
+        assert "llm-unconfirmed" in result[0].to_dict()["tags"]
+
+
+# ---------------------------------------------------------------------------
 # LLMMetaAnalyzer.run_batches (mocked LLM)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #59

## What

`meta_analyzer.apply_filter()` previously kept a static finding only if the LLM echoed it back as `is_vulnerability=True` with `confidence ≥ 0.6` — so any finding the LLM omitted or denied was silently dropped, **regardless of severity**.

Because the LLM's input includes attacker-controlled skill content, a prompt-injection payload could make the LLM drop a real CRITICAL/HIGH **static** finding, hiding it from the report (a false negative in a security gate). This affects all providers.

## Fix (severity-gated floor)

- CRITICAL/HIGH static findings are always kept. If the LLM confirms one, it's enriched as before; if not, the original finding is preserved and tagged `llm-unconfirmed` (now surfaced in `Finding.to_dict()` / JSON output).
- MEDIUM/LOW keep the existing LLM false-positive filtering.
- Rationale: in a security gate, a false negative (hiding a real CRITICAL) is far worse than a false positive.

## Test

New tests cover CRITICAL/HIGH preserved+tagged, MEDIUM/LOW still filtered, confirmed-CRITICAL still enriched, and the tag surfacing via `to_dict()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)