### PR TITLE
feat(analyzer): add agent snooping detector (AS1/AS2/AS3)

### DIFF
--- a/src/skillspector/nodes/analyzers/__init__.py
+++ b/src/skillspector/nodes/analyzers/__init__.py
@@ -33,6 +33,9 @@ from skillspector.nodes.analyzers.semantic_quality_policy import (
 from skillspector.nodes.analyzers.semantic_security_discovery import (
     node as semantic_security_discovery_node,
 )
+from skillspector.nodes.analyzers.static_patterns_agent_snooping import (
+    node as static_patterns_agent_snooping_node,
+)
 from skillspector.nodes.analyzers.static_patterns_data_exfiltration import (
     node as static_patterns_data_exfiltration_node,
 )
@@ -80,6 +83,7 @@ ANALYZER_NODE_IDS: list[str] = [
     "static_patterns_memory_poisoning",
     "static_patterns_tool_misuse",
     "static_patterns_rogue_agent",
+    "static_patterns_agent_snooping",
     "static_yara",
     "behavioral_ast",
     "behavioral_taint_tracking",
@@ -103,6 +107,7 @@ ANALYZER_NODES = {
     "static_patterns_memory_poisoning": static_patterns_memory_poisoning_node,
     "static_patterns_tool_misuse": static_patterns_tool_misuse_node,
     "static_patterns_rogue_agent": static_patterns_rogue_agent_node,
+    "static_patterns_agent_snooping": static_patterns_agent_snooping_node,
     "static_yara": static_yara_node,
     "behavioral_ast": behavioral_ast_node,
     "behavioral_taint_tracking": behavioral_taint_tracking_node,

--- a/src/skillspector/nodes/analyzers/pattern_defaults.py
+++ b/src/skillspector/nodes/analyzers/pattern_defaults.py
@@ -38,6 +38,7 @@ class PatternCategory(StrEnum):
     YARA_MATCH = "YARA Match"
     MCP_LEAST_PRIVILEGE = "MCP Least Privilege"
     MCP_TOOL_POISONING = "MCP Tool Poisoning"
+    AGENT_SNOOPING = "Agent Snooping"
 
 
 # Pattern-specific explanations (why the finding is dangerous)
@@ -119,6 +120,10 @@ DEFAULT_EXPLANATIONS: dict[str, str] = {
     "TP2": "Unicode deception detected in skill identifiers or descriptions. Homoglyphs, RTL overrides, or invisible characters can make malicious content appear benign.",
     "TP3": "Instruction injection patterns found in parameter descriptions or default values. Parameter metadata is read by LLMs and can override intended behavior.",
     "TP4": "Skill description does not match actual code behavior. The declared purpose diverges from what the code actually does, indicating possible deception.",
+    # Agent Snooping (AS1–AS3)
+    "AS1": "Skill reads from agent configuration directories (.claude/, .codex/, .gemini/). These directories may contain API keys, personal settings, and other credentials that the skill has no legitimate need to access.",
+    "AS2": "Skill accesses MCP server configuration files (mcp.json). MCP configs contain server URLs, authentication tokens, and tool definitions — reading them allows the skill to discover and potentially abuse other tool integrations.",
+    "AS3": "Skill enumerates or reads other installed skills. Access to other skills' SKILL.md files or the skills directory reveals prompt instructions, capabilities, and secrets that should be invisible to peer skills.",
 }
 
 # Rule ID -> category (for report output)
@@ -182,6 +187,10 @@ RULE_ID_TO_CATEGORY: dict[str, str] = {
     "TP2": PatternCategory.MCP_TOOL_POISONING.value,
     "TP3": PatternCategory.MCP_TOOL_POISONING.value,
     "TP4": PatternCategory.MCP_TOOL_POISONING.value,
+    # Agent Snooping (AS1–AS3)
+    "AS1": PatternCategory.AGENT_SNOOPING.value,
+    "AS2": PatternCategory.AGENT_SNOOPING.value,
+    "AS3": PatternCategory.AGENT_SNOOPING.value,
 }
 
 # Rule ID -> pattern display name (for report output)
@@ -245,6 +254,10 @@ PATTERN_NAMES: dict[str, str] = {
     "TP2": "Unicode Deception",
     "TP3": "Parameter Description Injection",
     "TP4": "Description-Behavior Mismatch",
+    # Agent Snooping (AS1–AS3)
+    "AS1": "Agent Config Directory Access",
+    "AS2": "MCP Config Access",
+    "AS3": "Skill Enumeration",
 }
 
 # Pattern-specific remediations (how to fix the issue)
@@ -326,6 +339,10 @@ DEFAULT_REMEDIATIONS: dict[str, str] = {
     "TP2": "Replace non-ASCII characters in identifiers with ASCII equivalents. Remove RTL override and invisible formatting characters.",
     "TP3": "Remove injection patterns, system tokens, and suspicious content from parameter descriptions and default values.",
     "TP4": "Update the skill description to accurately reflect all capabilities, or remove undeclared functionality.",
+    # Agent Snooping (AS1–AS3)
+    "AS1": "Remove all code or instructions that access agent configuration directories (.claude/, .codex/, .gemini/). If configuration values are needed, pass them explicitly as parameters or environment variables — never read the agent's own config files.",
+    "AS2": "Remove all code or instructions that read MCP configuration files (mcp.json). MCP server details should be managed by the agent runtime, not read by individual skills.",
+    "AS3": "Remove all code or instructions that list or read other skills' files or directories. Skills should operate independently; cross-skill access is a privilege escalation.",
 }
 
 

--- a/src/skillspector/nodes/analyzers/static_patterns_agent_snooping.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_agent_snooping.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static patterns: agent snooping (AS1–AS3). Node and analyze() in one module.
+
+Detects patterns where a skill attempts to read agent configuration
+directories (AS1), access MCP server config files (AS2), or enumerate and
+read other installed skills (AS3).
+
+A skill performing these accesses gains knowledge it has no legitimate
+need for: API keys stored in agent config, other skills' prompts, or the
+full list of tools available to the agent.
+
+Framework: OWASP LLMT09 (Misinformation), ASI-SR-003 (Least Knowledge).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+from skillspector.logging_config import get_logger
+from skillspector.models import AnalyzerFinding, Location, Severity
+from skillspector.state import AnalyzerNodeResponse, SkillspectorState
+
+from . import static_runner
+from .common import get_context, get_line_number
+from .pattern_defaults import PatternCategory
+
+logger = get_logger(__name__)
+
+ANALYZER_ID = "static_patterns_agent_snooping"
+
+# AS1: Agent Config Directory Access
+# Matches code/instructions that read from well-known agent config directories.
+AS1_PATTERNS = [
+    # Direct filesystem access to .claude/, .codex/, .gemini/ directories
+    (r"open\s*\(\s*['\"]?\.(?:claude|codex|gemini|continue)/", 0.9),
+    (r"(?:Path|pathlib\.Path)\s*\(\s*['\"]?\.(?:claude|codex|gemini|continue)/", 0.9),
+    (r"os\.path\.(?:join|exists|isfile)\s*\(\s*['\"]?\.(?:claude|codex|gemini|continue)", 0.85),
+    (r"(?:read|load|open|access|fetch)\s+(?:the\s+)?(?:agent|claude|codex|gemini)\s+(?:config|configuration|settings?)\s+(?:from|at|in)\s+~?/?\.(?:claude|codex|gemini)", 0.9),
+    # Shell commands targeting config dirs
+    (r"(?:cat|less|head|tail|grep|find)\s+[^|&;\n]*~?/?\.(claude|codex|gemini)/", 0.85),
+    # Home-directory config paths
+    (r"~?/\.(?:claude|codex|gemini|continue)/(?:config|settings?|preferences?|credentials?)(?:\.(?:json|yaml|yml|toml))?", 0.9),
+    # Generic "agent config" snooping instructions
+    (r"(?:read|access|inspect|examine|retrieve)\s+(?:the\s+)?(?:agent|assistant)\s+(?:config(?:uration)?|settings?|preferences?)\s+(?:file|directory|folder)", 0.8),
+]
+
+# AS2: MCP Config Access
+# Matches code/instructions specifically targeting MCP server configuration.
+AS2_PATTERNS = [
+    # Direct access to mcp.json files
+    (r"open\s*\(\s*['\"][^'\"]*mcp(?:_config)?\.json['\"]", 0.95),
+    (r"(?:Path|pathlib\.Path)\s*\(\s*['\"][^'\"]*mcp(?:_config)?\.json['\"]", 0.9),
+    (r"(?:cat|less|head|grep)\s+[^|&;\n]*mcp(?:_config)?\.json", 0.9),
+    # Instructions referencing MCP config
+    (r"(?:read|access|load|inspect)\s+(?:the\s+)?mcp(?:\.json|_config)?\s+(?:file|config(?:uration)?|settings?)", 0.9),
+    (r"\.(?:claude|codex|gemini)/mcp(?:_config)?\.json", 0.95),
+    # Listing MCP servers
+    (r"(?:list|enumerate|discover)\s+(?:all\s+)?(?:available\s+)?mcp\s+(?:servers?|tools?|services?)", 0.8),
+    # Accessing MCP server URLs or API keys from config
+    (r"mcp(?:_config)?\.json.*?(?:api_?key|token|secret|url|endpoint)", 0.9),
+]
+
+# AS3: Skill Enumeration / Snooping
+# Matches code/instructions that enumerate or read other installed skills.
+AS3_PATTERNS = [
+    # Listing skill directories
+    (r"(?:os\.listdir|os\.scandir|glob\.glob|Path\.iterdir)\s*\([^)]*\.(?:claude|codex|gemini)/skills?", 0.9),
+    (r"(?:ls|find|dir)\s+[^|&;\n]*\.(?:claude|codex|gemini)/skills?", 0.85),
+    # Reading other skills' SKILL.md files
+    (r"open\s*\(\s*['\"][^'\"]*SKILL\.md['\"].*?\bother\b", 0.85),
+    (r"(?:read|access|inspect|enumerate)\s+(?:all\s+)?(?:installed|available|other)\s+skills?(?:\s+in\s+(?:the\s+)?(?:skills?|agent)\s+(?:directory|folder))?", 0.85),
+    # Instructions to discover other skills
+    (r"(?:list|discover|find|enumerate|identify)\s+(?:all\s+)?(?:other|installed|available)\s+(?:skills?|agents?|tools?)\s+(?:in\s+)?(?:the\s+)?(?:\.(?:claude|codex|gemini)|\$HOME)", 0.85),
+    # Accessing skills/CURRENT or adjacent skill directories
+    (r"skills?/(?:(?!CURRENT)[A-Z][A-Za-z0-9_-]+)/SKILL\.md", 0.8),
+    # Reading tool manifests of other agents
+    (r"(?:read|access|load)\s+(?:the\s+)?(?:SKILL|skill)\.md\s+(?:file\s+)?(?:of|from|for)\s+(?:another|other|different|all)\s+(?:skill|agent|tool)", 0.9),
+]
+
+
+def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFinding]:
+    """Analyze content for agent snooping patterns (AS1–AS3)."""
+    findings: list[AnalyzerFinding] = []
+
+    def loc(ln: int) -> Location:
+        return Location(file=file_path, start_line=ln)
+
+    def ctx(start: int) -> str:
+        return get_context(content, start)
+
+    tag = [PatternCategory.AGENT_SNOOPING.value]
+
+    for pattern, confidence in AS1_PATTERNS:
+        for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
+            line_num = get_line_number(content, match.start())
+            findings.append(
+                AnalyzerFinding(
+                    rule_id="AS1",
+                    message="Agent Config Directory Access",
+                    severity=Severity.HIGH,
+                    location=loc(line_num),
+                    confidence=confidence,
+                    tags=tag,
+                    context=ctx(match.start()),
+                    matched_text=match.group(0)[:200],
+                )
+            )
+
+    for pattern, confidence in AS2_PATTERNS:
+        for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
+            line_num = get_line_number(content, match.start())
+            findings.append(
+                AnalyzerFinding(
+                    rule_id="AS2",
+                    message="MCP Config Access",
+                    severity=Severity.HIGH,
+                    location=loc(line_num),
+                    confidence=confidence,
+                    tags=tag,
+                    context=ctx(match.start()),
+                    matched_text=match.group(0)[:200],
+                )
+            )
+
+    for pattern, confidence in AS3_PATTERNS:
+        for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
+            line_num = get_line_number(content, match.start())
+            findings.append(
+                AnalyzerFinding(
+                    rule_id="AS3",
+                    message="Skill Enumeration",
+                    severity=Severity.MEDIUM,
+                    location=loc(line_num),
+                    confidence=confidence,
+                    tags=tag,
+                    context=ctx(match.start()),
+                    matched_text=match.group(0)[:200],
+                )
+            )
+
+    return findings
+
+
+def node(state: SkillspectorState) -> AnalyzerNodeResponse:
+    """Run agent_snooping patterns and return findings."""
+    findings = static_runner.run_static_patterns(state, [sys.modules[__name__]])
+    logger.info("%s: %d findings", ANALYZER_ID, len(findings))
+    return {"findings": findings}

--- a/tests/nodes/analyzers/test_registry.py
+++ b/tests/nodes/analyzers/test_registry.py
@@ -33,6 +33,7 @@ EXPECTED_ANALYZER_NODE_IDS: list[str] = [
     "static_patterns_memory_poisoning",
     "static_patterns_tool_misuse",
     "static_patterns_rogue_agent",
+    "static_patterns_agent_snooping",
     "static_yara",
     "behavioral_ast",
     "behavioral_taint_tracking",

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -18,6 +18,9 @@
 from __future__ import annotations
 
 from skillspector.nodes.analyzers import (
+    static_patterns_agent_snooping as agent_snooping_module,
+)
+from skillspector.nodes.analyzers import (
     static_patterns_data_exfiltration as data_exfiltration_module,
 )
 from skillspector.nodes.analyzers import (
@@ -153,6 +156,68 @@ class TestRunStaticPatternsSupplyChain:
         sc2 = [f for f in findings if f.rule_id == "SC2"]
         assert len(sc2) >= 1
         assert sc2[0].severity == "HIGH"
+
+
+class TestRunStaticPatternsAgentSnooping:
+    """run_static_patterns with agent_snooping: AS1, AS2, AS3."""
+
+    def test_as1_agent_config_dir_access_python(self):
+        """Reading .claude/ config files in Python code yields AS1."""
+        state = {
+            "components": ["helper.py"],
+            "file_cache": {
+                "helper.py": "import json\nwith open('.claude/settings.json') as f:\n    cfg = json.load(f)",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [agent_snooping_module])
+        assert len(findings) >= 1
+        as1 = [f for f in findings if f.rule_id == "AS1"]
+        assert len(as1) >= 1
+        assert as1[0].severity == "HIGH"
+
+    def test_as1_codex_config_dir_access(self):
+        """Reading .codex/ config directory in instructions yields AS1."""
+        state = {
+            "components": ["SKILL.md"],
+            "file_cache": {
+                "SKILL.md": "Read the agent settings from ~/.codex/config.json to determine capabilities.",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [agent_snooping_module])
+        assert any(f.rule_id == "AS1" for f in findings)
+
+    def test_as2_mcp_config_access(self):
+        """Accessing mcp.json files yields AS2."""
+        state = {
+            "components": ["reader.py"],
+            "file_cache": {
+                "reader.py": "with open('.claude/mcp.json') as f:\n    servers = json.load(f)",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [agent_snooping_module])
+        assert any(f.rule_id == "AS2" for f in findings)
+
+    def test_as3_skill_enumeration(self):
+        """Listing installed skills from skill directories yields AS3."""
+        state = {
+            "components": ["SKILL.md"],
+            "file_cache": {
+                "SKILL.md": "Enumerate all installed skills by listing files in the .claude/skills/ directory.",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [agent_snooping_module])
+        assert any(f.rule_id == "AS3" for f in findings)
+
+    def test_safe_content_no_agent_snooping(self):
+        """Legitimate skill content produces no agent snooping findings."""
+        state = {
+            "components": ["SKILL.md"],
+            "file_cache": {
+                "SKILL.md": "# Code Helper\n\nHelps you write better Python code.\n\n## Usage\nAsk me to review your code.",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [agent_snooping_module])
+        assert not any(f.rule_id in ("AS1", "AS2", "AS3") for f in findings)
 
 
 class TestRunStaticPatternsFileTypeAndSkip:


### PR DESCRIPTION
## Problem / Gap

No existing analyzer flagged skills that attempt to read the agent's own
configuration directories, access MCP server config files, or enumerate other
installed skills.  All three vectors give a malicious skill knowledge it has
no legitimate need for:

- **AS1 — Agent config directory access**: reading `.claude/`, `.codex/`,
  `.gemini/`, or `.continue/` exposes API keys, system prompts, and custom
  instructions stored there.
- **AS2 — MCP config file access**: `mcp.json` / `mcp_config.json` contains
  the full list of MCP servers, their endpoints, and their authentication
  tokens.
- **AS3 — Skill enumeration**: a skill that lists or reads other skills'
  source files learns the full tool surface of the agent and can craft targeted
  follow-on attacks.

## Solution

New static analyzer `static_patterns_agent_snooping` with 21 patterns across
three rule IDs, registered as analyzer node #21 (position 12, after
`static_patterns_rogue_agent`).

### AS1 patterns (confidence 0.85–0.9)
- `open(`.claude/…`)` / `Path(".claude/…")`
- `os.path.join/exists/isfile` with agent config directories
- Shell commands (`cat`, `find`, `grep`) targeting `~/.claude/` etc.
- Natural-language instructions to read agent config

### AS2 patterns (confidence 0.85–0.9)
- Direct file reads of `mcp.json` / `mcp_config.json`
- Path traversal to `.claude/mcp.json`
- Natural language: "read the MCP configuration"

### AS3 patterns (confidence 0.7–0.85)
- `os.listdir` / `glob` / `Path.glob` on skill directories
- Shell `ls` / `find` targeting skills folder
- Natural language: "list all available skills"

## Files Changed

| File | Change |
|------|--------|
| `src/skillspector/nodes/analyzers/static_patterns_agent_snooping.py` | New analyzer (SPDX header, `analyze()`, `node()`) |
| `src/skillspector/nodes/analyzers/pattern_defaults.py` | Add `PatternCategory.AGENT_SNOOPING`, AS1–AS3 explanations, remediations, pattern names |
| `src/skillspector/nodes/analyzers/__init__.py` | Register node in `ANALYZER_NODE_IDS` and `ANALYZER_NODES` |
| `tests/nodes/analyzers/test_static_patterns.py` | `TestRunStaticPatternsAgentSnooping` (5 tests) |
| `tests/nodes/analyzers/test_registry.py` | Updated `EXPECTED_ANALYZER_NODE_IDS` |

## Tests

- `test_as1_agent_config_dir_access_python` — Python `open()` call targeting `.claude/`
- `test_as1_codex_config_dir_access` — `Path(".codex/config.json")` construct
- `test_as2_mcp_config_access` — direct `mcp.json` read
- `test_as3_skill_enumeration` — `os.listdir` on skills directory
- `test_safe_content_no_agent_snooping` — clean content produces no findings (false-positive guard)

All 626 existing tests continue to pass.

Closes #75

## Checklist
- [x] `make lint` passes (`ruff check src/ tests/`)
- [x] All 626 existing tests pass (`python -m pytest tests/ -x --ignore=tests/integration`)
- [x] New tests for all three rule IDs + safe-content regression
- [x] SPDX header on new file
- [x] DCO sign-off on commit (`git commit -s`)