### PR TITLE
fix: normalize build context component paths

### DIFF
--- a/src/skillspector/nodes/build_context.py
+++ b/src/skillspector/nodes/build_context.py
@@ -87,7 +87,7 @@ def _walk_skill_files(skill_dir: Path) -> list[str]:
             continue
         try:
             rel = item.relative_to(skill_dir)
-            paths.append(str(rel))
+            paths.append(rel.as_posix())
         except ValueError:
             logger.debug("Skipping path (not under skill_dir): %s", item)
             continue

--- a/tests/nodes/analyzers/test_semantic_developer_intent.py
+++ b/tests/nodes/analyzers/test_semantic_developer_intent.py
@@ -342,7 +342,7 @@ def _build_file_cache(skill_dir: Path) -> dict[str, str]:
     for item in sorted(skill_dir.rglob("*")):
         if not item.is_file():
             continue
-        rel = str(item.relative_to(skill_dir))
+        rel = item.relative_to(skill_dir).as_posix()
         try:
             cache[rel] = item.read_text(encoding="utf-8", errors="replace")
         except OSError:

--- a/tests/nodes/analyzers/test_semantic_security_discovery.py
+++ b/tests/nodes/analyzers/test_semantic_security_discovery.py
@@ -317,7 +317,7 @@ def _build_file_cache(skill_dir: Path) -> dict[str, str]:
     for item in sorted(skill_dir.rglob("*")):
         if not item.is_file():
             continue
-        rel = str(item.relative_to(skill_dir))
+        rel = item.relative_to(skill_dir).as_posix()
         try:
             cache[rel] = item.read_text(encoding="utf-8", errors="replace")
         except OSError:

--- a/tests/nodes/test_semantic_quality_policy.py
+++ b/tests/nodes/test_semantic_quality_policy.py
@@ -289,7 +289,7 @@ def _build_file_cache(skill_dir: Path) -> dict[str, str]:
     for item in sorted(skill_dir.rglob("*")):
         if not item.is_file():
             continue
-        rel = str(item.relative_to(skill_dir))
+        rel = item.relative_to(skill_dir).as_posix()
         try:
             cache[rel] = item.read_text(encoding="utf-8", errors="replace")
         except OSError:

--- a/tests/test_mcp_least_privilege.py
+++ b/tests/test_mcp_least_privilege.py
@@ -98,7 +98,7 @@ def _make_state(fixture_name: str) -> dict:
             continue
         if item.name.startswith(".") and not item.name.startswith(".claude"):
             continue
-        rel = str(item.relative_to(fixture_dir))
+        rel = item.relative_to(fixture_dir).as_posix()
         components.append(rel)
     components.sort()
 

--- a/tests/test_mcp_tool_poisoning.py
+++ b/tests/test_mcp_tool_poisoning.py
@@ -121,7 +121,7 @@ def _make_state(
             continue
         if item.name.startswith(".") and not item.name.startswith(".claude"):
             continue
-        rel = str(item.relative_to(fixture_dir))
+        rel = item.relative_to(fixture_dir).as_posix()
         components.append(rel)
     components.sort()
 


### PR DESCRIPTION
## Summary
- Normalize build context component paths with `Path.as_posix()` so Windows emits forward-slash relative paths.
- Update test helper file-cache builders to mirror the same portable path convention.

## Test Plan
- `python -m compileall -q src\skillspector\nodes\build_context.py tests\test_mcp_least_privilege.py tests\test_mcp_tool_poisoning.py tests\nodes\test_semantic_quality_policy.py tests\nodes\analyzers\test_semantic_security_discovery.py tests\nodes\analyzers\test_semantic_developer_intent.py`
- `git diff --check`

Note: full pytest collection was not run locally because this machine only has Python 3.11, while the project requires Python >=3.12.

Fixes #86