### PR TITLE
fix(analyzer): parse structured output from text so OpenAI-compatible endpoints don't crash LLM analysis

### DIFF
--- a/src/skillspector/llm_analyzer_base.py
+++ b/src/skillspector/llm_analyzer_base.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from langchain_core.messages import BaseMessage
+from langchain_core.output_parsers import PydanticOutputParser
 from pydantic import BaseModel, Field, field_validator
 
 from skillspector.llm_utils import get_chat_model
@@ -274,9 +275,21 @@ class LLMAnalyzerBase:
         self.model = model
         self._input_budget = get_max_input_tokens(model)
         self._llm = get_chat_model(model=model)
-        self._structured_llm = (
-            self._llm.with_structured_output(self.response_schema) if self.response_schema else None
-        )
+        # Parse structured output from the text response rather than relying on
+        # the endpoint's native structured-output mode. ChatOpenAI defaults to
+        # method="json_schema" (strict response_format), which OpenAI-compatible
+        # endpoints are free to ignore -- they may wrap the JSON in markdown
+        # fences or surround it with prose. PydanticOutputParser uses langchain's
+        # fence-tolerant parser and supplies matching format instructions, so
+        # both strict and lenient endpoints work.
+        if self.response_schema:
+            self._parser = PydanticOutputParser(pydantic_object=self.response_schema)
+            self._structured_llm = self._llm | self._parser
+            self._format_instructions = self._parser.get_format_instructions()
+        else:
+            self._parser = None
+            self._structured_llm = None
+            self._format_instructions = ""
 
     # -- Batching -----------------------------------------------------------
 
@@ -336,6 +349,18 @@ class LLMAnalyzerBase:
 
     # -- Prompt / parse -----------------------------------------------------
 
+    def _with_format(self, prompt: str) -> str:
+        """Append schema format instructions for the structured-output chain.
+
+        Centralized here so both the default :meth:`build_prompt` and any
+        subclass override (e.g. the meta-analyzer) get the parser's format
+        guidance without each prompt template having to embed it. No-op when
+        running in raw-string mode (no ``response_schema``).
+        """
+        if not self._format_instructions:
+            return prompt
+        return f"{prompt}\n\n{self._format_instructions}"
+
     def build_prompt(self, batch: Batch, **kwargs: object) -> str:
         """Build the LLM prompt for a single batch.
 
@@ -386,7 +411,7 @@ class LLMAnalyzerBase:
                 len(batch.findings),
             )
             if self._structured_llm:
-                response = self._structured_llm.invoke(prompt)
+                response = self._structured_llm.invoke(self._with_format(prompt))
             else:
                 response = _message_text(self._llm.invoke(prompt))
             logger.debug("LLM response for %s", batch.file_label)
@@ -429,7 +454,7 @@ class LLMAnalyzerBase:
                     len(batch.findings),
                 )
                 if self._structured_llm:
-                    response = await self._structured_llm.ainvoke(prompt)
+                    response = await self._structured_llm.ainvoke(self._with_format(prompt))
                 else:
                     response = _message_text(await self._llm.ainvoke(prompt))
                 logger.debug("LLM response for %s", batch.file_label)

--- a/tests/nodes/test_llm_analyzer_base.py
+++ b/tests/nodes/test_llm_analyzer_base.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from langchain_core.messages import AIMessage
+from langchain_core.runnables import Runnable
 
 from skillspector.llm_analyzer_base import (
     Batch,
@@ -157,10 +158,8 @@ class TestBatch:
 
 
 def _mock_get_chat_model(*_args, **_kwargs):
-    """Return a mock ChatOpenAI that supports with_structured_output."""
-    mock_llm = MagicMock()
-    mock_llm.with_structured_output.return_value = MagicMock()
-    return mock_llm
+    """Return a mock chat model for tests that override ``_structured_llm``."""
+    return MagicMock()
 
 
 MOCK_PATCH_TARGET = "skillspector.llm_analyzer_base.get_chat_model"
@@ -174,6 +173,70 @@ class _RawTextAnalyzer(LLMAnalyzerBase):
     def parse_response(self, response: object, batch: Batch) -> list[str]:
         assert isinstance(response, str)
         return [response]
+
+
+class _FakeChatModel(Runnable):
+    """Minimal Runnable that returns a fixed ``AIMessage`` content.
+
+    Stands in for an OpenAI-compatible endpoint that ignores
+    ``response_format`` so the real ``PydanticOutputParser`` in the
+    structured-output chain is exercised end-to-end.
+    """
+
+    def __init__(self, content: str):
+        self._content = content
+
+    def invoke(self, _input, _config=None, **_kwargs):
+        return AIMessage(content=self._content)
+
+    async def ainvoke(self, _input, _config=None, **_kwargs):
+        return AIMessage(content=self._content)
+
+
+class TestStructuredOutputParsing:
+    """Regression tests: structured chain tolerates non-strict endpoints.
+
+    OpenAI-compatible endpoints may ignore ``response_format`` and wrap the
+    JSON in markdown fences or surround it with prose. The chain must still
+    parse into the response schema rather than crashing the scan.
+    """
+
+    MODEL = "nvidia/openai/gpt-oss-120b"
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            '{"findings": [{"rule_id": "R-1", "message": "m", "severity": "LOW", "start_line": 1}]}',
+            '```json\n{"findings": [{"rule_id": "R-1", "message": "m", "severity": "LOW", "start_line": 1}]}\n```',
+            'Here is the analysis:\n```json\n{"findings": [{"rule_id": "R-1", "message": "m", "severity": "LOW", "start_line": 1}]}\n```\nDone.',
+        ],
+    )
+    @patch(MOCK_PATCH_TARGET, _mock_get_chat_model)
+    def test_parses_fenced_and_prose_wrapped_json(self, content: str) -> None:
+        analyzer = LLMAnalyzerBase(base_prompt="test", model=self.MODEL)
+        analyzer._structured_llm = _FakeChatModel(content) | analyzer._parser
+        results = analyzer.run_batches([Batch(file_path="x.py", content="code")])
+        _, findings = results[0]
+        assert len(findings) == 1
+        assert findings[0].rule_id == "R-1"
+
+    @patch(MOCK_PATCH_TARGET, _mock_get_chat_model)
+    def test_empty_findings_object_parses(self) -> None:
+        analyzer = LLMAnalyzerBase(base_prompt="test", model=self.MODEL)
+        analyzer._structured_llm = (
+            _FakeChatModel('```json\n{"findings": []}\n```') | analyzer._parser
+        )
+        results = analyzer.run_batches([Batch(file_path="x.py", content="code")])
+        _, findings = results[0]
+        assert findings == []
+
+    @patch(MOCK_PATCH_TARGET, _mock_get_chat_model)
+    def test_format_instructions_appended_to_prompt(self) -> None:
+        analyzer = LLMAnalyzerBase(base_prompt="test", model=self.MODEL)
+        assert analyzer._format_instructions
+        augmented = analyzer._with_format("PROMPT BODY")
+        assert augmented.startswith("PROMPT BODY")
+        assert analyzer._format_instructions in augmented
 
 
 # ---------------------------------------------------------------------------
@@ -1577,22 +1640,22 @@ class TestLLMMetaAnalyzerRunBatches:
     @patch(MOCK_PATCH_TARGET)
     def test_run_batches_calls_structured_llm_per_batch(self, mock_get_model: MagicMock) -> None:
         mock_llm = MagicMock()
-        mock_structured = MagicMock()
         mock_get_model.return_value = mock_llm
-        mock_llm.with_structured_output.return_value = mock_structured
-        mock_structured.invoke.return_value = MetaAnalyzerResult(
-            findings=[
-                MetaAnalyzerFinding(
-                    pattern_id="E1",
-                    is_vulnerability=True,
-                    confidence=0.9,
-                    intent="malicious",
-                    impact="high",
-                )
-            ],
-        )
 
         analyzer = LLMMetaAnalyzer(model=self.MODEL)
+        analyzer._structured_llm.invoke = MagicMock(
+            return_value=MetaAnalyzerResult(
+                findings=[
+                    MetaAnalyzerFinding(
+                        pattern_id="E1",
+                        is_vulnerability=True,
+                        confidence=0.9,
+                        intent="malicious",
+                        impact="high",
+                    )
+                ],
+            )
+        )
         f1 = Finding(rule_id="E1", message="test", file="a.py", start_line=1)
         f2 = Finding(rule_id="E2", message="test", file="b.py", start_line=1)
         batches = [
@@ -1600,7 +1663,7 @@ class TestLLMMetaAnalyzerRunBatches:
             Batch(file_path="b.py", content="code b", findings=[f2]),
         ]
         results = analyzer.run_batches(batches, metadata_text="Name: skill")
-        assert mock_structured.invoke.call_count == 2
+        assert analyzer._structured_llm.invoke.call_count == 2
         assert len(results) == 2
 
     @patch(MOCK_PATCH_TARGET)
@@ -1621,10 +1684,10 @@ class TestLLMMetaAnalyzerARunBatches:
     @patch(MOCK_PATCH_TARGET)
     async def test_arun_batches_calls_ainvoke_per_batch(self, mock_get_model: MagicMock) -> None:
         mock_llm = MagicMock()
-        mock_structured = MagicMock()
         mock_get_model.return_value = mock_llm
-        mock_llm.with_structured_output.return_value = mock_structured
-        mock_structured.ainvoke = AsyncMock(
+
+        analyzer = LLMMetaAnalyzer(model=self.MODEL)
+        analyzer._structured_llm.ainvoke = AsyncMock(
             return_value=MetaAnalyzerResult(
                 findings=[
                     MetaAnalyzerFinding(
@@ -1637,8 +1700,6 @@ class TestLLMMetaAnalyzerARunBatches:
                 ],
             )
         )
-
-        analyzer = LLMMetaAnalyzer(model=self.MODEL)
         f1 = Finding(rule_id="E1", message="test", file="a.py", start_line=1)
         f2 = Finding(rule_id="E2", message="test", file="b.py", start_line=1)
         batches = [
@@ -1646,7 +1707,7 @@ class TestLLMMetaAnalyzerARunBatches:
             Batch(file_path="b.py", content="code b", findings=[f2]),
         ]
         results = await analyzer.arun_batches(batches, metadata_text="Name: skill")
-        assert mock_structured.ainvoke.call_count == 2
+        assert analyzer._structured_llm.ainvoke.call_count == 2
         assert len(results) == 2
 
     @patch(MOCK_PATCH_TARGET)
@@ -1655,10 +1716,10 @@ class TestLLMMetaAnalyzerARunBatches:
         mock_get_model: MagicMock,
     ) -> None:
         mock_llm = MagicMock()
-        mock_structured = MagicMock()
         mock_get_model.return_value = mock_llm
-        mock_llm.with_structured_output.return_value = mock_structured
-        mock_structured.ainvoke = AsyncMock(
+
+        analyzer = LLMMetaAnalyzer(model=self.MODEL)
+        analyzer._structured_llm.ainvoke = AsyncMock(
             return_value=MetaAnalyzerResult(
                 findings=[
                     MetaAnalyzerFinding(
@@ -1673,8 +1734,6 @@ class TestLLMMetaAnalyzerARunBatches:
                 ],
             )
         )
-
-        analyzer = LLMMetaAnalyzer(model=self.MODEL)
         finding = Finding(rule_id="E1", message="test", file="a.py", start_line=1)
         batches = [Batch(file_path="a.py", content="code", findings=[finding])]
         batch_results = await analyzer.arun_batches(batches, metadata_text="")


### PR DESCRIPTION
## What this fixes

Closes #69.

When you point `SKILLSPECTOR_PROVIDER=openai` at an OpenAI-compatible endpoint through `OPENAI_BASE_URL`, the semantic stage can crash the whole scan with a JSON decode error. Static analysis still runs, but every LLM finding is silently lost.

The cause is in how the analyzers build their structured-output client:

```python
self._structured_llm = self._llm.with_structured_output(self.response_schema)
```

`ChatOpenAI.with_structured_output` defaults to `method="json_schema"`, i.e. strict `response_format`. An endpoint can implement the OpenAI API faithfully and still not honor that, and plenty don't. The ones I hit return valid JSON, just wrapped in a markdown fence:

```
```json
{"findings": []}
```
```

or with a sentence of prose on either side. The strict path hands that straight to `json.loads`, which raises, and the scan exits with `Error: Expecting value: line 1 column 1 (char 0)` or `Invalid JSON ... for LLMAnalysisResult`. Every analyzer that inherits `LLMAnalyzerBase` is affected, including the meta-analyzer.

## The change

I dropped the strict client in favor of the canonical langchain chain:

```python
self._parser = PydanticOutputParser(pydantic_object=self.response_schema)
self._structured_llm = self._llm | self._parser
self._format_instructions = self._parser.get_format_instructions()
```

`PydanticOutputParser` already uses langchain's fence-tolerant `parse_json_markdown`, and it validates into the same Pydantic schema, so `parse_response` does not change for either the per-file analyzers or the meta-analyzer. Strict endpoints keep working exactly as before; lenient ones now work too.

I also moved the format guidance into one place. A small `_with_format` helper appends `get_format_instructions()` at the run-loop chokepoint, so the default prompt and the meta-analyzer's own prompt both get it without each template having to embed JSON instructions by hand. It is a no-op in raw-string mode.

I deliberately did not hand-roll a fence stripper or a brace slicer. langchain's parser already covers the fenced, bare, and prose-wrapped cases, and reusing it keeps the surface small.

## Tests

- Added a regression suite that pushes bare, fenced, and prose-wrapped JSON through the real `PydanticOutputParser` via a tiny fake `Runnable`, plus an empty-findings case and a check that the format instructions land on the prompt.
- Updated the three existing tests that asserted the now-removed `with_structured_output` seam. They use the same direct `_structured_llm` mock pattern that the other run-loop tests already rely on.
- `make test`: 605 passed, 11 skipped. `make lint` and `make format` are clean.

## How I verified it end to end

Against a non-strict OpenAI-compatible endpoint, `main` aborts in the semantic stage with the JSON error above. With this change the same scan completes and returns LLM-backed findings. Repeated runs show no more decode crashes; the only non-zero exits are the intended `risk_score > 50` gate (exit 1), not parser errors (exit 2).
