### PR TITLE
fix: restrict Python version to <3.14 due to jsonschema-rs/PyO3 incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.2.3"
 description = "SkillSpector: Security scanner for AI agent skills (Claude Code, Cursor, and similar). Scans skills for vulnerabilities, malicious patterns, and security risks before installation. Supports Git repos, URLs, zips, and local directories; runs static pattern checks and optional LLM semantic analysis; outputs terminal, JSON, and Markdown reports with risk scoring."
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.12,<3.15"
+requires-python = ">=3.12,<3.14"
 keywords = [
     "security",
     "ai-agents",
@@ -25,7 +25,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Topic :: Security",
     "Topic :: Software Development :: Quality Assurance",
 ]


### PR DESCRIPTION
## Summary

Fixes #111: Python 3.14 incompatibility due to outdated PyO3 in jsonschema-rs.

## Problem

When installing or running tests on Python 3.14, jsonschema-rs (v0.29.1) fails to compile because the bundled PyO3 (v0.23.4) does not support Python 3.14. SkillSpector's pyproject.toml declares requires-python = ">=3.12,<3.15" which includes Python 3.14.

## Fix

1. Restrict requires-python from <3.15 to <3.14
2. Remove the Programming Language :: Python :: 3.14 classifier

## Testing

All 621 unit tests pass (same as main).
