### PR TITLE
chore: add perseus-ctx and mimir-mcp to popular PyPI packages

### DIFF
--- a/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
@@ -231,6 +231,8 @@ _POPULAR_PYPI: set[str] = {
     "pylint",
     "flake8",
     "isort",
+    "perseus-ctx",
+    "mimir-mcp",
 }
 
 _POPULAR_NPM: set[str] = {


### PR DESCRIPTION
## Summary

Add `perseus-ctx` and `mimir-mcp` to `_POPULAR_PYPI`, the set used by SC6 typosquat detection to identify well-known packages.

## Why

- `perseus-ctx` and `mimir-mcp` are established MCP ecosystem packages on PyPI
- `perseus-ctx` (context engine, 27+ MCP tools) and `mimir-mcp` (persistent memory, 36+ MCP tools) serve hundreds of agent installations
- Including them prevents false-positive SC6 typosquat flags on packages with similar names
- Helps protect these package names from typosquatting confusion in the MCP ecosystem

## Testing

All 621 tests pass. No functional changes — data-only addition.
