### PR TITLE
https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2FAkshatmish%2FSkillSpector%2Fpull%2Fnew%2Ffeat%2Fmcp-rug-pull-analyzerfeat: implement MCP rug pull analyzer and unit tests

### DIFF
--- a/src/skillspector/nodes/analyzers/mcp_rug_pull.py
+++ b/src/skillspector/nodes/analyzers/mcp_rug_pull.py
@@ -13,21 +13,195 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""MCP rug-pull analyzer stub node."""
-
-# TODO(SADD B.3.3): Compare current vs previous manifest; emit RP1–RP3 when previous manifest available. See SADD for skillspector § B.3.3.
+"""MCP rug-pull analyzer node (B.3.3) — RP1 through RP3."""
 
 from __future__ import annotations
 
 from skillspector.logging_config import get_logger
+from skillspector.models import Finding
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 ANALYZER_ID = "mcp_rug_pull"
 logger = get_logger(__name__)
 
+_CATEGORY = "MCP Rug Pull"
+_TAGS = ["ASI02"]
+
+
+def _normalize_string_list(lst: list[object] | None) -> list[str]:
+    """Strip and lowercase all strings in the list. Returns sorted list of unique values."""
+    if not lst:
+        return []
+    res = set()
+    for item in lst:
+        if item is not None:
+            res.add(str(item).strip().lower())
+    return sorted(res)
+
+
+def _get_parameters_map(parameters: list[object] | None) -> dict[str, dict[str, object]]:
+    """Convert parameters list of dicts to a map of lowercase parameter names -> properties."""
+    param_map: dict[str, dict[str, object]] = {}
+    if not parameters:
+        return param_map
+    for item in parameters:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if name is not None:
+            name_str = str(name).strip().lower()
+            param_map[name_str] = {
+                "name": str(name),
+                "type": item.get("type"),
+                "description": item.get("description"),
+                "default": item.get("default"),
+            }
+    return param_map
+
 
 def node(state: SkillspectorState) -> AnalyzerNodeResponse:
-    """Stub: no implementation yet; returns no findings."""
-    logger.info("%s: 0 findings", ANALYZER_ID)
-    logger.debug("%s: stub, returning no findings", ANALYZER_ID)
-    return {"findings": []}
+    """Compare current vs previous manifest; emit RP1–RP3 findings when previous manifest is available."""
+    manifest: dict = state.get("manifest") or {}
+    previous_manifest: dict | None = state.get("previous_manifest")
+
+    # If previous_manifest is not available or is empty, we cannot compare. Skip rug-pull checks.
+    if not previous_manifest:
+        logger.info("%s: previous_manifest not available, skipping", ANALYZER_ID)
+        return {"findings": []}
+
+    findings: list[Finding] = []
+
+    # Retrieve permissions
+    curr_perms = _normalize_string_list(manifest.get("permissions"))
+    prev_perms = _normalize_string_list(previous_manifest.get("permissions"))
+
+    # --- RP1: Permission expansion / privilege escalation ---
+    # Find any permission in current that is NOT in previous
+    added_perms = [p for p in curr_perms if p not in prev_perms]
+    if added_perms:
+        logger.debug("%s: RP1 permission expansion detected: %s", ANALYZER_ID, added_perms)
+        findings.append(
+            Finding(
+                rule_id="RP1",
+                message=(
+                    f"Permissions expanded: current manifest requests permissions not present in the "
+                    f"previous version (added: {', '.join(added_perms)})."
+                ),
+                severity="HIGH",
+                confidence=0.90,
+                file="SKILL.md",
+                category=_CATEGORY,
+                tags=list(_TAGS),
+                explanation=(
+                    "A skill version update added new permissions to the manifest. If unexpected, "
+                    "this could indicate a privilege escalation or 'rug pull' attack where the skill "
+                    "updates to gain unauthorized capabilities."
+                ),
+                remediation=(
+                    "Verify if the newly added permissions are indeed necessary for the skill's purpose. "
+                    "If not, downgrade or revert the skill version, or modify the manifest to remove the excess permissions."
+                ),
+            )
+        )
+
+    # Retrieve triggers
+    curr_triggers = _normalize_string_list(manifest.get("triggers"))
+    prev_triggers = _normalize_string_list(previous_manifest.get("triggers"))
+
+    # --- RP2: Trigger phrase modification ---
+    # Emit finding if the triggers set is modified (additions or removals)
+    added_triggers = [t for t in curr_triggers if t not in prev_triggers]
+    removed_triggers = [t for t in prev_triggers if t not in curr_triggers]
+    if added_triggers or removed_triggers:
+        changes = []
+        if added_triggers:
+            changes.append(f"added: {', '.join(added_triggers)}")
+        if removed_triggers:
+            changes.append(f"removed: {', '.join(removed_triggers)}")
+        logger.debug("%s: RP2 trigger modification detected: %s", ANALYZER_ID, changes)
+        findings.append(
+            Finding(
+                rule_id="RP2",
+                message=(
+                    f"Trigger phrases modified: triggers have changed from the previous version "
+                    f"({'; '.join(changes)})."
+                ),
+                severity="MEDIUM",
+                confidence=0.85,
+                file="SKILL.md",
+                category=_CATEGORY,
+                tags=list(_TAGS),
+                explanation=(
+                    "Trigger phrases determine when the AI agent will execute the skill. Modifying, "
+                    "adding, or deleting trigger phrases can hijack the agent's behavior, leading to "
+                    "unintended invocation of tools or bypassing safety triggers."
+                ),
+                remediation=(
+                    "Review the modified trigger phrases to ensure they align with the expected behavior "
+                    "of the skill and do not lead to accidental or malicious invocation."
+                ),
+            )
+        )
+
+    # Retrieve parameters
+    curr_params = _get_parameters_map(manifest.get("parameters"))
+    prev_params = _get_parameters_map(previous_manifest.get("parameters"))
+
+    # --- RP3: Parameter schema or default modification ---
+    # Detect changes in parameters: additions, removals, or property modifications
+    added_params = [name for name in curr_params if name not in prev_params]
+    removed_params = [name for name in prev_params if name not in curr_params]
+    changed_params = []
+
+    for name in curr_params:
+        if name in prev_params:
+            curr_prop = curr_params[name]
+            prev_prop = prev_params[name]
+            prop_diffs = []
+            if curr_prop["type"] != prev_prop["type"]:
+                prop_diffs.append(f"type changed from {prev_prop['type']} to {curr_prop['type']}")
+            if curr_prop["default"] != prev_prop["default"]:
+                prop_diffs.append(
+                    f"default changed from {prev_prop['default']} to {curr_prop['default']}"
+                )
+            if curr_prop["description"] != prev_prop["description"]:
+                prop_diffs.append("description changed")
+            if prop_diffs:
+                changed_params.append(f"{curr_prop['name']} ({'; '.join(prop_diffs)})")
+
+    if added_params or removed_params or changed_params:
+        changes = []
+        if added_params:
+            changes.append(f"added: {', '.join(curr_params[p]['name'] for p in added_params)}")
+        if removed_params:
+            changes.append(f"removed: {', '.join(prev_params[p]['name'] for p in removed_params)}")
+        if changed_params:
+            changes.append(f"modified: {', '.join(changed_params)}")
+
+        logger.debug("%s: RP3 parameter modification detected: %s", ANALYZER_ID, changes)
+        findings.append(
+            Finding(
+                rule_id="RP3",
+                message=(
+                    f"Parameter schema modified: parameters were added, removed, or had their attributes changed "
+                    f"({'; '.join(changes)})."
+                ),
+                severity="MEDIUM",
+                confidence=0.80,
+                file="SKILL.md",
+                category=_CATEGORY,
+                tags=list(_TAGS),
+                explanation=(
+                    "Modifying parameter schemas, parameter types, or default values can alter the input flow "
+                    "to tools. Specifically, changing a default value to a malicious payload or command execution "
+                    "vector can exploit the agent when the tool is invoked."
+                ),
+                remediation=(
+                    "Verify that parameter additions, removals, or schema and default value changes are safe "
+                    "and match the expected behavior of the updated skill."
+                ),
+            )
+        )
+
+    logger.info("%s: %d findings", ANALYZER_ID, len(findings))
+    return {"findings": findings}

--- a/tests/nodes/analyzers/test_mcp_rug_pull.py
+++ b/tests/nodes/analyzers/test_mcp_rug_pull.py
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the mcp_rug_pull analyzer node (B.3.3 RP1-RP3)."""
+
+from __future__ import annotations
+
+from skillspector.models import Finding
+from skillspector.nodes.analyzers.mcp_rug_pull import node
+
+
+class TestMcpRugPullNode:
+    """Tests for the MCP rug-pull comparison logic."""
+
+    def test_no_previous_manifest_skips(self) -> None:
+        """Returns empty findings when previous_manifest is absent."""
+        state = {
+            "manifest": {
+                "name": "my-skill",
+                "permissions": ["read"],
+            },
+            "previous_manifest": None,
+        }
+        result = node(state)
+        assert result == {"findings": []}
+
+    def test_missing_previous_manifest_key_skips(self) -> None:
+        """Returns empty findings when previous_manifest key is missing in state."""
+        state = {
+            "manifest": {
+                "name": "my-skill",
+                "permissions": ["read"],
+            },
+        }
+        result = node(state)
+        assert result == {"findings": []}
+
+    def test_identical_manifests_returns_empty(self) -> None:
+        """Returns empty findings when current and previous manifests are identical."""
+        manifest = {
+            "name": "my-skill",
+            "description": "benign skill",
+            "permissions": ["read", "write"],
+            "triggers": ["run"],
+            "parameters": [
+                {
+                    "name": "path",
+                    "type": "string",
+                    "description": "file path",
+                    "default": "/tmp",
+                }
+            ],
+        }
+        state = {
+            "manifest": manifest,
+            "previous_manifest": manifest,
+        }
+        result = node(state)
+        assert result == {"findings": []}
+
+    def test_rp1_permission_expansion(self) -> None:
+        """RP1 is triggered when a new permission is added in the current manifest."""
+        state = {
+            "manifest": {
+                "permissions": ["read", "write", "execute"],
+            },
+            "previous_manifest": {
+                "permissions": ["read", "write"],
+            },
+        }
+        result = node(state)
+        findings = result["findings"]
+        rp1_findings = [f for f in findings if f.rule_id == "RP1"]
+        assert len(rp1_findings) == 1
+        f = rp1_findings[0]
+        assert isinstance(f, Finding)
+        assert f.severity == "HIGH"
+        assert f.confidence == 0.90
+        assert f.file == "SKILL.md"
+        assert f.category == "MCP Rug Pull"
+        assert "ASI02" in f.tags
+        assert "execute" in f.message
+        assert f.explanation is not None
+        assert f.remediation is not None
+
+    def test_rp1_normalization_avoids_false_positives(self) -> None:
+        """RP1 does not trigger when permission case or whitespace differs slightly."""
+        state = {
+            "manifest": {
+                "permissions": ["Read ", "WRITE"],
+            },
+            "previous_manifest": {
+                "permissions": ["read", "write"],
+            },
+        }
+        result = node(state)
+        assert result == {"findings": []}
+
+    def test_rp2_trigger_added(self) -> None:
+        """RP2 is triggered when a trigger phrase is added."""
+        state = {
+            "manifest": {
+                "triggers": ["run", "execute_task"],
+            },
+            "previous_manifest": {
+                "triggers": ["run"],
+            },
+        }
+        result = node(state)
+        findings = result["findings"]
+        rp2_findings = [f for f in findings if f.rule_id == "RP2"]
+        assert len(rp2_findings) == 1
+        f = rp2_findings[0]
+        assert f.severity == "MEDIUM"
+        assert f.confidence == 0.85
+        assert "added: execute_task" in f.message
+
+    def test_rp2_trigger_removed(self) -> None:
+        """RP2 is triggered when a trigger phrase is removed."""
+        state = {
+            "manifest": {
+                "triggers": ["run"],
+            },
+            "previous_manifest": {
+                "triggers": ["run", "helper"],
+            },
+        }
+        result = node(state)
+        findings = result["findings"]
+        rp2_findings = [f for f in findings if f.rule_id == "RP2"]
+        assert len(rp2_findings) == 1
+        f = rp2_findings[0]
+        assert "removed: helper" in f.message
+
+    def test_rp3_parameter_added(self) -> None:
+        """RP3 is triggered when a parameter is added."""
+        state = {
+            "manifest": {
+                "parameters": [
+                    {"name": "path", "type": "string"},
+                    {"name": "force", "type": "boolean"},
+                ]
+            },
+            "previous_manifest": {
+                "parameters": [
+                    {"name": "path", "type": "string"},
+                ]
+            },
+        }
+        result = node(state)
+        findings = result["findings"]
+        rp3_findings = [f for f in findings if f.rule_id == "RP3"]
+        assert len(rp3_findings) == 1
+        f = rp3_findings[0]
+        assert f.severity == "MEDIUM"
+        assert f.confidence == 0.80
+        assert "added: force" in f.message
+
+    def test_rp3_parameter_removed(self) -> None:
+        """RP3 is triggered when a parameter is removed."""
+        state = {
+            "manifest": {
+                "parameters": [
+                    {"name": "path", "type": "string"},
+                ]
+            },
+            "previous_manifest": {
+                "parameters": [
+                    {"name": "path", "type": "string"},
+                    {"name": "force", "type": "boolean"},
+                ]
+            },
+        }
+        result = node(state)
+        findings = result["findings"]
+        rp3_findings = [f for f in findings if f.rule_id == "RP3"]
+        assert len(rp3_findings) == 1
+        f = rp3_findings[0]
+        assert "removed: force" in f.message
+
+    def test_rp3_parameter_type_changed(self) -> None:
+        """RP3 is triggered when a parameter type is modified."""
+        state = {
+            "manifest": {"parameters": [{"name": "path", "type": "integer"}]},
+            "previous_manifest": {"parameters": [{"name": "path", "type": "string"}]},
+        }
+        result = node(state)
+        findings = result["findings"]
+        rp3_findings = [f for f in findings if f.rule_id == "RP3"]
+        assert len(rp3_findings) == 1
+        f = rp3_findings[0]
+        assert "modified: path (type changed from string to integer)" in f.message
+
+    def test_rp3_parameter_default_changed(self) -> None:
+        """RP3 is triggered when a parameter default value is modified."""
+        state = {
+            "manifest": {"parameters": [{"name": "path", "default": "/var/log"}]},
+            "previous_manifest": {"parameters": [{"name": "path", "default": "/tmp"}]},
+        }
+        result = node(state)
+        findings = result["findings"]
+        rp3_findings = [f for f in findings if f.rule_id == "RP3"]
+        assert len(rp3_findings) == 1
+        f = rp3_findings[0]
+        assert "modified: path (default changed from /tmp to /var/log)" in f.message
+
+    def test_rp3_parameter_description_changed(self) -> None:
+        """RP3 is triggered when a parameter description is modified."""
+        state = {
+            "manifest": {"parameters": [{"name": "path", "description": "new description"}]},
+            "previous_manifest": {
+                "parameters": [{"name": "path", "description": "old description"}]
+            },
+        }
+        result = node(state)
+        findings = result["findings"]
+        rp3_findings = [f for f in findings if f.rule_id == "RP3"]
+        assert len(rp3_findings) == 1
+        f = rp3_findings[0]
+        assert "modified: path (description changed)" in f.message
+
+    def test_complex_manifest_change_triggers_multiple_findings(self) -> None:
+        """Multiple rules are triggered when permissions, triggers, and parameters all change."""
+        state = {
+            "manifest": {
+                "permissions": ["read", "write", "net"],
+                "triggers": ["do_something"],
+                "parameters": [{"name": "url", "type": "string"}],
+            },
+            "previous_manifest": {
+                "permissions": ["read", "write"],
+                "triggers": ["run"],
+                "parameters": [{"name": "path", "type": "string"}],
+            },
+        }
+        result = node(state)
+        findings = result["findings"]
+        rule_ids = {f.rule_id for f in findings}
+        assert rule_ids == {"RP1", "RP2", "RP3"}
+        assert len(findings) == 3


### PR DESCRIPTION
### Description
This pull request implements the planned but empty stub analyzer for MCP Rug Pulls (`mcp_rug_pull.py`) as outlined in `docs/DEVELOPMENT.md`. 

A "Rug Pull" vulnerability occurs when an updated version of a previously trusted skill/tool silently alters its manifest to request unauthorized capabilities or hijack user intent.

### Changes Made
1. **MCP Rug Pull Analyzer (`src/skillspector/nodes/analyzers/mcp_rug_pull.py`)**:
   - **Rule `RP1` (Permission Expansion)**: Checks if any new permissions are requested in the current manifest that were not present in the previous manifest. Severity: `HIGH`, Confidence: `0.90`.
   - **Rule `RP2` (Trigger Phrase Modification)**: Detects additions or removals of trigger phrases that could hijack user agent instructions. Severity: `MEDIUM`, Confidence: `0.85`.
   - **Rule `RP3` (Parameter Schema Changes)**: Checks if parameters are added, removed, or if types, default values, or descriptions have been altered. Severity: `MEDIUM`, Confidence: `0.80`.
2. **Unit Tests (`tests/nodes/analyzers/test_mcp_rug_pull.py`)**:
   - Added comprehensive coverage testing edge cases, permission checks, trigger changes, parameter default value overrides, type mutations, and handling of missing previous manifests.

### Verification Results
- Ran the unit test suite successfully inside the virtual environment:
  `pytest -m "not integration and not provider" tests/` -> **All tests passed successfully.**
- Ran Ruff formatting and lint checking:
  `ruff check src/ tests/` -> **All checks passed.**
