### PR TITLE
feat(pi): add SkillSpector scan tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ SkillSpector helps you answer: **"Is this skill safe to install?"**
 ## Documentation
 
 - **[Development guide](docs/DEVELOPMENT.md)** — Architecture, package layout, and how to extend the analyzer pipeline.
+- **[Pi extension](docs/PI_EXTENSION.md)** — Install SkillSpector as a Pi tool for scanning skills from inside agent sessions.
 
 ## Features
 

--- a/docs/PI_EXTENSION.md
+++ b/docs/PI_EXTENSION.md
@@ -1,0 +1,67 @@
+# SkillSpector Pi Extension
+
+SkillSpector can be installed into Pi as a local package. The extension registers a `skillspector_scan` tool that runs the existing SkillSpector CLI.
+
+## Requirements
+
+- Pi installed.
+- Python `>=3.12,<3.14`.
+- `uv` recommended.
+- This repo checked out locally.
+
+## Install
+
+```bash
+cd /path/to/SkillSpector
+uv sync
+pi install /path/to/SkillSpector
+```
+
+Then reload Pi:
+
+```text
+/reload
+```
+
+## Basic scan
+
+Ask Pi:
+
+```text
+Use skillspector_scan on tests/fixtures/safe_skill/SKILL.md with noLlm=true.
+```
+
+Equivalent CLI:
+
+```bash
+.venv/bin/skillspector scan tests/fixtures/safe_skill/SKILL.md --no-llm
+```
+
+## Tool parameters
+
+- `target`: path, URL, zip, Git repo, or `SKILL.md` to scan.
+- `format`: `terminal`, `json`, `markdown`, or `sarif`. Default: `terminal`.
+- `output`: optional report path.
+- `noLlm`: default `true`.
+- `provider`: optional `openai`, `anthropic`, `anthropic_proxy`, `nv_build`, or `nv_inference`.
+- `model`: optional model override.
+- `yaraRulesDir`: optional directory of extra YARA rules.
+- `verbose`: optional detailed progress.
+
+## LLM-backed analysis
+
+Static scan is default. To use semantic LLM analysis, configure provider credentials in your shell before launching Pi, then call the tool with `noLlm=false` and a provider.
+
+Example:
+
+```text
+Use skillspector_scan on ./my-skill with noLlm=false and provider=anthropic.
+```
+
+The extension does not read `.env` and redacts secret-looking output.
+
+## Remove
+
+```bash
+pi remove /path/to/SkillSpector
+```

--- a/extensions/skillspector.ts
+++ b/extensions/skillspector.ts
@@ -1,0 +1,142 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Type, type Static } from "typebox";
+import { existsSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scanSchema = Type.Object({
+  target: Type.String({ description: "Path, URL, zip, Git repo, or SKILL.md to scan." }),
+  format: Type.Optional(
+    StringEnum(["terminal", "json", "markdown", "sarif"] as const, {
+      description: "SkillSpector output format. Defaults to terminal.",
+    }),
+  ),
+  output: Type.Optional(Type.String({ description: "Optional report output path." })),
+  noLlm: Type.Optional(Type.Boolean({ description: "Skip LLM analysis. Defaults to true." })),
+  provider: Type.Optional(
+    StringEnum(["openai", "anthropic", "anthropic_proxy", "nv_build", "nv_inference"] as const, {
+      description: "Optional SkillSpector LLM provider when noLlm is false.",
+    }),
+  ),
+  model: Type.Optional(Type.String({ description: "Optional model override." })),
+  yaraRulesDir: Type.Optional(Type.String({ description: "Optional extra YARA rules directory." })),
+  verbose: Type.Optional(Type.Boolean({ description: "Show detailed progress." })),
+});
+
+type SkillSpectorScanParams = Static<typeof scanSchema>;
+
+function isLikelyUrl(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(value) || /^[\w.-]+\/[\w.-]+(?:\.git)?(?:@.+)?$/i.test(value);
+}
+
+function resolveMaybePath(ctxCwd: string, value?: string): string | undefined {
+  if (!value) return undefined;
+  if (isLikelyUrl(value)) return value;
+  return isAbsolute(value) ? value : resolve(ctxCwd, value);
+}
+
+function redactSecrets(value: string): string {
+  return value
+    .replace(/(sk-ant-[A-Za-z0-9_-]{12,})/g, "[REDACTED_ANTHROPIC_KEY]")
+    .replace(/(sk-[A-Za-z0-9_-]{20,})/g, "[REDACTED_OPENAI_KEY]")
+    .replace(/([A-Za-z0-9_]*API_KEY[=:]\s*)[^\s]+/gi, "$1[REDACTED]")
+    .replace(/([A-Za-z0-9_]*TOKEN[=:]\s*)[^\s]+/gi, "$1[REDACTED]");
+}
+
+function truncateText(value: string, maxChars = 12000): { text: string; truncated: boolean } {
+  if (value.length <= maxChars) return { text: value, truncated: false };
+  return {
+    text: `${value.slice(0, maxChars)}\n\n[truncated ${value.length - maxChars} chars]`,
+    truncated: true,
+  };
+}
+
+function packageRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+function findSkillSpectorBin(): string {
+  if (process.env.SKILLSPECTOR_BIN) return process.env.SKILLSPECTOR_BIN;
+  const localBin = resolve(packageRoot(), ".venv/bin/skillspector");
+  if (existsSync(localBin)) return localBin;
+  return "skillspector";
+}
+
+function buildScanArgs(params: SkillSpectorScanParams, cwd: string): string[] {
+  const args = ["scan", resolveMaybePath(cwd, params.target) ?? params.target];
+  args.push("--format", params.format ?? "terminal");
+
+  const noLlm = params.noLlm ?? true;
+  if (noLlm) args.push("--no-llm");
+
+  const output = resolveMaybePath(cwd, params.output);
+  if (output) args.push("--output", output);
+
+  const yaraRulesDir = resolveMaybePath(cwd, params.yaraRulesDir);
+  if (yaraRulesDir) args.push("--yara-rules-dir", yaraRulesDir);
+
+  if (params.verbose) args.push("--verbose");
+  return args;
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "skillspector_scan",
+    label: "SkillSpector Scan",
+    description: "Scan agent skills, directories, zip files, URLs, or Git repos for security risks using the local SkillSpector CLI.",
+    promptSnippet: "Scan agent skills for security risks with local SkillSpector CLI.",
+    promptGuidelines: [
+      "Use skillspector_scan before installing or trusting third-party agent skills.",
+      "skillspector_scan defaults to noLlm=true; set noLlm=false only when user wants provider-backed semantic analysis.",
+    ],
+    parameters: scanSchema,
+    async execute(_toolCallId, params, signal, onUpdate, ctx) {
+      const bin = findSkillSpectorBin();
+      const args = buildScanArgs(params, ctx.cwd);
+      const env: Record<string, string> = {};
+
+      if (params.provider) env.SKILLSPECTOR_PROVIDER = params.provider;
+      if (params.model) env.SKILLSPECTOR_MODEL = params.model;
+
+      onUpdate?.({ content: [{ type: "text", text: `Running ${bin} ${args.slice(0, 2).join(" ")} ...` }] });
+
+      const result = await pi.exec(bin, args, {
+        cwd: ctx.cwd,
+        env,
+        signal,
+        timeout: 120000,
+      });
+
+      const stdout = truncateText(redactSecrets(result.stdout ?? ""));
+      const stderr = truncateText(redactSecrets(result.stderr ?? ""), 6000);
+
+      if (result.code !== 0) {
+        throw new Error(`SkillSpector failed with exit code ${result.code}.\n${stderr.text}`);
+      }
+
+      const outputPath = resolveMaybePath(ctx.cwd, params.output);
+      const lines = [
+        `SkillSpector scan complete: ${params.target}`,
+        `format: ${params.format ?? "terminal"}`,
+        `noLlm: ${params.noLlm ?? true}`,
+      ];
+      if (outputPath) lines.push(`output: ${outputPath}`);
+      if (stdout.truncated) lines.push("stdout truncated: true");
+      if (stderr.text.trim()) lines.push(`stderr:\n${stderr.text}`);
+      if (stdout.text.trim()) lines.push(`stdout:\n${stdout.text}`);
+
+      return {
+        content: [{ type: "text", text: lines.join("\n") }],
+        details: {
+          code: result.code,
+          command: bin,
+          args,
+          outputPath,
+          stdoutTruncated: stdout.truncated,
+          stderrTruncated: stderr.truncated,
+        },
+      };
+    },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "skillspector-pi",
+  "version": "2.2.3",
+  "private": true,
+  "description": "Pi extension exposing SkillSpector as a local scan tool for agent skills.",
+  "keywords": ["pi-package", "skillspector", "agent-skills", "security"],
+  "pi": {
+    "extensions": ["./extensions/skillspector.ts"]
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "*"
+  }
+}


### PR DESCRIPTION
## Summary

- add a Pi package manifest for local installation
- add `skillspector_scan` Pi tool backed by the existing SkillSpector CLI
- document Pi install and usage flow

## Verification

- `pi -p --no-session --approve "Use only the skillspector_scan tool. Run it on tests/fixtures/safe_skill/SKILL.md with noLlm=true and format=terminal. Return concise result."`
- `.venv/bin/pytest -m "not integration and not provider" tests/`
- `.venv/bin/ruff check src/ tests/`

## Notes

- `skillspector_scan` defaults to `noLlm=true`
- provider-backed analysis remains opt-in
