### PR TITLE
fix(build_context): use forward-slash component paths (cross-platform)

### DIFF
--- a/src/skillspector/nodes/build_context.py
+++ b/src/skillspector/nodes/build_context.py
@@ -87,7 +87,10 @@ def _walk_skill_files(skill_dir: Path) -> list[str]:
             continue
         try:
             rel = item.relative_to(skill_dir)
-            paths.append(str(rel))
+            # Use forward slashes on every OS: these relative paths are dict keys
+            # and SARIF/URI locations, so they must be portable (not OS-specific
+            # backslashes on Windows).
+            paths.append(rel.as_posix())
         except ValueError:
             logger.debug("Skipping path (not under skill_dir): %s", item)
             continue

--- a/tests/nodes/analyzers/test_semantic_developer_intent.py
+++ b/tests/nodes/analyzers/test_semantic_developer_intent.py
@@ -342,7 +342,7 @@ def _build_file_cache(skill_dir: Path) -> dict[str, str]:
     for item in sorted(skill_dir.rglob("*")):
         if not item.is_file():
             continue
-        rel = str(item.relative_to(skill_dir))
+        rel = item.relative_to(skill_dir).as_posix()  # forward slashes on every OS
         try:
             cache[rel] = item.read_text(encoding="utf-8", errors="replace")
         except OSError:

--- a/tests/nodes/analyzers/test_semantic_security_discovery.py
+++ b/tests/nodes/analyzers/test_semantic_security_discovery.py
@@ -317,7 +317,7 @@ def _build_file_cache(skill_dir: Path) -> dict[str, str]:
     for item in sorted(skill_dir.rglob("*")):
         if not item.is_file():
             continue
-        rel = str(item.relative_to(skill_dir))
+        rel = item.relative_to(skill_dir).as_posix()  # forward slashes on every OS
         try:
             cache[rel] = item.read_text(encoding="utf-8", errors="replace")
         except OSError:

--- a/tests/nodes/test_semantic_quality_policy.py
+++ b/tests/nodes/test_semantic_quality_policy.py
@@ -289,7 +289,7 @@ def _build_file_cache(skill_dir: Path) -> dict[str, str]:
     for item in sorted(skill_dir.rglob("*")):
         if not item.is_file():
             continue
-        rel = str(item.relative_to(skill_dir))
+        rel = item.relative_to(skill_dir).as_posix()  # forward slashes on every OS
         try:
             cache[rel] = item.read_text(encoding="utf-8", errors="replace")
         except OSError:

--- a/tests/test_mcp_least_privilege.py
+++ b/tests/test_mcp_least_privilege.py
@@ -98,7 +98,7 @@ def _make_state(fixture_name: str) -> dict:
             continue
         if item.name.startswith(".") and not item.name.startswith(".claude"):
             continue
-        rel = str(item.relative_to(fixture_dir))
+        rel = item.relative_to(fixture_dir).as_posix()  # forward slashes on every OS
         components.append(rel)
     components.sort()
 

--- a/tests/test_mcp_tool_poisoning.py
+++ b/tests/test_mcp_tool_poisoning.py
@@ -121,7 +121,7 @@ def _make_state(
             continue
         if item.name.startswith(".") and not item.name.startswith(".claude"):
             continue
-        rel = str(item.relative_to(fixture_dir))
+        rel = item.relative_to(fixture_dir).as_posix()  # forward slashes on every OS
         components.append(rel)
     components.sort()
 


### PR DESCRIPTION
Fixes #86

## What

`build_context` emitted OS-native path separators for relative component paths — backslashes on Windows (e.g. `references\guide.md`). These paths are used as dict keys (`components` / `file_cache` / `component_metadata`) and as **SARIF `physicalLocation` URIs**, which are meant to be portable, forward-slash, URI-style paths. So on Windows the generated report locations were non-portable, downstream path-keyed lookups mismatched, and the unit/integration suite failed (11 tests across `test_build_context.py` and the semantic-analyzer fixtures).

## How

Use `Path.as_posix()` instead of `str(Path)` so component paths are forward-slash on **every** OS:
- `src/skillspector/nodes/build_context.py` (the actual fix).
- The handful of test helpers that mirror the same `relative_to` logic (`_build_file_cache` in the semantic-analyzer tests, plus the two MCP fixture helpers — those have flat fixtures today, fixed for consistency so the latent bug can't resurface).

Behaviour-preserving on Linux/macOS, where `str(Path)` already yields forward slashes.

## Test

Full suite green on Windows (was 11 failing): `pytest` passes; ruff clean. No new dependencies; one-line idiom change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
