### PR TITLE
fix(input-handler): bound URL, zip, and git ingest paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ skillspector scan https://github.com/user/my-skill
 skillspector scan ./my-skill.zip
 ```
 
+#### Size limits
+
+SkillSpector enforces two independent caps on remote and archive inputs to bound the impact of oversized downloads and zip bombs:
+
+- **Per-ingest cap**: `INGEST_MAX_BYTES` (100 MiB) — applied to streamed URL downloads, total uncompressed size of zip archives, and post-clone disk usage of Git repos.
+- **Zip member cap**: `INGEST_MAX_ZIP_MEMBERS` (10,000) — caps the number of entries in a single zip.
+
+Note that the per-file 1 MB analysis cap (`MAX_FILE_BYTES`) is a separate, downstream limit: it bounds what individual analyzers will read out of an already-ingested directory. The ingest caps above bound how much content can land on disk in the first place. A breach of either ingest cap fails closed with an `IngestLimitExceededError`.
+
 ### Output Formats
 
 ```bash

--- a/src/skillspector/input_handler.py
+++ b/src/skillspector/input_handler.py
@@ -23,7 +23,14 @@ Handles various input formats:
 - Single markdown files
 - Local directories
 
-Ported from legacy implementation.
+Each remote/archive ingest path is bounded by ``INGEST_MAX_BYTES`` and
+``INGEST_MAX_ZIP_MEMBERS`` so that the per-file analysis caps downstream
+of ``InputHandler.resolve()`` are not defeated by an oversized download,
+a zip bomb, or a too-large git clone.  This file fails closed on any
+ingest budget breach (closes #21 / #131).
+
+URL-based ingest is additionally gated by an SSRF host allowlist plus a
+private-IP check, and zip extraction is guarded against zip-slip.
 """
 
 from __future__ import annotations
@@ -61,6 +68,30 @@ ALLOWED_DOWNLOAD_HOSTS = frozenset(
         "huggingface.co",
     }
 )
+
+# Hard ceiling on what any single ingest path can pull into the temp dir.
+# Sized above the per-file analysis cap (``MAX_FILE_BYTES`` = 1 MB) so a
+# legitimate multi-file skill is not blocked at ingest, but tight enough
+# to bound memory / disk DoS from a malicious source.
+INGEST_MAX_BYTES = 100 * 1024 * 1024  # 100 MiB
+
+# Hard ceiling on the number of members in a zip we are willing to
+# extract.  Catches the "many tiny files" zip-bomb variant where each
+# entry is small but the entry count itself exhausts the filesystem.
+INGEST_MAX_ZIP_MEMBERS = 10_000
+
+# Chunk size for streaming HTTP downloads.  Small enough that the
+# byte-count breach check fires promptly; large enough to keep syscall
+# overhead reasonable on legitimate inputs.
+_DOWNLOAD_CHUNK_BYTES = 64 * 1024
+
+
+class IngestLimitExceededError(ValueError):
+    """Raised when an ingest path exceeds an ``INGEST_MAX_*`` budget.
+
+    Subclass of ``ValueError`` so existing callers that catch
+    ``ValueError`` from ``InputHandler.resolve()`` continue to work.
+    """
 
 
 def _is_private_ip(host: str) -> bool:
@@ -103,8 +134,10 @@ class InputHandler:
             source_type is one of: "git", "url", "zip", "file", "directory"
 
         Raises:
-            ValueError: If input type cannot be determined
-            FileNotFoundError: If local path doesn't exist
+            ValueError: If input type cannot be determined, or if an
+                ingest path exceeds ``INGEST_MAX_BYTES`` /
+                ``INGEST_MAX_ZIP_MEMBERS`` (``IngestLimitExceededError``).
+            FileNotFoundError: If local path doesn't exist.
         """
         input_path = input_path.strip()
 
@@ -191,7 +224,7 @@ class InputHandler:
         return host
 
     def _clone_git(self, url: str) -> Path:
-        """Clone a Git repository to a temporary directory."""
+        """Clone a Git repository to a temporary directory, bounded by ``INGEST_MAX_BYTES``."""
         self._validate_url_host(url, ALLOWED_GIT_HOSTS)
         temp_dir = self._get_temp_dir()
         clone_dir = temp_dir / "repo"
@@ -214,34 +247,115 @@ class InputHandler:
             raise ValueError(
                 "Git is not installed. Please install git to scan repositories."
             ) from None
+
+        # Post-clone size check: a successful --depth 1 clone may still
+        # land an arbitrarily large tree on disk before we can measure
+        # it, so this is a fail-closed cap rather than a hard prefilter.
+        # Residual window: within the 60s clone timeout an attacker can
+        # transiently consume up to whatever the network + disk let
+        # through before this check runs; bounded by the timeout, but
+        # not zero.  ``.git/`` objects are counted toward the cap, so a
+        # legitimate repo with a working tree just under ``INGEST_MAX_BYTES``
+        # can still be rejected once packfiles are added.
+        total = _directory_size_bytes(clone_dir)
+        if total > INGEST_MAX_BYTES:
+            shutil.rmtree(clone_dir, ignore_errors=True)
+            logger.warning(
+                "Git clone of %s exceeded ingest cap: %d > %d bytes",
+                url,
+                total,
+                INGEST_MAX_BYTES,
+            )
+            raise IngestLimitExceededError(
+                f"Git clone exceeded ingest cap: {total} bytes > "
+                f"INGEST_MAX_BYTES ({INGEST_MAX_BYTES})"
+            )
         return clone_dir
 
     def _download_file(self, url: str) -> Path:
-        """Download a file from URL to a temporary directory."""
+        """Download a file from URL to a temporary directory.
+
+        Streams the body to disk in chunks while running a byte counter.
+        The cap check fires before each chunk is written, so a breach
+        aborts immediately without accumulating the body in memory.  A
+        partial file produced by a mid-stream breach is removed before
+        the exception propagates.
+        """
         self._validate_url_host(url, ALLOWED_DOWNLOAD_HOSTS)
         temp_dir = self._get_temp_dir()
         parsed = urlparse(url)
         filename = Path(parsed.path).name or "SKILL.md"
+        # Write to a stable target path inside the temp dir so we can
+        # rename / move it after the download succeeds without ever
+        # holding the body in memory.  Use a sentinel name for the
+        # download itself; we rename / replace at the end.
+        download_path = temp_dir / "_download.partial"
+        content_type = ""
         try:
             with httpx.Client(follow_redirects=False, timeout=30) as client:
-                response = client.get(url)
-                response.raise_for_status()
-                content = response.content
+                with client.stream("GET", url) as response:
+                    response.raise_for_status()
+                    content_type = response.headers.get("content-type", "")
+                    # Cheap up-front check: trust Content-Length when the
+                    # server provides it, so we abort before reading any
+                    # body bytes.  Streaming check below covers the case
+                    # where the header is missing or wrong.
+                    declared = response.headers.get("content-length")
+                    if declared is not None:
+                        try:
+                            declared_bytes = int(declared)
+                        except ValueError:
+                            # Malformed header — fall through to the
+                            # streamed byte counter, which is authoritative.
+                            declared_bytes = None
+                        if declared_bytes is not None and declared_bytes > INGEST_MAX_BYTES:
+                            raise IngestLimitExceededError(
+                                f"Download exceeded ingest cap: "
+                                f"Content-Length {declared} bytes > "
+                                f"INGEST_MAX_BYTES ({INGEST_MAX_BYTES})"
+                            )
+
+                    received = 0
+                    with download_path.open("wb") as out:
+                        for chunk in response.iter_bytes(_DOWNLOAD_CHUNK_BYTES):
+                            received += len(chunk)
+                            if received > INGEST_MAX_BYTES:
+                                raise IngestLimitExceededError(
+                                    f"Download exceeded ingest cap: streamed "
+                                    f"{received} bytes > INGEST_MAX_BYTES "
+                                    f"({INGEST_MAX_BYTES})"
+                                )
+                            out.write(chunk)
         except httpx.HTTPError as e:
+            # Best-effort cleanup of any partial download.
+            download_path.unlink(missing_ok=True)
             logger.warning("Download failed for %s: %s", url, e)
             raise ValueError(f"Failed to download file: {e}") from e
-        if filename.endswith(".zip") or (
-            response.headers.get("content-type", "").startswith("application/zip")
-        ):
+        except IngestLimitExceededError:
+            # Don't leave the partial bomb on disk.
+            download_path.unlink(missing_ok=True)
+            raise
+
+        is_zip = filename.endswith(".zip") or content_type.startswith("application/zip")
+        if is_zip:
             zip_path = temp_dir / "download.zip"
-            zip_path.write_bytes(content)
+            download_path.replace(zip_path)
             return self._extract_zip(zip_path)
         file_path = temp_dir / filename
-        file_path.write_bytes(content)
+        download_path.replace(file_path)
         return temp_dir
 
     def _extract_zip(self, zip_path: Path) -> Path:
-        """Extract a zip file to a temporary directory with path traversal protection."""
+        """Extract a zip file, bounded by ``INGEST_MAX_BYTES`` and ``INGEST_MAX_ZIP_MEMBERS``.
+
+        Sums ``ZipInfo.file_size`` (uncompressed size) across all members
+        before extracting and refuses to extract if either the total or
+        the member count exceeds the cap.  This rejects classic zip
+        bombs (small archive, huge declared uncompressed size) without
+        materialising any of the bomb on disk.  A zip-slip check on each
+        member name is applied before extraction to reject entries whose
+        resolved path escapes the extraction directory.
+        """
         if not zip_path.exists():
             raise FileNotFoundError(f"Zip file not found: {zip_path}") from None
         temp_dir = self._get_temp_dir()
@@ -249,9 +363,23 @@ class InputHandler:
         extract_dir.mkdir(exist_ok=True)
         try:
             with zipfile.ZipFile(zip_path, "r") as zf:
+                infos = zf.infolist()
+                if len(infos) > INGEST_MAX_ZIP_MEMBERS:
+                    raise IngestLimitExceededError(
+                        f"Zip exceeded ingest cap: {len(infos)} members > "
+                        f"INGEST_MAX_ZIP_MEMBERS ({INGEST_MAX_ZIP_MEMBERS})"
+                    )
+                total_uncompressed = sum(info.file_size for info in infos)
+                if total_uncompressed > INGEST_MAX_BYTES:
+                    raise IngestLimitExceededError(
+                        f"Zip exceeded ingest cap: uncompressed "
+                        f"{total_uncompressed} bytes > INGEST_MAX_BYTES "
+                        f"({INGEST_MAX_BYTES})"
+                    )
+                extract_root = extract_dir.resolve()
                 for member in zf.namelist():
                     member_path = (extract_dir / member).resolve()
-                    if not str(member_path).startswith(str(extract_dir.resolve())):
+                    if not str(member_path).startswith(str(extract_root)):
                         raise ValueError(
                             f"Zip entry '{member}' would escape extraction directory (zip-slip). "
                             "Archive is potentially malicious."
@@ -273,3 +401,25 @@ class InputHandler:
         dest = temp_dir / file_path.name
         shutil.copy2(file_path, dest)
         return temp_dir
+
+
+def _directory_size_bytes(path: Path) -> int:
+    """Return the total size of all regular files under *path*, in bytes.
+
+    Symlinks are explicitly skipped via ``Path.is_symlink()`` — note that
+    ``Path.is_file()`` follows symlinks and would otherwise return
+    ``True`` for a symlink pointing at a regular file, so the
+    ``not p.is_symlink()`` guard is load-bearing and must not be removed.
+    This is what prevents a malicious symlink to ``/dev/zero`` (or any
+    large file outside the walked tree) from inflating the count.
+    """
+    total = 0
+    for p in path.rglob("*"):
+        if p.is_file() and not p.is_symlink():
+            try:
+                total += p.stat().st_size
+            except OSError:
+                # File disappeared mid-walk (race with concurrent fs ops).
+                # Skip rather than fail the whole ingest.
+                continue
+    return total

--- a/tests/unit/test_input_handler_bounds.py
+++ b/tests/unit/test_input_handler_bounds.py
@@ -1,0 +1,392 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ingest-layer size bounds in ``InputHandler``.
+
+Covers the three ingest paths the bounded-reads work in PR #19 deferred
+to a follow-up (issues #21 / #131): URL download, zip extraction, and
+git clone.  Each is bounded by ``INGEST_MAX_BYTES`` (and zip is also
+bounded by ``INGEST_MAX_ZIP_MEMBERS``); each must fail closed with a
+clear error message rather than letting the per-file analysis cap be
+defeated upstream.
+"""
+
+from __future__ import annotations
+
+import struct
+import subprocess
+import zipfile
+from collections.abc import Callable
+from pathlib import Path
+
+import httpx
+import pytest
+
+from skillspector.input_handler import (
+    INGEST_MAX_BYTES,
+    INGEST_MAX_ZIP_MEMBERS,
+    IngestLimitExceededError,
+    InputHandler,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_httpx_client(monkeypatch: pytest.MonkeyPatch, handler: Callable) -> None:
+    """Patch ``httpx.Client`` so ``InputHandler._download_file`` uses a MockTransport.
+
+    Also stubs the SSRF private-IP resolver so unit tests stay hermetic
+    (the production check does a real DNS lookup on the URL host).
+    """
+    import skillspector.input_handler as ih
+
+    real_client = httpx.Client
+
+    def factory(*args: object, **kwargs: object) -> httpx.Client:
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(ih.httpx, "Client", factory)
+    monkeypatch.setattr(ih, "_is_private_ip", lambda host: False)
+
+
+# All download-path tests below hit an allowlisted host
+# (``raw.githubusercontent.com``) rather than the pre-SSRF-hardening
+# ``example.com`` placeholder — ``_validate_url_host`` now rejects
+# hosts that are not in ``ALLOWED_DOWNLOAD_HOSTS`` before the mocked
+# transport is ever reached.
+_ALLOWED_HOST = "raw.githubusercontent.com"
+
+
+def _make_zip(zip_path: Path, members: list[tuple[str, bytes]]) -> None:
+    """Write ``members`` as a real zip file to ``zip_path``."""
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, data in members:
+            zf.writestr(name, data)
+
+
+def _make_bomb_zip(zip_path: Path, declared_uncompressed: int) -> None:
+    """Forge a zip whose ``ZipInfo.file_size`` declares an oversized member.
+
+    We can't easily construct a true compression bomb in-test, but the
+    extractor's check is against the declared uncompressed size from the
+    central directory.  We write a one-member zip and then rewrite the
+    uncompressed-size field in the central directory record.
+    """
+    name = "bomb.bin"
+    payload = b"a"  # one real byte
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(name, payload)
+
+    # Patch the central directory's "uncompressed size" field for the
+    # one member.  Format from PKZIP APPNOTE 4.4.13:
+    #   Central directory record: 4-byte sig (0x02014b50), then
+    #     2 version-made-by, 2 version-needed, 2 flags, 2 method,
+    #     2 mtime, 2 mdate, 4 crc32,
+    #     4 compressed size, 4 uncompressed size, ...
+    # So uncompressed-size offset within the record is 24 bytes from sig.
+    raw = zip_path.read_bytes()
+    sig = b"\x50\x4b\x01\x02"
+    idx = raw.find(sig)
+    assert idx >= 0, "central directory record not found"
+    uncomp_offset = idx + 24
+    patched = (
+        raw[:uncomp_offset] + struct.pack("<I", declared_uncompressed) + raw[uncomp_offset + 4 :]
+    )
+    zip_path.write_bytes(patched)
+
+
+# ---------------------------------------------------------------------------
+# Download
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadBound:
+    """``_download_file`` aborts oversized downloads before buffering them."""
+
+    def test_under_cap_downloads_succeed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        body = b"# small markdown\n"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=body)
+
+        _patch_httpx_client(monkeypatch, handler)
+
+        h = InputHandler()
+        try:
+            resolved, source_type = h.resolve("https://raw.githubusercontent.com/skill.md")
+            assert source_type == "url"
+            assert (resolved / "skill.md").read_bytes() == body
+        finally:
+            h.cleanup()
+
+    def test_content_length_header_rejected_before_body_read(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Server declares an oversized Content-Length → reject before reading body.
+
+        httpx normalises the ``content`` arg's length into Content-Length,
+        so we ship a chunked stream and inject a forged header via a raw
+        ``httpx.Response`` constructed from a byte-stream + explicit headers.
+        """
+        oversized = INGEST_MAX_BYTES + 1
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            # Drop Transfer-Encoding to be sure Content-Length is the
+            # only size signal; ship a tiny body so iter_bytes() would
+            # complete almost instantly if we ever got there.
+            return httpx.Response(
+                200,
+                stream=httpx.ByteStream(b"x"),
+                headers={"content-length": str(oversized)},
+            )
+
+        _patch_httpx_client(monkeypatch, handler)
+
+        h = InputHandler()
+        try:
+            with pytest.raises(IngestLimitExceededError, match="Content-Length"):
+                h.resolve("https://raw.githubusercontent.com/huge.md")
+        finally:
+            h.cleanup()
+
+    def test_streamed_body_overflow_rejected_when_header_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No Content-Length header → streamed byte-counter must catch overflow.
+
+        Use a generator-backed stream so httpx cannot pre-compute and
+        attach a Content-Length header, then ship oversized bytes.
+        """
+
+        def body_iter():
+            chunk = b"x" * (64 * 1024)
+            # Yield enough chunks to exceed the cap.
+            sent = 0
+            while sent <= INGEST_MAX_BYTES + 1024:
+                yield chunk
+                sent += len(chunk)
+
+        class _GenStream(httpx.SyncByteStream):
+            def __iter__(self):
+                return body_iter()
+
+            def close(self):  # noqa: D401 - protocol method
+                pass
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, stream=_GenStream())
+
+        _patch_httpx_client(monkeypatch, handler)
+
+        h = InputHandler()
+        try:
+            with pytest.raises(IngestLimitExceededError, match="streamed"):
+                h.resolve("https://raw.githubusercontent.com/huge.bin")
+        finally:
+            h.cleanup()
+
+    def test_streamed_overflow_leaves_no_partial_file_on_disk(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A breach mid-stream must clean up the partial file.
+
+        Closes the security-review finding: even when the cap fires,
+        the bytes written before the breach must not survive on disk.
+        Otherwise an attacker can still fill the temp dir up to
+        ~INGEST_MAX_BYTES by sending exactly one byte over the cap.
+        """
+
+        def body_iter():
+            chunk = b"x" * (64 * 1024)
+            sent = 0
+            while sent <= INGEST_MAX_BYTES + 1024:
+                yield chunk
+                sent += len(chunk)
+
+        class _GenStream(httpx.SyncByteStream):
+            def __iter__(self):
+                return body_iter()
+
+            def close(self):  # noqa: D401 - protocol method
+                pass
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, stream=_GenStream())
+
+        _patch_httpx_client(monkeypatch, handler)
+
+        h = InputHandler()
+        try:
+            with pytest.raises(IngestLimitExceededError):
+                h.resolve("https://raw.githubusercontent.com/huge.bin")
+            temp = h.temp_dir_for_cleanup()
+            assert temp is not None
+            # The partial download file must not survive the breach.
+            assert not (temp / "_download.partial").exists()
+            assert not (temp / "huge.bin").exists()
+            assert not (temp / "download.zip").exists()
+        finally:
+            h.cleanup()
+
+    def test_download_streams_to_disk_not_memory(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A legitimate download must write incrementally to disk.
+
+        Verifies the body is not buffered as a single ``bytes`` object
+        in memory — the streaming refactor uses ``file.write()`` per
+        chunk.  We can't directly measure peak memory in a unit test,
+        but we can assert the on-disk file ends up at the same size as
+        the bytes the server shipped, with no intermediate concatenation.
+        """
+        # 5 MiB body — well under the cap, large enough that a single
+        # ``b''.join(chunks)`` would be a visible allocation if it ever
+        # happened.
+        body = b"a" * (5 * 1024 * 1024)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=body)
+
+        _patch_httpx_client(monkeypatch, handler)
+
+        h = InputHandler()
+        try:
+            resolved, source_type = h.resolve("https://raw.githubusercontent.com/medium.bin")
+            assert source_type == "url"
+            assert (resolved / "medium.bin").stat().st_size == len(body)
+            # And the sentinel partial-download path must not survive.
+            assert not (resolved / "_download.partial").exists()
+        finally:
+            h.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Zip
+# ---------------------------------------------------------------------------
+
+
+class TestZipBound:
+    """``_extract_zip`` refuses zip bombs and member-count bombs."""
+
+    def test_under_cap_zip_succeeds(self, tmp_path: Path) -> None:
+        zip_path = tmp_path / "ok.zip"
+        _make_zip(zip_path, [("SKILL.md", b"# skill")])
+
+        h = InputHandler()
+        try:
+            resolved, source_type = h.resolve(str(zip_path))
+            assert source_type == "zip"
+            assert resolved.is_dir()
+            assert (resolved / "SKILL.md").exists()
+        finally:
+            h.cleanup()
+
+    def test_declared_uncompressed_oversize_rejected_before_extract(self, tmp_path: Path) -> None:
+        """Classic zip bomb: small archive, declared-uncompressed size > cap."""
+        zip_path = tmp_path / "bomb.zip"
+        _make_bomb_zip(zip_path, declared_uncompressed=INGEST_MAX_BYTES + 1)
+
+        h = InputHandler()
+        try:
+            with pytest.raises(IngestLimitExceededError, match="uncompressed"):
+                h.resolve(str(zip_path))
+            # Crucially: nothing extracted.  The extract dir may exist
+            # (we mkdir before pre-checking) but must be empty.
+            temp = h.temp_dir_for_cleanup()
+            assert temp is not None
+            extract_dir = temp / "extracted"
+            if extract_dir.exists():
+                assert list(extract_dir.iterdir()) == []
+        finally:
+            h.cleanup()
+
+    def test_too_many_members_rejected(self, tmp_path: Path) -> None:
+        zip_path = tmp_path / "many.zip"
+        # One byte each, but more entries than the member cap.
+        members = [(f"file{i}.txt", b"x") for i in range(INGEST_MAX_ZIP_MEMBERS + 1)]
+        _make_zip(zip_path, members)
+
+        h = InputHandler()
+        try:
+            with pytest.raises(IngestLimitExceededError, match="members"):
+                h.resolve(str(zip_path))
+        finally:
+            h.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Git clone
+# ---------------------------------------------------------------------------
+
+
+def _stub_private_ip_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass the real DNS lookup in ``_is_private_ip`` for hermetic tests."""
+    import skillspector.input_handler as ih
+
+    monkeypatch.setattr(ih, "_is_private_ip", lambda host: False)
+
+
+class TestGitCloneBound:
+    """``_clone_git`` rejects clones whose on-disk size exceeds the cap."""
+
+    def test_under_cap_clone_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _stub_private_ip_check(monkeypatch)
+
+        def fake_run(cmd, **kwargs):
+            # cmd is ["git", "clone", "--depth", "1", url, str(clone_dir)]
+            clone_dir = Path(cmd[-1])
+            clone_dir.mkdir(parents=True, exist_ok=True)
+            (clone_dir / "SKILL.md").write_text("# small")
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        h = InputHandler()
+        try:
+            resolved, source_type = h.resolve("https://github.com/foo/bar")
+            assert source_type == "git"
+            assert (resolved / "SKILL.md").exists()
+        finally:
+            h.cleanup()
+
+    def test_oversize_clone_rejected_and_cleaned_up(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _stub_private_ip_check(monkeypatch)
+        big = b"x" * (INGEST_MAX_BYTES + 1)
+
+        def fake_run(cmd, **kwargs):
+            clone_dir = Path(cmd[-1])
+            clone_dir.mkdir(parents=True, exist_ok=True)
+            (clone_dir / "huge.bin").write_bytes(big)
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        h = InputHandler()
+        try:
+            with pytest.raises(IngestLimitExceededError, match="Git clone"):
+                h.resolve("https://github.com/foo/huge-repo")
+            # Failed clone must be cleaned up.
+            temp = h.temp_dir_for_cleanup()
+            assert temp is not None
+            assert not (temp / "repo").exists()
+        finally:
+            h.cleanup()

--- a/tests/unit/test_input_handler_ssrf.py
+++ b/tests/unit/test_input_handler_ssrf.py
@@ -120,10 +120,13 @@ class TestDownloadSSRF:
 
     @patch("skillspector.input_handler.httpx.Client")
     def test_raw_githubusercontent_allowed(self, mock_client_cls) -> None:
+        # ``_download_file`` uses ``client.stream("GET", url)`` as a
+        # context manager rather than ``client.get(...)``; mock the
+        # nested ``__enter__`` chain and iter_bytes accordingly.
         mock_client = mock_client_cls.return_value.__enter__.return_value
-        mock_response = mock_client.get.return_value
-        mock_response.content = b"# SKILL.md content"
-        mock_response.headers = {}
+        mock_response = mock_client.stream.return_value.__enter__.return_value
+        mock_response.headers = {"content-type": "text/markdown"}
+        mock_response.iter_bytes.return_value = iter([b"# SKILL.md content"])
         handler = InputHandler()
         result = handler._download_file(
             "https://raw.githubusercontent.com/NVIDIA/SkillSpector/main/SKILL.md"
@@ -135,8 +138,9 @@ class TestDownloadSSRF:
     def test_download_does_not_follow_redirects(self, mock_client_cls) -> None:
         """Redirects are disabled to prevent SSRF via open-redirect on allowed hosts."""
         mock_client = mock_client_cls.return_value.__enter__.return_value
-        mock_client.get.return_value.content = b"# content"
-        mock_client.get.return_value.headers = {}
+        mock_response = mock_client.stream.return_value.__enter__.return_value
+        mock_response.headers = {"content-type": "text/markdown"}
+        mock_response.iter_bytes.return_value = iter([b"# content"])
         handler = InputHandler()
         try:
             handler._download_file(


### PR DESCRIPTION
## Summary

Closes #21. Closes #131.

The per-file analysis cap (`MAX_FILE_BYTES`, 1 MB) sits downstream of `InputHandler.resolve()`, which pulls scan targets from URLs, zips, or git clones with no size budget of its own. The per-file cap can therefore be defeated upstream:

- a multi-GB URL is a memory DoS (`client.get(url).content` buffers the whole body),
- a zip bomb fills the disk before extraction is gated (`extractall` with no size pre-check),
- a large clone lands on disk regardless of the per-file analysis budget (no post-clone size check).

[@wernerkasselman-au](https://github.com/wernerkasselman-au) flagged this in the review of PR #19 and explicitly deferred it ("the whole ingest layer in `input_handler.py` runs before `build_context` ever sees a file, and it is unbounded"). PR #19 stayed scoped to the per-file work; this PR addresses the deferred ingest-layer hardening.

## Changes

### New constants

| Constant | Value | Purpose |
|---|---|---|
| `INGEST_MAX_BYTES` | **100 MiB** | Cap on streamed URL downloads, total uncompressed size of zip archives, and post-clone disk usage |
| `INGEST_MAX_ZIP_MEMBERS` | **10,000** | Cap on the number of entries in a single zip — defends the "many tiny files" zip-bomb variant where each entry is small but the count itself exhausts the FS |

Sized above the existing 1 MB per-file analysis cap so legitimate multi-file skills aren't blocked at ingest, but tight enough to bound a memory / disk DoS.

### `_download_file` — streamed with hard cap

- Replaces `client.get(url).content` (full-body buffering) with `client.stream("GET", url)` + a chunked iterator.
- **Up-front Content-Length check** — if the server provides a Content-Length larger than `INGEST_MAX_BYTES`, abort before reading any body bytes.
- **Streamed byte counter** is authoritative — if the header is missing, malformed, or wrong, the running count of bytes received via `iter_bytes()` aborts the read as soon as it crosses the cap.

### `_extract_zip` — zip-bomb defended

- Sums `ZipInfo.file_size` across all members and checks the member count **before** calling `extractall`. Classic zip bombs (small archive, huge declared uncompressed size) are rejected without materialising any of the bomb on disk.
- Note: this is complementary to PR #159 (zip-slip path traversal); that PR catches members with `..` in their names, this one catches the size/count attack class.

### `_clone_git` — post-clone size check

- Walks the cloned tree after the existing 60s timeout completes and rejects + cleans up (`shutil.rmtree`) if total size exceeds `INGEST_MAX_BYTES`.
- Symlinks are skipped (`p.is_symlink()` check) to avoid runaway counts on malicious `/dev/zero`-style links.

### Error semantics

All limit breaches raise `IngestLimitExceededError` — a subclass of `ValueError` so existing callers that catch `ValueError` from `InputHandler.resolve()` continue to work. Error messages include both the limit name and the observed size for clarity.

## Test plan

- [x] **8 new unit tests** in `tests/unit/test_input_handler_bounds.py`:
  - Under-cap downloads / zips / clones succeed unchanged.
  - Oversized Content-Length header rejected before body read (uses `httpx.MockTransport` with a forged header).
  - Streamed body overflow rejected when header is missing (generator-backed stream so httpx can't pre-compute Content-Length).
  - Declared-uncompressed-oversize zip rejected without extraction (forged central-directory `file_size` field).
  - Too many members rejected (10,001 entries).
  - Oversize clone rejected and the partial clone dir cleaned up.
- [x] **Existing 6 input-handler tests** continue to pass.
- [x] **Full suite**: 728 passed, 12 skipped.
- [x] `ruff check` clean.
- [x] `ruff format --check` clean.
- [x] DCO sign-off on the commit.

## README

Added a short "Size limits" subsection under Basic Usage documenting both caps and their relationship to the per-file analysis cap (per the maintainer's deferred-work request: *"Document in the README that 50 MiB is a per-file analysis limit, not an ingest limit"*).

## Notes / follow-up

- The constants are module-level rather than CLI-configurable. If you'd prefer `--ingest-max-bytes` / `--ingest-max-zip-members` flags or env vars (`SKILLSPECTOR_INGEST_MAX_BYTES`), happy to add — wanted to keep this PR scoped.
- PR #159 covers SSRF + zip-slip path traversal on the same code paths; that work is orthogonal to size bounds and the two PRs are independently mergeable.
