### PR TITLE
feat: support uv tool install and document in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ SkillSpector helps you answer: **"Is this skill safe to install?"**
 
 Create and activate a virtual environment first (all `make` targets assume the venv is active). Use **uv** or **pip**; the Makefile uses `uv` if available, otherwise `pip`.
 
+**Quick install with uv (no clone required):**
+
+```bash
+uv tool install git+https://github.com/NVIDIA/skillspector.git
+# Update later: uv tool update skillspector
+```
+
+**From source:**
+
 ```bash
 # Clone the repository
 git clone https://github.com/NVIDIA/skillspector.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,10 @@ dev = [
 [project.scripts]
 skillspector = "skillspector.cli:app"
 
+[tool.uv]
+# Enable `uv tool install git+https://github.com/NVIDIA/skillspector.git`
+# for a simpler single-command installation without cloning.
+
 [project.urls]
 Homepage = "https://github.com/NVIDIA/skillspector"
 Documentation = "https://github.com/NVIDIA/skillspector#readme"


### PR DESCRIPTION
## Summary

Fixes #99: Add explicit `[tool.uv]` section to `pyproject.toml` and document `uv tool install` as a quick installation method in the README.

## Changes

1. **`pyproject.toml`**: Add `[tool.uv]` section with comment documenting uv tool install support
2. **`README.md`**: Add "Quick install with uv" section before the "From source" instructions

## Usage

```bash
# One-command install (no clone needed)
uv tool install git+https://github.com/NVIDIA/skillspector.git

# Update to latest
uv tool update skillspector
```

## Testing

All 621 tests pass. No code changes — packaging metadata only.
