### PR TITLE
fix(meta_analyzer): parse stringified findings array from LLM

### DIFF
--- a/src/skillspector/nodes/meta_analyzer.py
+++ b/src/skillspector/nodes/meta_analyzer.py
@@ -87,6 +87,18 @@ class MetaAnalyzerResult(BaseModel):
     findings: list[MetaAnalyzerFinding] = Field(default_factory=list)
     overall_assessment: OverallAssessment | None = None
 
+    @field_validator("findings", mode="before")
+    @classmethod
+    def _parse_stringified_findings(cls, v: object) -> object:
+        """LLMs sometimes return the findings array as a JSON string."""
+        if isinstance(v, str):
+            try:
+                parsed = json.loads(v)
+            except (json.JSONDecodeError, TypeError):
+                return []
+            return parsed if isinstance(parsed, list) else []
+        return v
+
     @field_validator("overall_assessment", mode="before")
     @classmethod
     def _parse_stringified_assessment(cls, v: object) -> object:

--- a/tests/nodes/test_llm_analyzer_base.py
+++ b/tests/nodes/test_llm_analyzer_base.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -284,6 +285,40 @@ class TestBaseParseResponse:
         batch = Batch(file_path="a.py", content="code")
         with pytest.raises(NotImplementedError):
             analyzer.parse_response("raw string", batch)
+
+
+# ---------------------------------------------------------------------------
+# MetaAnalyzerResult — tolerate LLMs that stringify the `findings` array
+# ---------------------------------------------------------------------------
+
+
+class TestMetaAnalyzerResultFindingsValidator:
+    _FINDING = {
+        "pattern_id": "E2",
+        "start_line": 12,
+        "is_vulnerability": True,
+        "confidence": 0.9,
+        "intent": "malicious",
+        "impact": "high",
+    }
+
+    def test_findings_as_json_string(self) -> None:
+        """Some LLMs return the findings array as a JSON string, not a list."""
+        result = MetaAnalyzerResult.model_validate({"findings": json.dumps([self._FINDING])})
+        assert len(result.findings) == 1
+        assert result.findings[0].pattern_id == "E2"
+
+    def test_findings_as_native_list(self) -> None:
+        result = MetaAnalyzerResult.model_validate({"findings": [self._FINDING]})
+        assert len(result.findings) == 1
+
+    def test_findings_invalid_string_yields_empty(self) -> None:
+        result = MetaAnalyzerResult.model_validate({"findings": "not json"})
+        assert result.findings == []
+
+    def test_findings_non_list_json_yields_empty(self) -> None:
+        result = MetaAnalyzerResult.model_validate({"findings": json.dumps({"a": 1})})
+        assert result.findings == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`MetaAnalyzerResult` has a `field_validator` that repairs `overall_assessment` when an LLM returns it as a JSON **string** (`mode="before"` → `json.loads`), but there is no equivalent validator for the top-level `findings` array.

Some models/endpoints — reproducibly **Claude Sonnet via an OpenAI-compatible gateway** (`SKILLSPECTOR_PROVIDER=openai` pointed at a router) — return `findings` as a stringified JSON array rather than a real list. This fails Pydantic's `list_type` validation and crashes the scan:

```
Error: 1 validation error for MetaAnalyzerResult
findings
  Input should be a valid array [type=list_type, input_value='[\n  {\n    "pattern_id"...', input_type=str]
```

The process exits with code 2 and **no report is written**, even though all per-file analyzers ran successfully. I hit this on multiple real scans (a skill and an MCP-server repo).

## Fix

Add a mirrored `field_validator("findings", mode="before")` that `json.loads` a string payload, falling back to an empty list on parse failure or a non-list result — exactly matching the existing `_parse_stringified_assessment` behavior for `overall_assessment`.

## Tests

New `TestMetaAnalyzerResultFindingsValidator` in `tests/nodes/test_llm_analyzer_base.py` covering:
- stringified JSON array → parsed into `MetaAnalyzerFinding` objects
- native list → unchanged
- invalid string → `[]`
- non-list JSON (e.g. an object) → `[]`

Full file suite passes (`83 passed`); `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)