### PR TITLE
Sync OSS release snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,3 +103,4 @@ docker-build:
 # Build and smoke test the Docker image
 docker-smoke: docker-build
 	tests/docker/smoke.sh
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skillspector"
-version = "2.1.4"
+version = "2.1.5"
 description = "SkillSpector: Security scanner for AI agent skills (Claude Code, Cursor, and similar). Scans skills for vulnerabilities, malicious patterns, and security risks before installation. Supports Git repos, URLs, zips, and local directories; runs static pattern checks and optional LLM semantic analysis; outputs terminal, JSON, and Markdown reports with risk scoring."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "skillspector"
-version = "2.1.4"
+version = "2.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Refresh public SkillSpector from the internal OSS release snapshot.
- Source branch: `release/oss-2026-06-15-2`
- Source commit: `9edade32a5ceacb523b591c70eea5de1aec176ba`

## Diff Notes

- Bump the package version from `2.1.4` to `2.1.5` in `pyproject.toml` and `uv.lock`.
- Sync the generated OSS `Makefile` snapshot.

## Verification

- `./scripts/create-oss-release.sh release/oss-2026-06-15-2` was run. Its bare `make test-unit` step initially could not find `pytest` on PATH in this shell.
- `PATH="$PWD/.venv/bin:$PATH" make test-unit` passed on the generated OSS branch: 601 passed, 11 skipped, 23 deselected.

## Notes

- The public diff is limited to `Makefile`, `pyproject.toml`, and `uv.lock`.
- No GitHub-only files such as `.github/` were deleted by the snapshot sync.
