### PR TITLE
Sync OSS release snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Issues (2)
 | `OPENAI_BASE_URL` | Override the OpenAI endpoint (e.g. point at Ollama). | Optional |
 | `ANTHROPIC_API_KEY` | Credential for the Anthropic provider (`SKILLSPECTOR_PROVIDER=anthropic`). | Required for LLM analysis when `SKILLSPECTOR_PROVIDER=anthropic` |
 | `SKILLSPECTOR_MODEL` | Override the active provider's default model. See the LLM Analysis table for each provider's default. | Optional |
-| `SKILLSPECTOR_MODEL_REGISTRY` | Override the bundled per-provider YAML registry (`src/skillspector/providers/<provider>.yaml`) with a custom path. | Optional |
+| `SKILLSPECTOR_MODEL_REGISTRY` | Override the bundled per-provider YAML registry (`src/skillspector/providers/<provider>/model_registry.yaml`) with a custom path. | Optional |
 | `SKILLSPECTOR_LOG_LEVEL` | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR` (default: `WARNING`). | Optional |
 
 ### CLI Options

--- a/tests/docker/smoke.sh
+++ b/tests/docker/smoke.sh
@@ -11,6 +11,7 @@ GITHUB_EXPECTED_COMPONENT="${SKILLSPECTOR_DOCKER_GITHUB_EXPECTED_COMPONENT:-READ
 run() {
   printf "\n>> %s\n" "$*"
   "$@"
+  return
 }
 
 validate_json_report() {
@@ -19,6 +20,7 @@ validate_json_report() {
   test -s "${REPO_DIR}/${report_path}"
   run docker run --rm --entrypoint python -v "${REPO_DIR}:/scan" "${IMAGE}" \
     -m json.tool "/scan/${report_path}" >/dev/null
+  return
 }
 
 assert_report_contains_component() {
@@ -28,6 +30,7 @@ assert_report_contains_component() {
   run docker run --rm --entrypoint python -v "${REPO_DIR}:/scan" "${IMAGE}" \
     -c 'import json, sys; data = json.load(open("/scan/" + sys.argv[1])); expected = sys.argv[2]; assert any(c.get("path") == expected for c in data.get("components", [])), f"missing component: {expected}"' \
     "${report_path}" "${expected_component}"
+  return
 }
 
 scan_github_url() {
@@ -48,6 +51,7 @@ scan_github_url() {
   validate_json_report "${GITHUB_REPORT}"
   assert_report_contains_component "${GITHUB_REPORT}" "${GITHUB_EXPECTED_COMPONENT}"
   echo "GitHub URL scan completed with accepted exit code ${github_scan_status}"
+  return
 }
 
 run docker run --rm "${IMAGE}" --version


### PR DESCRIPTION
## Summary

- Refresh public SkillSpector from the internal OSS release snapshot.
- Source branch: `release/oss-2026-06-15`
- Source commit: `a7ebb82733fba54512c546fed08cd17a2cbc4a17`
- Rebased onto latest GitHub `main` after #78 was merged.
- Supersedes the original provider-registry documentation PR: #30.

## Diff Notes

- Add explicit returns in Docker smoke helper functions.
- Correct the documented bundled model registry path for `SKILLSPECTOR_MODEL_REGISTRY`.

## Verification

- `PATH="$PWD/.venv/bin:$PATH" ./scripts/create-oss-release.sh release/oss-2026-06-15` in the internal repo; includes `make test-unit`: 600 passed, 11 skipped, 22 deselected.
- `git diff --check origin/main..HEAD` in the public GitHub checkout.