### PR TITLE
feat(analyzer): detect skills snooping on the agent ecosystem (other skills, MCP config, agent memory)

### DIFF
--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -265,3 +265,66 @@ class TestRunStaticPatternsFileTypeAndSkip:
         state = {"components": [], "file_cache": {}}
         findings = static_runner.run_static_patterns(state, [prompt_injection_module])
         assert findings == []
+
+
+class TestRunStaticPatternsAgentSnooping:
+    """run_static_patterns with agent_snooping: AS1, AS2, AS3."""
+
+    def test_as1_agent_config_dir_produces_finding(self):
+        """Reading the agent config/home dir yields AS1 (HIGH)."""
+        state = {
+            "components": ["s.py"],
+            "file_cache": {"s.py": 'open("/Users/x/.claude/settings.json").read()\n'},
+        }
+        findings = static_runner.run_static_patterns(state, [agent_snooping_module])
+        as1 = [f for f in findings if f.rule_id == "AS1"]
+        assert len(as1) == 1
+        assert as1[0].severity == "HIGH"
+        assert as1[0].remediation is not None
+
+    def test_as2_mcp_config_produces_finding(self):
+        """Reading MCP configuration yields AS2 (HIGH)."""
+        state = {
+            "components": ["s.py"],
+            "file_cache": {"s.py": 'open("config/.mcp.json").read()\n'},
+        }
+        findings = static_runner.run_static_patterns(state, [agent_snooping_module])
+        as2 = [f for f in findings if f.rule_id == "AS2"]
+        assert len(as2) == 1
+        assert as2[0].severity == "HIGH"
+
+    def test_as3_other_skill_produces_finding(self):
+        """Reading another skill's manifest yields AS3."""
+        state = {
+            "components": ["s.py"],
+            "file_cache": {"s.py": 'open("skills/other-skill/SKILL.md").read()\n'},
+        }
+        findings = static_runner.run_static_patterns(state, [agent_snooping_module])
+        assert any(f.rule_id == "AS3" for f in findings)
+
+    def test_no_same_line_duplicate(self):
+        """A line matching one rule twice yields a single finding (built-in dedup)."""
+        state = {
+            "components": ["s.py"],
+            "file_cache": {"s.py": 'open("/Users/x/.claude/.codex/note")\n'},
+        }
+        findings = static_runner.run_static_patterns(state, [agent_snooping_module])
+        assert len([f for f in findings if f.rule_id == "AS1"]) == 1
+
+    def test_normal_file_access_not_flagged(self):
+        """Ordinary project file access produces no agent-snooping finding."""
+        state = {
+            "components": ["s.py"],
+            "file_cache": {"s.py": 'open("data/input.csv")\nopen("./config.yaml")\n'},
+        }
+        findings = static_runner.run_static_patterns(state, [agent_snooping_module])
+        assert [f for f in findings if f.rule_id.startswith("AS")] == []
+
+    def test_node_runs_over_state(self):
+        """The node entrypoint runs the analyzer over state and returns findings."""
+        state = {
+            "components": ["s.py"],
+            "file_cache": {"s.py": 'open("/Users/x/.claude/settings.json")\n'},
+        }
+        result = agent_snooping_module.node(state)
+        assert any(f.rule_id == "AS1" for f in result["findings"])


### PR DESCRIPTION
Fixes #75.

## What this adds

A skill that reaches into the agent's own environment — agent config/home dirs, MCP server configuration, or another installed skill's files — was not flagged by any analyzer. Adds a `static_patterns_agent_snooping` analyzer under a new "Agent Ecosystem Snooping" category:

- **AS1** — agent config/home dirs (`~/.claude/`, `~/.codex/`, `~/.gemini/`, `~/.cursor/`) where API keys and settings live — HIGH
- **AS2** — MCP server configuration (`.mcp.json`, `mcp_servers`) which holds server tokens/endpoints — HIGH
- **AS3** — reading another installed skill's manifest (`skills/*/SKILL.md`) — MEDIUM

## Why this fits the skill threat model

Unlike generic file access, this threat exists *only because skills run inside an agent*: a malicious skill performs lateral movement within the agent's environment — stealing another skill's logic/secrets, harvesting MCP server tokens, or exfiltrating prior conversation memory. This is distinct from `E3`, which targets generic OS credential files (`~/.ssh`, `~/.aws`).

The reproduction from the issue (a skill reading `.mcp.json`, agent memory, and another skill) went from **score 0 / LOW** to **score 100 / CRITICAL**.

## Scope / non-overlap

Verified the reproduction triggers none of `E1`–`E4`, taint tracking, or `behavioral_ast`. The analyzer de-duplicates matches per `(rule, line)` so a single line is not reported twice by the same rule.

## Testing

- `ruff check src/ tests/` and `ruff format --check src/ tests/` pass.
- `pytest -m 'not integration'` passes (606 passed, 11 skipped).
- `static_patterns_agent_snooping` at 100% coverage. Tests cover: agent-config / MCP-config / cross-skill detection, same-line de-duplication, a false-positive guard (ordinary project file access is not flagged), and the node entrypoint.