### PR TITLE
fix: address non-blocking reviewer nits from #140, #141, #143

### DIFF
--- a/src/skillspector/cli.py
+++ b/src/skillspector/cli.py
@@ -177,7 +177,7 @@ def scan(
         typer.Option(
             "--recursive",
             "-r",
-            help="Scan directories containing multiple skills (immediate subdirectories with SKILL.md) independently.",
+            help="Scan immediate subdirectories that each contain a SKILL.md as independent skills.",
         ),
     ] = False,
     verbose: Annotated[

--- a/src/skillspector/nodes/analyzers/static_runner.py
+++ b/src/skillspector/nodes/analyzers/static_runner.py
@@ -84,7 +84,7 @@ _DOCUMENTATION_DIR_NAMES = (
 _DOCUMENTATION_CONFIDENCE_FACTOR = 0.3
 _CODE_EXAMPLE_CONFIDENCE_FACTOR = 0.5
 
-_NON_EXECUTABLE_FILE_TYPES = frozenset({"markdown", "text", "json", "yaml", "toml", "other"})
+_NON_EXECUTABLE_FILE_TYPES = frozenset({"markdown", "text", "json", "yaml", "toml"})
 
 
 def _is_documentation_markdown(path: str) -> bool:

--- a/src/skillspector/nodes/meta_analyzer.py
+++ b/src/skillspector/nodes/meta_analyzer.py
@@ -236,7 +236,7 @@ def _fallback_filtered(findings: list[Finding]) -> list[Finding]:
 
     result: list[Finding] = []
     for f in findings:
-        severity_upper = f.severity.upper()
+        severity_upper = (f.severity or "LOW").upper()
         confidence = f.confidence
         if f.context and is_code_example(f.context):
             confidence *= _CODE_EXAMPLE_DOWNWEIGHT

--- a/tests/nodes/analyzers/test_static_runner_filtering.py
+++ b/tests/nodes/analyzers/test_static_runner_filtering.py
@@ -115,6 +115,23 @@ result = subprocess.run(cmd, shell=True)
         for f in tm1_findings:
             assert f.confidence > 0
 
+    def test_extensionless_file_not_hard_dropped_by_code_example(self) -> None:
+        """An extensionless file (inferred as 'other') in code-example context is downweighted, not dropped."""
+        content = """\
+#!/bin/bash
+# Example: cleanup old builds
+rm -rf /tmp/build-cache
+"""
+        state = {
+            "components": ["cleanup_script"],
+            "file_cache": {"cleanup_script": content},
+        }
+        findings = static_runner.run_static_patterns(state, [tm_module])
+        tm1_findings = [f for f in findings if f.rule_id == "TM1"]
+        assert len(tm1_findings) >= 1, (
+            "Extensionless files must not have code-example findings hard-dropped"
+        )
+
     def test_skill_md_findings_are_not_filtered_by_backticks(self) -> None:
         """SKILL.md is the primary instruction file — backticks alone shouldn't filter."""
         content = """\

--- a/tests/nodes/test_meta_analyzer_fallback.py
+++ b/tests/nodes/test_meta_analyzer_fallback.py
@@ -99,6 +99,19 @@ class TestSeverityFloor:
         assert len(result) == 0
 
 
+    def test_none_severity_treated_as_low(self) -> None:
+        """Finding with None severity does not crash — treated as LOW."""
+        findings = [_finding(confidence=0.8, severity=None)]
+        result = _fallback_filtered(findings)
+        assert len(result) == 1
+
+    def test_none_severity_below_threshold_dropped(self) -> None:
+        """None severity at low confidence is dropped (no severity floor protection)."""
+        findings = [_finding(confidence=0.3, severity=None)]
+        result = _fallback_filtered(findings)
+        assert len(result) == 0
+
+
 class TestCodeExampleFiltering:
     """Findings in code example context are downweighted, not hard-dropped."""
 


### PR DESCRIPTION
## Summary

Bundles non-blocking reviewer nits from three merged PRs into a single follow-up:

- **#140** (`_NON_EXECUTABLE_FILE_TYPES`): Remove `"other"` from the non-executable set so extensionless scripts (e.g. `cleanup_script` with no `.sh` extension, inferred as `"other"` by `_infer_file_type`) get code-example findings **downweighted** instead of **hard-dropped**. This closes the edge case @rng1995 flagged where an unknown-but-executable extension could re-open the code-example bypass.
- **#143** (`_fallback_filtered` severity guard): Guard `f.severity.upper()` with `(f.severity or "LOW").upper()` to match the codebase convention (e.g. `_compute_risk_score`). Prevents `AttributeError` if a finding has `severity=None`.
- **#141** (`--recursive` help text): Reword to say "immediate subdirectories" instead of "directories containing multiple skills" — clarifies that `--recursive` scans one level deep, not a full recursive tree walk.

## Testing

- `test_extensionless_file_not_hard_dropped_by_code_example` — confirms an extensionless file with code-example context is downweighted, not dropped.
- `test_none_severity_treated_as_low` — confirms `severity=None` doesn't crash and is treated as LOW.
- `test_none_severity_below_threshold_dropped` — confirms None severity at low confidence is dropped (no severity floor protection).
- All existing tests pass (43 in the affected test files).

## Not addressed in this PR

- **#143** `filtering_mode` metadata on LLM-runtime-failure path: requires adding a state field + TypedDict change across 3 files — deferred as metadata-accuracy improvement.
- **#157** `.svg` in `_BINARY_EXTENSIONS`: code isn't on `main` yet (#157 still open). Will be addressed on the #157 branch or after merge.
- **#141** remaining nits (dead `finally: pass`, per-skill cleanup path, typing, summary count): `finally: pass` already removed; others are minor style items.