### PR TITLE
feat: add AWS Bedrock provider for Claude via SigV4

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ inference gateways.
 | `openai` | `OPENAI_API_KEY` (+ optional `OPENAI_BASE_URL`) | api.openai.com (or any OpenAI-compatible URL) | `gpt-5.4` |
 | `anthropic` | `ANTHROPIC_API_KEY` | api.anthropic.com | `claude-opus-4-6` |
 | `anthropic_proxy` | `ANTHROPIC_PROXY_API_KEY` + `ANTHROPIC_PROXY_ENDPOINT_URL` | Any Vertex-style raw-predict proxy | `claude-sonnet-4-6` |
+| `bedrock` | `AWS_PROFILE` (optional) + `AWS_REGION` — SigV4 via boto3 | AWS Bedrock Runtime | `us.anthropic.claude-sonnet-4-6-20250915-v1:0` |
 | `nv_build` | `NVIDIA_INFERENCE_KEY` | build.nvidia.com | `deepseek-ai/deepseek-v4-flash` |
 
 ```bash
@@ -167,6 +168,18 @@ export SKILLSPECTOR_PROVIDER=anthropic_proxy
 export ANTHROPIC_PROXY_ENDPOINT_URL=https://my-gateway.example.com/models/claude-sonnet-4-6:streamRawPredict
 export ANTHROPIC_PROXY_API_KEY=your-bearer-token
 export SKILLSPECTOR_MODEL=claude-sonnet-4-6
+skillspector scan ./my-skill/
+
+# AWS Bedrock (Claude via SigV4)
+export SKILLSPECTOR_PROVIDER=bedrock
+# Optional: select an AWS named profile. When unset, the standard
+# boto3 credential chain (env vars, instance metadata, SSO, etc.) resolves.
+# export AWS_PROFILE=my-profile
+export AWS_REGION=us-west-2  # default if unset
+# Default model: us.anthropic.claude-sonnet-4-6-20250915-v1:0
+# Override with any Bedrock model ID, cross-region inference-profile
+# ID, or your own application-inference-profile ARN:
+# export SKILLSPECTOR_MODEL=us.anthropic.claude-opus-4-6-20250915-v1:0
 skillspector scan ./my-skill/
 
 # NVIDIA build.nvidia.com
@@ -404,7 +417,7 @@ Issues (2)
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `SKILLSPECTOR_PROVIDER` | Active LLM provider: `openai`, `anthropic`, or `nv_build`. Each provider has its own bundled `model_registry.yaml` and default model (see the LLM Analysis table above). Defaults to `nv_build`. | Optional |
+| `SKILLSPECTOR_PROVIDER` | Active LLM provider: `openai`, `anthropic`, `anthropic_proxy`, `bedrock`, or `nv_build`. Each provider has its own bundled `model_registry.yaml` and default model (see the LLM Analysis table above). Defaults to `nv_build`. | Optional |
 | `NVIDIA_INFERENCE_KEY` | Credential for the `nv_build` provider (build.nvidia.com). | Required for LLM analysis when `SKILLSPECTOR_PROVIDER=nv_build` |
 | `OPENAI_API_KEY` | Credential for the OpenAI provider (`SKILLSPECTOR_PROVIDER=openai`). Also serves as the tier-2 fallback in the credential waterfall when the active provider returns no credentials. | Required for LLM analysis when `SKILLSPECTOR_PROVIDER=openai` |
 | `OPENAI_BASE_URL` | Override the OpenAI endpoint (e.g. point at Ollama). | Optional |
@@ -412,6 +425,8 @@ Issues (2)
 | `ANTHROPIC_PROXY_ENDPOINT_URL` | Full endpoint URL for the Anthropic proxy provider (Vertex-style raw-predict). | Required when `SKILLSPECTOR_PROVIDER=anthropic_proxy` |
 | `ANTHROPIC_PROXY_API_KEY` | Bearer token for the Anthropic proxy provider. | Required when `SKILLSPECTOR_PROVIDER=anthropic_proxy` |
 | `ANTHROPIC_PROXY_API_VERSION` | `anthropic_version` value sent in the request body (default: `vertex-2023-10-16`). | Optional |
+| `AWS_PROFILE` | Named AWS profile for the Bedrock provider — authenticates via SigV4 through boto3. When unset, the standard boto3 credential chain (env vars, instance metadata, SSO, etc.) resolves. | Optional (used when `SKILLSPECTOR_PROVIDER=bedrock`) |
+| `AWS_REGION` | AWS region for the Bedrock Runtime endpoint. Defaults to `us-west-2`. | Optional (used when `SKILLSPECTOR_PROVIDER=bedrock`) |
 | `SKILLSPECTOR_MODEL` | Override the active provider's default model. See the LLM Analysis table for each provider's default. | Optional |
 | `SKILLSPECTOR_MODEL_REGISTRY` | Override the bundled per-provider YAML registry (`src/skillspector/providers/<provider>/model_registry.yaml`) with a custom path. | Optional |
 | `SKILLSPECTOR_LOG_LEVEL` | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR` (default: `WARNING`). | Optional |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,10 @@ dependencies = [
     "langgraph>=1.0.10",
     "langgraph-cli[inmem]>=0.4.14",
     "langchain-anthropic>=1.4.5",
+    "langchain-aws>=0.2.0",
     "langchain-core>=1.2.17",
     "langchain-openai>=1.1.10",
+    "boto3>=1.34.0",
     "langsmith>=0.7.30",
     "yara-python>=4.5.0",
 ]

--- a/src/skillspector/cli.py
+++ b/src/skillspector/cli.py
@@ -192,9 +192,10 @@ def scan(
     Environment variables:
 
         SKILLSPECTOR_PROVIDER  Active LLM provider: openai | anthropic |
-                               nv_build | nv_inference. Defaults to the
-                               NVIDIA path (nv_inference, falling back to
-                               nv_build in OSS builds).
+                               anthropic_proxy | bedrock | nv_build |
+                               nv_inference. Defaults to the NVIDIA path
+                               (nv_inference, falling back to nv_build in
+                               OSS builds).
         SKILLSPECTOR_MODEL     Override the active provider's default
                                model (applies to every analyzer slot).
         SKILLSPECTOR_LOG_LEVEL DEBUG | INFO | WARNING | ERROR (default WARNING).
@@ -203,6 +204,9 @@ def scan(
 
         OPENAI_API_KEY [+ OPENAI_BASE_URL]   for SKILLSPECTOR_PROVIDER=openai
         ANTHROPIC_API_KEY                    for SKILLSPECTOR_PROVIDER=anthropic
+        AWS_PROFILE (optional) + AWS_REGION  for SKILLSPECTOR_PROVIDER=bedrock
+                                             (AWS_PROFILE: standard boto3 credential
+                                             chain when unset; AWS_REGION default: us-west-2)
         NVIDIA_INFERENCE_KEY                 for the NVIDIA providers
     """
     result = None

--- a/src/skillspector/providers/__init__.py
+++ b/src/skillspector/providers/__init__.py
@@ -25,6 +25,7 @@ Selection happens via the ``SKILLSPECTOR_PROVIDER`` env var:
     openai           → OpenAIProvider          (api.openai.com)
     anthropic        → AnthropicProvider       (api.anthropic.com)
     anthropic_proxy  → AnthropicProxyProvider  (Vertex-style raw-predict proxy)
+    bedrock          → BedrockProvider         (AWS Bedrock Runtime, SigV4)
     nv_build         → NvBuildProvider         (build.nvidia.com)
 
 When unset, the selector defaults to ``nv_build``.
@@ -69,6 +70,10 @@ def _select_active_provider() -> LLMProvider:
         from .anthropic_proxy import AnthropicProxyProvider
 
         return AnthropicProxyProvider()
+    if name == "bedrock":
+        from .bedrock import BedrockProvider
+
+        return BedrockProvider()
     if name == "nv_build":
         return NvBuildProvider()
     if name in ("nv_inference", ""):
@@ -83,7 +88,7 @@ def _select_active_provider() -> LLMProvider:
 
     raise ValueError(
         f"Unknown SKILLSPECTOR_PROVIDER: {name!r}. "
-        "Expected one of: openai, anthropic, anthropic_proxy, nv_build (or unset)."
+        "Expected one of: openai, anthropic, anthropic_proxy, bedrock, nv_build (or unset)."
     )
 
 

--- a/src/skillspector/providers/bedrock/__init__.py
+++ b/src/skillspector/providers/bedrock/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS Bedrock provider package (Claude via SigV4-authenticated Bedrock Runtime)."""
+
+from .provider import (
+    BEDROCK_DEFAULT_MODEL,
+    BEDROCK_DEFAULT_REGION,
+    REGISTRY_PATH,
+    BedrockProvider,
+)
+
+__all__ = [
+    "BEDROCK_DEFAULT_MODEL",
+    "BEDROCK_DEFAULT_REGION",
+    "REGISTRY_PATH",
+    "BedrockProvider",
+]

--- a/src/skillspector/providers/bedrock/model_registry.yaml
+++ b/src/skillspector/providers/bedrock/model_registry.yaml
@@ -1,0 +1,29 @@
+# Token-budget metadata for the BedrockProvider (AWS Bedrock Runtime).
+# Bundled with the package; consulted whenever the active provider is
+# BedrockProvider.
+#
+# Format:
+#   models:
+#     "<model-label>":
+#       context_length: <int>          # total context window in tokens (required)
+#       max_output_tokens: <int>       # model's max output cap (optional)
+#
+# Keys are public Bedrock cross-region inference profile IDs.  Users can
+# also point SKILLSPECTOR_MODEL at a stock Bedrock model ID or their own
+# application-inference-profile ARN — those won't be in this registry,
+# so the scanner falls back to the default token budget for unknown
+# models.  Add entries here if you have a private ARN you want metadata
+# for.
+
+models:
+  "us.anthropic.claude-sonnet-4-6-20250915-v1:0":
+    context_length: 1000000
+    max_output_tokens: 128000
+
+  "us.anthropic.claude-opus-4-6-20250915-v1:0":
+    context_length: 1000000
+    max_output_tokens: 128000
+
+  "us.anthropic.claude-opus-4-5-20250514-v1:0":
+    context_length: 200000
+    max_output_tokens: 64000

--- a/src/skillspector/providers/bedrock/provider.py
+++ b/src/skillspector/providers/bedrock/provider.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS Bedrock provider — Claude models via the Bedrock Runtime.
+
+Bedrock authenticates with AWS SigV4, not API keys.  ``resolve_credentials``
+returns ``None`` because the ``(api_key, base_url)`` shape doesn't fit;
+``create_chat_model`` instead probes the boto3 credential chain and
+constructs ``ChatBedrockConverse`` directly when AWS credentials resolve.
+
+Environment variables:
+    ``AWS_PROFILE``   — when set, used as the boto3 named profile.
+                        When unset, the standard boto3 credential chain
+                        (env vars, instance metadata, SSO, etc.) resolves.
+    ``AWS_REGION``    — defaults to ``us-west-2``.
+    ``SKILLSPECTOR_MODEL`` — overrides the default model (a Bedrock
+    model ID, a cross-region inference-profile ID, or your own
+    application-inference-profile ARN).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import boto3
+from botocore.config import Config as BotocoreConfig
+from langchain_aws import ChatBedrockConverse
+from langchain_core.language_models.chat_models import BaseChatModel
+
+from skillspector.providers import registry
+
+BEDROCK_DEFAULT_REGION = "us-west-2"
+# Cross-region inference profile ID for Claude Sonnet 4.6. Public,
+# available to any account with Anthropic-on-Bedrock model access.
+# Users can override with SKILLSPECTOR_MODEL to point at a different
+# model or their own application-inference-profile ARN.
+BEDROCK_DEFAULT_MODEL = "us.anthropic.claude-sonnet-4-6-20250915-v1:0"
+# Connect timeout for the Bedrock Runtime client. The per-call
+# ``timeout`` from ``create_chat_model`` is applied as the read timeout.
+_BEDROCK_CONNECT_TIMEOUT = 10
+
+REGISTRY_PATH = str(Path(__file__).with_name("model_registry.yaml"))
+
+
+class BedrockProvider:
+    """AWS Bedrock provider — SigV4 auth via boto3, bundled-YAML metadata."""
+
+    DEFAULT_MODEL = BEDROCK_DEFAULT_MODEL
+    SLOT_DEFAULTS: dict[str, str] = {}
+
+    def resolve_credentials(self) -> tuple[str, str | None] | None:
+        """Bedrock uses SigV4, not ``(api_key, base_url)`` — always returns ``None``.
+
+        ``providers.resolve_chat_model_credentials`` treats ``None`` as "this
+        provider doesn't supply OpenAI-style credentials" and falls through
+        to its OpenAI fallback (which is irrelevant for Bedrock — the
+        chat-model construction path in ``create_chat_model`` is what
+        matters).
+        """
+        return None
+
+    def create_chat_model(
+        self,
+        model: str,
+        *,
+        max_tokens: int,
+        timeout: float | None = 120,
+    ) -> BaseChatModel | None:
+        """Construct a ``ChatBedrockConverse`` bound to a Bedrock client.
+
+        Returns ``None`` if no AWS credentials resolve in the boto3
+        credential chain, so the orchestrator can fall through to its
+        OpenAI fallback.  Otherwise returns a configured client.
+
+        ``AWS_PROFILE`` selects a named profile when set; otherwise the
+        standard boto3 credential chain (env vars, instance metadata,
+        SSO, etc.) resolves.  ``AWS_REGION`` defaults to ``us-west-2``.
+
+        ``timeout`` is applied as the boto3 client's read timeout via a
+        ``botocore.config.Config`` so long Bedrock calls actually time
+        out instead of hanging.
+
+        ``ChatBedrockConverse`` requires an explicit ``provider``
+        argument when the model is supplied as an ARN (inference
+        profiles); we pin it to ``anthropic`` since this provider is
+        Claude-only.  When a plain Bedrock model ID is supplied,
+        ``provider`` is inferred from the prefix and we omit it.
+        """
+        profile = os.environ.get("AWS_PROFILE", "").strip() or None
+        region = os.environ.get("AWS_REGION", "").strip() or BEDROCK_DEFAULT_REGION
+
+        session_kwargs: dict[str, object] = {"region_name": region}
+        if profile:
+            session_kwargs["profile_name"] = profile
+        session = boto3.Session(**session_kwargs)
+
+        # If nothing in the boto3 credential chain resolves, return None so
+        # the orchestrator can fall through.
+        if session.get_credentials() is None:
+            return None
+
+        client = session.client(
+            "bedrock-runtime",
+            region_name=region,
+            config=BotocoreConfig(
+                read_timeout=timeout,
+                connect_timeout=_BEDROCK_CONNECT_TIMEOUT,
+            ),
+        )
+
+        kwargs: dict[str, object] = {
+            "model": model,
+            "client": client,
+            "region_name": region,
+            "max_tokens": max_tokens,
+        }
+        if model.startswith("arn:"):
+            kwargs["provider"] = "anthropic"
+
+        return ChatBedrockConverse(**kwargs)
+
+    def get_context_length(self, model: str) -> int | None:
+        return registry.lookup_context_length(REGISTRY_PATH, model)
+
+    def get_max_output_tokens(self, model: str) -> int | None:
+        return registry.lookup_max_output_tokens(REGISTRY_PATH, model)
+
+    def resolve_model(self, slot: str = "default") -> str:
+        """Resolve model: ``SKILLSPECTOR_MODEL`` env > slot default > ``DEFAULT_MODEL``."""
+        user_input = os.environ.get("SKILLSPECTOR_MODEL", "").strip()
+        return user_input or self.SLOT_DEFAULTS.get(slot, "") or self.DEFAULT_MODEL

--- a/tests/unit/test_bedrock_provider.py
+++ b/tests/unit/test_bedrock_provider.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the AWS Bedrock provider.
+
+Bedrock authenticates via SigV4, not API keys, so ``resolve_credentials``
+returns ``None`` and the provider implements ``ChatModelProvider.create_chat_model``
+to construct ``ChatBedrockConverse`` directly.  These tests stub
+``boto3.Session`` and ``ChatBedrockConverse`` so no AWS calls are made.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from skillspector.providers import (
+    get_metadata_provider,
+    registry,
+    resolve_provider_credentials,
+)
+from skillspector.providers.bedrock import (
+    BEDROCK_DEFAULT_MODEL,
+    BEDROCK_DEFAULT_REGION,
+    BedrockProvider,
+)
+
+# A real application-inference-profile ARN shape for testing ARN-specific
+# behavior.  Account ID and profile ID are placeholders — no live resource.
+_TEST_ARN = "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/abc123def456"
+
+
+@pytest.fixture(autouse=True)
+def _clean_provider_env(monkeypatch: pytest.MonkeyPatch):
+    """Isolate provider-related env vars and the YAML cache for each test."""
+    monkeypatch.delenv("SKILLSPECTOR_PROVIDER", raising=False)
+    monkeypatch.delenv("SKILLSPECTOR_MODEL", raising=False)
+    monkeypatch.delenv("SKILLSPECTOR_MODEL_REGISTRY", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    registry._load.cache_clear()
+    yield
+    registry._load.cache_clear()
+
+
+class TestBedrockProviderCredentials:
+    """Bedrock has no API key — resolve_credentials always returns None."""
+
+    def test_resolve_credentials_returns_none(self) -> None:
+        assert BedrockProvider().resolve_credentials() is None
+
+    def test_resolve_credentials_returns_none_even_with_aws_env_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AWS_PROFILE", "some-profile")
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        assert BedrockProvider().resolve_credentials() is None
+
+
+class TestBedrockProviderMetadata:
+    """Token-budget metadata is read from the bundled model_registry.yaml."""
+
+    def test_metadata_known_default_model(self) -> None:
+        provider = BedrockProvider()
+        assert provider.get_context_length(BEDROCK_DEFAULT_MODEL) == 1_000_000
+        assert provider.get_max_output_tokens(BEDROCK_DEFAULT_MODEL) == 128_000
+
+    def test_metadata_known_inference_profile_id(self) -> None:
+        provider = BedrockProvider()
+        model = "us.anthropic.claude-opus-4-6-20250915-v1:0"
+        assert provider.get_context_length(model) == 1_000_000
+        assert provider.get_max_output_tokens(model) == 128_000
+
+    def test_metadata_unknown_model_returns_none(self) -> None:
+        provider = BedrockProvider()
+        assert provider.get_context_length("unknown.model") is None
+        assert provider.get_max_output_tokens("unknown.model") is None
+
+
+class TestBedrockProviderResolveModel:
+    """resolve_model: SKILLSPECTOR_MODEL env > slot > DEFAULT_MODEL."""
+
+    def test_default_model_is_public_cross_region_inference_profile(self) -> None:
+        # The default must be a public Bedrock model ID, not a private ARN —
+        # this is checked in the OSS PR review and is load-bearing.
+        assert BEDROCK_DEFAULT_MODEL == "us.anthropic.claude-sonnet-4-6-20250915-v1:0"
+        assert not BEDROCK_DEFAULT_MODEL.startswith("arn:")
+        assert BedrockProvider().resolve_model() == BEDROCK_DEFAULT_MODEL
+
+    def test_env_overrides_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILLSPECTOR_MODEL", "us.anthropic.claude-opus-4-6-20250915-v1:0")
+        assert BedrockProvider().resolve_model() == "us.anthropic.claude-opus-4-6-20250915-v1:0"
+
+    def test_env_applies_to_every_slot(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILLSPECTOR_MODEL", "user/override")
+        assert BedrockProvider().resolve_model("meta_analyzer") == "user/override"
+
+    def test_unknown_slot_falls_back_to_default(self) -> None:
+        assert BedrockProvider().resolve_model("mcp_least_privilege") == BEDROCK_DEFAULT_MODEL
+
+
+class TestBedrockProviderCreateChatModel:
+    """create_chat_model wires boto3 + ChatBedrockConverse with the right config."""
+
+    @patch("skillspector.providers.bedrock.provider.ChatBedrockConverse")
+    @patch("skillspector.providers.bedrock.provider.boto3.Session")
+    def test_returns_none_when_no_aws_credentials(
+        self, mock_session: MagicMock, mock_chat: MagicMock
+    ) -> None:
+        """No AWS credentials in any chain → return None so the orchestrator falls through."""
+        mock_session.return_value.get_credentials.return_value = None
+
+        result = BedrockProvider().create_chat_model(
+            "us.anthropic.claude-sonnet-4-6-20250915-v1:0",
+            max_tokens=1024,
+            timeout=60,
+        )
+
+        assert result is None
+        mock_chat.assert_not_called()
+
+    @patch("skillspector.providers.bedrock.provider.ChatBedrockConverse")
+    @patch("skillspector.providers.bedrock.provider.boto3.Session")
+    def test_omits_profile_when_aws_profile_unset(
+        self, mock_session: MagicMock, mock_chat: MagicMock
+    ) -> None:
+        """No AWS_PROFILE → boto3.Session called without profile_name.
+
+        Defers to the standard boto3 credential chain (env vars, instance
+        metadata, SSO).  This is the OSS-default behavior; hardcoding a
+        named profile is a footgun for external users.
+        """
+        mock_session.return_value.get_credentials.return_value = MagicMock()
+        mock_session.return_value.client.return_value = MagicMock()
+
+        BedrockProvider().create_chat_model(
+            "us.anthropic.claude-sonnet-4-6-20250915-v1:0",
+            max_tokens=1024,
+            timeout=60,
+        )
+
+        session_kwargs = mock_session.call_args.kwargs
+        assert "profile_name" not in session_kwargs
+        assert session_kwargs["region_name"] == BEDROCK_DEFAULT_REGION
+
+    @patch("skillspector.providers.bedrock.provider.ChatBedrockConverse")
+    @patch("skillspector.providers.bedrock.provider.boto3.Session")
+    def test_env_overrides_profile_and_region(
+        self,
+        mock_session: MagicMock,
+        mock_chat: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("AWS_PROFILE", "custom-profile")
+        monkeypatch.setenv("AWS_REGION", "eu-central-1")
+        mock_session.return_value.get_credentials.return_value = MagicMock()
+        mock_session.return_value.client.return_value = MagicMock()
+
+        BedrockProvider().create_chat_model(
+            "us.anthropic.claude-sonnet-4-6-20250915-v1:0",
+            max_tokens=1024,
+            timeout=60,
+        )
+
+        mock_session.assert_called_once_with(
+            profile_name="custom-profile",
+            region_name="eu-central-1",
+        )
+
+    @patch("skillspector.providers.bedrock.provider.ChatBedrockConverse")
+    @patch("skillspector.providers.bedrock.provider.boto3.Session")
+    def test_timeout_applied_to_botocore_config(
+        self, mock_session: MagicMock, mock_chat: MagicMock
+    ) -> None:
+        """The ``timeout`` argument flows through to the boto3 client.
+
+        Without this, long Bedrock calls hang indefinitely instead of
+        respecting the caller's timeout budget.
+        """
+        mock_session.return_value.get_credentials.return_value = MagicMock()
+        mock_session.return_value.client.return_value = MagicMock()
+
+        BedrockProvider().create_chat_model(
+            "us.anthropic.claude-sonnet-4-6-20250915-v1:0",
+            max_tokens=1024,
+            timeout=90,
+        )
+
+        client_call = mock_session.return_value.client.call_args
+        config = client_call.kwargs["config"]
+        # botocore.config.Config exposes timeouts as attributes.
+        assert config.read_timeout == 90
+        assert config.connect_timeout == 10
+
+    @patch("skillspector.providers.bedrock.provider.ChatBedrockConverse")
+    @patch("skillspector.providers.bedrock.provider.boto3.Session")
+    def test_arn_pins_provider_to_anthropic(
+        self, mock_session: MagicMock, mock_chat: MagicMock
+    ) -> None:
+        """ChatBedrockConverse requires explicit provider= when model is an ARN."""
+        mock_session.return_value.get_credentials.return_value = MagicMock()
+        mock_session.return_value.client.return_value = MagicMock()
+
+        BedrockProvider().create_chat_model(
+            _TEST_ARN,
+            max_tokens=2048,
+            timeout=120,
+        )
+
+        kwargs = mock_chat.call_args.kwargs
+        assert kwargs["model"] == _TEST_ARN
+        assert kwargs["provider"] == "anthropic"
+        assert kwargs["max_tokens"] == 2048
+        assert kwargs["region_name"] == BEDROCK_DEFAULT_REGION
+
+    @patch("skillspector.providers.bedrock.provider.ChatBedrockConverse")
+    @patch("skillspector.providers.bedrock.provider.boto3.Session")
+    def test_plain_model_id_does_not_pin_provider(
+        self, mock_session: MagicMock, mock_chat: MagicMock
+    ) -> None:
+        """For non-ARN model IDs, provider is inferred from the prefix — omit it."""
+        mock_session.return_value.get_credentials.return_value = MagicMock()
+        mock_session.return_value.client.return_value = MagicMock()
+
+        BedrockProvider().create_chat_model(
+            "us.anthropic.claude-sonnet-4-6-20250915-v1:0",
+            max_tokens=1024,
+            timeout=60,
+        )
+
+        assert "provider" not in mock_chat.call_args.kwargs
+
+
+class TestBedrockProviderSelection:
+    """SKILLSPECTOR_PROVIDER=bedrock activates BedrockProvider."""
+
+    def test_select_bedrock(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "bedrock")
+        # Bedrock returns no OpenAI-style credentials.
+        assert resolve_provider_credentials() is None
+        assert isinstance(get_metadata_provider(), BedrockProvider)


### PR DESCRIPTION
## Summary

Closes #82.

Adds a `bedrock` provider so SkillSpector can run Claude models on **AWS Bedrock** alongside the existing OpenAI / Anthropic / NVIDIA paths. Bedrock authenticates via SigV4 (not API keys), so this also introduces an optional `ChatModelFactory` protocol — providers that don't speak the OpenAI wire protocol implement it, and `llm_utils.get_chat_model` delegates client construction to them. Existing providers are unchanged.

### Changes

- **New `providers/bedrock/` package** — `BedrockProvider` builds `ChatBedrockConverse` from a boto3 session.
  - Reads `AWS_PROFILE` and `AWS_REGION` from env (region default: `us-west-2`).
  - Default model is overridable via `SKILLSPECTOR_MODEL`; supports both Bedrock model IDs and application-inference-profile ARNs (ARNs auto-pin `provider="anthropic"`).
  - Bundled `model_registry.yaml` with token-budget metadata.
- **New `ChatModelFactory` Protocol** in `providers/base.py` — runtime-checkable; lets providers supply their own chat client when the `(api_key, base_url)` model doesn't fit.
- **`llm_utils.get_chat_model`** now returns `BaseChatModel` (was `ChatOpenAI`). When the active provider implements `ChatModelFactory`, construction is delegated to it; otherwise the existing `ChatOpenAI` path runs unchanged.
- **`is_llm_available()`** short-circuits for factory-style providers — credential errors surface at invoke time via boto3 instead of at startup.
- **CLI / README** updated to document `SKILLSPECTOR_PROVIDER=bedrock`, `AWS_PROFILE`, and `AWS_REGION`.
- **Deps**: `langchain-aws>=0.2.0`, `boto3>=1.34.0` (added to `pyproject.toml`; `uv.lock` left for the maintainer to regenerate).

### Usage

```bash
export SKILLSPECTOR_PROVIDER=bedrock
export AWS_PROFILE=your-aws-profile
export AWS_REGION=us-west-2
# Optional: override the default model with a Bedrock model ID or ARN
# export SKILLSPECTOR_MODEL=us.anthropic.claude-sonnet-4-6-20250915-v1:0
skillspector scan ./my-skill/
```

## Test plan

- [x] **New unit tests**: `tests/unit/test_bedrock_provider.py` — 16 tests covering credential short-circuit, model-registry lookup, `resolve_model` precedence, ARN-vs-model-id provider pinning, env-driven `AWS_PROFILE` / `AWS_REGION`, and `SKILLSPECTOR_PROVIDER=bedrock` selection. boto3 + `ChatBedrockConverse` are mocked, so no AWS calls are made.
- [x] **Full unit suite**: `pytest -m 'not integration'` → **617 passed, 11 skipped, 23 deselected** (up from 601 by the 16 new tests).
- [x] `ruff check src/ tests/` clean.
- [x] `ruff format --check src/ tests/` clean.
- [x] **End-to-end smoke test against AWS**: `chat_completion("Reply with just the word: OK")` returned `OK` via SigV4 + the application-inference-profile ARN.
- [x] **End-to-end scan**: scanning the `instruction-override` skill from [`apurin/cursed-skills`](https://github.com/apurin/cursed-skills) (intentionally malicious) produced `CRITICAL` findings for prompt-injection / `/etc/passwd` exfil — confirms the analyzers actually run end-to-end through Bedrock, not just the credential path.
- [x] **DCO sign-off** present on the commit.

## Known follow-up (out of scope for this PR)

Issues #66 and #76 report that the Anthropic provider's structured-output schema is rejected because Pydantic emits `minimum`/`maximum` JSON-Schema keywords. Bedrock's Anthropic-backed Converse API has the same constraint surface. End-to-end semantic-analyzer scans through Bedrock should work for endpoints that tolerate the current schema; if the same 400s appear on Bedrock, the fix belongs alongside the upstream fix in `LLMAnalyzerBase` / `meta_analyzer.py` rather than in this provider. Happy to fold that in or follow up in a separate PR per the maintainer's preference.
