### PR TITLE
fix(P2): add bidi control character detection (Trojan Source / CVE-2021-42574)

### DIFF
--- a/src/skillspector/nodes/analyzers/static_patterns_prompt_injection.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_prompt_injection.py
@@ -51,6 +51,7 @@ P2_PATTERNS = [
     (r"<!--.*?(?:system|instructions?|ignore|POST|GET|send|transmit).*?-->", 0.7),
     (r"\[//\]:\s*#\s*\(.*?(?:system|instructions?|ignore|POST|GET|send|transmit).*?\)", 0.8),
     (r"[\u200b\u200c\u200d\u2060\ufeff]", 0.6),
+    (r"[\u202a-\u202e\u2066-\u2069]", 0.85),
     (r"data:text/plain;base64,[A-Za-z0-9+/=]{50,}", 0.7),
 ]
 # P3: Exfiltration Commands

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -66,6 +66,31 @@ class TestRunStaticPatternsPromptInjection:
         assert len(findings) >= 1
         assert any(f.rule_id == "P2" for f in findings)
 
+    def test_p2_bidi_control_chars_produce_finding(self):
+        """Bidi control characters (Trojan Source CVE-2021-42574) yield P2."""
+        # ‮ is RIGHT-TO-LEFT OVERRIDE — a bidi control character
+        state = {
+            "components": ["SKILL.md"],
+            "file_cache": {
+                "SKILL.md": "Normal text‮ evil hidden content‬",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [prompt_injection_module])
+        assert len(findings) >= 1
+        assert any(f.rule_id == "P2" for f in findings)
+
+    def test_p2_bidi_rlo_edge_cases(self):
+        """Bidi override variants ‪-‮ and ⁦-⁩ all yield P2."""
+        bidi_chars = ["‪", "‫", "‬", "‭", "‮", "⁦", "⁧", "⁨", "⁩"]
+        for ch in bidi_chars:
+            state = {
+                "components": ["skill.md"],
+                "file_cache": {"skill.md": f"text{ch}more"},
+            }
+            findings = static_runner.run_static_patterns(state, [prompt_injection_module])
+            p2 = [f for f in findings if f.rule_id == "P2"]
+            assert len(p2) >= 1, f"Expected P2 for bidi char U+{ord(ch):04X}"
+
     def test_safe_content_no_p1_p2(self):
         """Safe content does not produce P1/P2."""
         state = {


### PR DESCRIPTION
## Problem

`P2_PATTERNS` catches zero-width characters (`​`–`﻿`) but was missing the full set of Unicode **bidi control characters** (`U+202A`–`U+202E`, `U+2066`–`U+2069`).

Bidi overrides are the attack vector behind [CVE-2021-42574 (Trojan Source)](https://trojansource.codes/): an attacker inserts a RIGHT-TO-LEFT OVERRIDE (`‮`) or similar character so the code _looks_ safe to a human reviewer, but the LLM reads the characters in logical order and follows hidden instructions.

## Fix

Add one regex entry to `P2_PATTERNS`:

```python
(r"[‪-‮⁦-⁩]", 0.85),
```

Confidence 0.85 — higher than plain zero-width chars because bidi controls have almost no legitimate use in AI skill markdown content.

## Tests

- `test_p2_bidi_control_chars_produce_finding` — RLO character triggers P2
- `test_p2_bidi_rlo_edge_cases` — all 9 bidi control characters individually trigger P2

Closes #39

## Checklist
- [x] `make lint` passes
- [x] Tests added for new behaviour
- [x] DCO sign-off on commit (`git commit -s`)