### PR TITLE
fix(supply-chain): relative edit distance for SC6 typosquat detection

### DIFF
--- a/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
@@ -294,8 +294,19 @@ def _is_typosquat(pkg_name: str, popular: set[str], max_distance: int = 2) -> st
         if len(normalized) < 3 or len(pop_norm) < 3:
             continue
         dist = _edit_distance(normalized, pop_norm)
-        if 0 < dist <= max_distance:
-            return popular_name
+        if not 0 < dist <= max_distance:
+            continue
+        # Relative-distance guard: a genuine typosquat perturbs only a small
+        # fraction of the name. Short, legitimate-but-distinct names collide
+        # under an absolute distance of 2 (e.g. "task" is edit-distance 2 from
+        # "flask" yet is a real package) and are not typosquats. Require
+        # dist/len <= 1/3, so short names need an all-but-one-character match
+        # while longer names may still differ by two (e.g. "reqeusts" vs
+        # "requests").
+        shorter = min(len(normalized), len(pop_norm))
+        if dist * 3 > shorter:
+            continue
+        return popular_name
     return None
 
 

--- a/tests/unit/test_patterns_new.py
+++ b/tests/unit/test_patterns_new.py
@@ -1012,6 +1012,14 @@ class TestSupplyChainHelpers:
     def test_is_typosquat_too_distant_returns_none(self) -> None:
         assert sc_mod._is_typosquat("completely_different", {"requests"}) is None
 
+    def test_is_typosquat_short_distinct_name_not_flagged(self) -> None:
+        # Regression: "task" is a real package and is edit-distance 2 from
+        # "flask", but distance 2 on a 4-char name is not a typosquat. Short
+        # names must clear the relative-distance guard, not just absolute <=2.
+        assert sc_mod._is_typosquat("task", {"flask"}) is None
+        # Longer names may still differ by two characters and be flagged.
+        assert sc_mod._is_typosquat("reqeusts", {"requests"}) == "requests"
+
     @pytest.mark.parametrize(
         "a,b,expected",
         [


### PR DESCRIPTION
## What

Fixes one of the false positives reported in #103: SC6 typosquat detection
uses an absolute edit-distance threshold of 2, which collides on short,
legitimate package names. `task` is a real package and is edit-distance 2
from `flask`, so it was flagged as a "possible typosquat".

## Fix

Add a relative-distance guard to `_is_typosquat`: a genuine typosquat perturbs
only a small fraction of the name, so require `dist / shorter_len <= 1/3`.
Short names then need an all-but-one-character match, while longer names may
still differ by two characters.

| candidate → popular | len | dist | before | after |
|---|---|---|---|---|
| `reqeusts` → `requests` | 8 | 2 | flag | **flag** (unchanged) |
| `expreess` → `express` | 7/8 | 1 | flag | **flag** (unchanged) |
| `task` → `flask` | 4/5 | 2 | flag | **not flagged** (FP fixed) |

## Test plan

- Added a regression test (`test_is_typosquat_short_distinct_name_not_flagged`)
  asserting `task`/`flask` is not flagged while `reqeusts`/`requests` still is.
- `pytest tests/unit/test_patterns_new.py` — **177 passed** (all existing
  SC4/SC5/SC6 assertions preserved).
- End-to-end: scanning a `package.json` with `task` + `expreess` deps now
  reports SC6 for `expreess` only.
- `ruff check src/ tests/` clean.

Signed off per DCO. Refs #103.
