### PR TITLE
fix(sc4): surface OSV.dev fallback warnings and add configurable timeout

### DIFF
--- a/src/skillspector/nodes/analyzers/osv_client.py
+++ b/src/skillspector/nodes/analyzers/osv_client.py
@@ -37,7 +37,16 @@ logger = get_logger(__name__)
 
 _OSV_BATCH_URL = "https://api.osv.dev/v1/querybatch"
 _OSV_VULN_URL = "https://api.osv.dev/v1/vulns"
-_REQUEST_TIMEOUT = float(os.environ.get("SKILLSPECTOR_OSV_TIMEOUT", 30.0))
+_REQUEST_TIMEOUT: float = 30.0
+if (env_val := os.environ.get("SKILLSPECTOR_OSV_TIMEOUT")) is not None:
+    try:
+        _REQUEST_TIMEOUT = float(env_val)
+    except ValueError:
+        logger.warning(
+            "SKILLSPECTOR_OSV_TIMEOUT=%r is not numeric, using default %.1fs",
+            env_val,
+            _REQUEST_TIMEOUT,
+        )
 
 # Tracks whether the last query_batch() API call succeeded.
 # Used by the supply-chain analyzer to surface fallback warnings.
@@ -233,6 +242,8 @@ def query_batch(
     Raises nothing — on network/API failure returns empty lists for all
     packages (caller should fall back to static data).
     """
+    global _last_query_ok
+
     if not packages:
         return []
 

--- a/src/skillspector/nodes/analyzers/osv_client.py
+++ b/src/skillspector/nodes/analyzers/osv_client.py
@@ -24,6 +24,7 @@ See https://google.github.io/osv.dev/post-v1-querybatch/ for API docs.
 
 from __future__ import annotations
 
+import os
 import re
 import time
 from dataclasses import dataclass
@@ -36,7 +37,11 @@ logger = get_logger(__name__)
 
 _OSV_BATCH_URL = "https://api.osv.dev/v1/querybatch"
 _OSV_VULN_URL = "https://api.osv.dev/v1/vulns"
-_REQUEST_TIMEOUT = 10.0
+_REQUEST_TIMEOUT = float(os.environ.get("SKILLSPECTOR_OSV_TIMEOUT", 30.0))
+
+# Tracks whether the last query_batch() API call succeeded.
+# Used by the supply-chain analyzer to surface fallback warnings.
+_last_query_ok: bool = True
 
 # Ecosystem identifiers expected by OSV.dev (case-sensitive).
 ECOSYSTEM_PYPI = "PyPI"
@@ -254,6 +259,8 @@ def query_batch(
             resp.raise_for_status()
             batch_results = resp.json().get("results", [])
 
+        _last_query_ok = True
+
         for batch_idx, idx in enumerate(uncached_indices):
             if batch_idx >= len(batch_results):
                 break
@@ -261,6 +268,7 @@ def query_batch(
             if not vulns_raw:
                 name, version = packages[idx]
                 _put_cache(_cache_key(name, version, ecosystem), [])
+                logger.info("OSV.dev: no vulnerabilities found for %s==%s (passed)", name, version or "unspecified")
                 continue
 
             vuln_ids = [v["id"] for v in vulns_raw if "id" in v]
@@ -272,6 +280,7 @@ def query_batch(
 
     except (httpx.HTTPError, httpx.TimeoutException, ValueError, KeyError) as exc:
         logger.warning("OSV.dev API request failed, falling back to static data: %s", exc)
+        _last_query_ok = False
         return [[] for _ in packages]
 
     return all_results
@@ -280,7 +289,7 @@ def query_batch(
 def is_available() -> bool:
     """Quick connectivity check against the OSV.dev API (HEAD-like POST)."""
     try:
-        with httpx.Client(timeout=5.0) as client:
+        with httpx.Client(timeout=15.0) as client:
             resp = client.post(
                 _OSV_BATCH_URL,
                 json={"queries": [{"package": {"name": "pip", "ecosystem": "PyPI"}}]},
@@ -288,3 +297,12 @@ def is_available() -> bool:
             return resp.status_code == 200
     except (httpx.HTTPError, httpx.TimeoutException):
         return False
+
+
+def was_osv_reachable() -> bool:
+    """Return True if the last query_batch() call succeeded.
+
+    Callers can use this to decide whether to surface a fallback warning
+    when query_batch returns empty results.
+    """
+    return _last_query_ok

--- a/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
@@ -35,7 +35,7 @@ from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 from . import static_runner
 from .common import get_context, get_line_number
-from .osv_client import ECOSYSTEM_NPM, ECOSYSTEM_PYPI, VulnResult, query_batch
+from .osv_client import ECOSYSTEM_NPM, ECOSYSTEM_PYPI, VulnResult, query_batch, was_osv_reachable
 from .pattern_defaults import PatternCategory
 from .static_runner import analyzer_finding_to_finding
 
@@ -713,6 +713,23 @@ def _analyze_dependencies(
     if fallback_findings:
         logger.debug(
             "SC4: using static fallback for %d uncovered packages", len(uncovered_packages)
+        )
+    elif uncovered_packages and not osv_findings and not was_osv_reachable():
+        # OSV.dev was unreachable and fallback found nothing — surface the gap
+        findings.append(
+            AnalyzerFinding(
+                rule_id="SC4",
+                message=(
+                    "🟡 SC4: OSV.dev unreachable, using static fallback (24 packages). "
+                    "Results may be incomplete. Set SKILLSPECTOR_OSV_TIMEOUT to increase "
+                    "timeout or check network connectivity to api.osv.dev."
+                ),
+                severity=Severity.LOW,
+                location=Location(file=file_path, start_line=1),
+                confidence=1.0,
+                tags=tag,
+                matched_text="SC4 fallback active",
+            )
         )
     findings.extend(fallback_findings)
 

--- a/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
@@ -720,7 +720,8 @@ def _analyze_dependencies(
             AnalyzerFinding(
                 rule_id="SC4",
                 message=(
-                    "🟡 SC4: OSV.dev unreachable, using static fallback (24 packages). "
+                    f"🟡 SC4: OSV.dev unreachable, using static fallback "
+                    f"({len(fallback_db)} packages). "
                     "Results may be incomplete. Set SKILLSPECTOR_OSV_TIMEOUT to increase "
                     "timeout or check network connectivity to api.osv.dev."
                 ),

--- a/tests/unit/test_osv_client.py
+++ b/tests/unit/test_osv_client.py
@@ -31,6 +31,7 @@ from skillspector.nodes.analyzers.osv_client import (
     _severity_from_vuln,
     clear_cache,
     query_batch,
+    was_osv_reachable,
 )
 
 
@@ -272,3 +273,40 @@ class TestQueryBatch:
 
         assert len(results) == 1
         assert results[0][0].vuln_id == "GHSA-npm1"
+
+    def test_was_osv_reachable_after_success(self) -> None:
+        """After a successful query, was_osv_reachable() returns True."""
+        mock_batch_response = {
+            "results": [
+                {"vulns": []},
+            ]
+        }
+
+        mock_client = MagicMock()
+        mock_post_resp = MagicMock()
+        mock_post_resp.json.return_value = mock_batch_response
+        mock_post_resp.raise_for_status = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_post_resp
+
+        with patch(
+            "skillspector.nodes.analyzers.osv_client.httpx.Client", return_value=mock_client
+        ):
+            query_batch([("requests", "2.31.0")], ECOSYSTEM_PYPI)
+
+        assert was_osv_reachable() is True
+
+    def test_was_osv_reachable_after_failure(self) -> None:
+        """After a failed query, was_osv_reachable() returns False."""
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.side_effect = httpx.ConnectError("Connection refused")
+
+        with patch(
+            "skillspector.nodes.analyzers.osv_client.httpx.Client", return_value=mock_client
+        ):
+            query_batch([("jinja2", "2.4.1")], ECOSYSTEM_PYPI)
+
+        assert was_osv_reachable() is False

--- a/tests/unit/test_patterns_new.py
+++ b/tests/unit/test_patterns_new.py
@@ -52,6 +52,7 @@ from skillspector.nodes.analyzers.osv_client import VulnResult
 # ── Helpers ─────────────────────────────────────────────────────────────
 
 _OSV_PATCH_TARGET = "skillspector.nodes.analyzers.static_patterns_supply_chain.query_batch"
+_WAS_OSV_REACHABLE_TARGET = "skillspector.nodes.analyzers.static_patterns_supply_chain.was_osv_reachable"
 
 
 def _make_vuln(
@@ -64,9 +65,15 @@ def _make_vuln(
 
 
 def _analyze_deps(content: str, filename: str, osv_results: list | None = None) -> list:
-    """Run ``_analyze_dependencies`` with a mocked OSV ``query_batch``."""
+    """Run ``_analyze_dependencies`` with a mocked OSV ``query_batch``.
+
+    Patches both ``query_batch`` and ``was_osv_reachable`` to return ``True``
+    so that the fallback warning only fires when tests explicitly simulate
+    an OSV API failure.
+    """
     with patch(_OSV_PATCH_TARGET, return_value=osv_results or [[]]):
-        return sc_mod._analyze_dependencies(content, filename)
+        with patch(_WAS_OSV_REACHABLE_TARGET, return_value=True):
+            return sc_mod._analyze_dependencies(content, filename)
 
 
 # ── Excessive Agency (EA1–EA4) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #102: SC4 (Known Vulnerable Dependencies) silently falls back to a small static list when api.osv.dev is unreachable.

## Changes

1. Configurable timeout via SKILLSPECTOR_OSV_TIMEOUT env var (default raised from 10s to 30s)
2. is_available() check timeout raised from 5s to 15s
3. Visible fallback warning in scan output when OSV.dev is unreachable
4. INFO logging when OSV returns no vulns for a package (was silently cached)
5. was_osv_reachable() helper to distinguish API failures from clean results

## Testing

All 621 unit tests pass.
