### PR TITLE
Sync OSS release snapshot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skillspector"
-version = "2.3.1"
+version = "2.3.5"
 description = "SkillSpector: Security scanner for AI agent skills (Claude Code, Cursor, and similar). Scans skills for vulnerabilities, malicious patterns, and security risks before installation. Supports Git repos, URLs, zips, and local directories; runs static pattern checks and optional LLM semantic analysis; outputs terminal, JSON, and Markdown reports with risk scoring."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/skillspector/input_handler.py
+++ b/src/skillspector/input_handler.py
@@ -43,19 +43,23 @@ from skillspector.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-ALLOWED_GIT_HOSTS = frozenset({
-    "github.com",
-    "gitlab.com",
-    "bitbucket.org",
-})
+ALLOWED_GIT_HOSTS = frozenset(
+    {
+        "github.com",
+        "gitlab.com",
+        "bitbucket.org",
+    }
+)
 
-ALLOWED_DOWNLOAD_HOSTS = frozenset({
-    "github.com",
-    "raw.githubusercontent.com",
-    "gitlab.com",
-    "bitbucket.org",
-    "huggingface.co",
-})
+ALLOWED_DOWNLOAD_HOSTS = frozenset(
+    {
+        "github.com",
+        "raw.githubusercontent.com",
+        "gitlab.com",
+        "bitbucket.org",
+        "huggingface.co",
+    }
+)
 
 
 def _is_private_ip(host: str) -> bool:
@@ -167,8 +171,7 @@ class InputHandler:
             raise ValueError(f"URL has no valid hostname: {url}")
         if not any(host == allowed or host.endswith("." + allowed) for allowed in allowed_hosts):
             raise ValueError(
-                f"Host '{host}' is not in the allowed hosts list. "
-                f"Allowed: {sorted(allowed_hosts)}"
+                f"Host '{host}' is not in the allowed hosts list. Allowed: {sorted(allowed_hosts)}"
             )
         if _is_private_ip(host):
             raise ValueError(

--- a/src/skillspector/llm_analyzer_base.py
+++ b/src/skillspector/llm_analyzer_base.py
@@ -87,11 +87,11 @@ class LLMFinding(BaseModel):
     @field_validator("confidence", mode="before")
     @classmethod
     def _normalize_confidence(cls, v: object) -> float:
-        """Accept 0-100 scale (e.g. from Ollama) and normalize to [0, 1]."""
-        v = float(v)  # raises TypeError/ValueError for non-numeric inputs
-        if v > 1.0:
+        # Accept 0-100 scale values from some models, then clamp into [0, 1].
+        v = float(v)
+        if v > 2.0:
             v = v / 100.0
-        return max(0.0, min(1.0, v))
+        return min(1.0, max(0.0, v))
 
     def to_finding(self, file: str) -> Finding:
         """Convert to a :class:`Finding` for the graph state."""

--- a/src/skillspector/nodes/analyzers/behavioral_ast.py
+++ b/src/skillspector/nodes/analyzers/behavioral_ast.py
@@ -222,10 +222,7 @@ def _analyze_python(content: str, file_path: str) -> list[AnalyzerFinding]:
             second_arg = ast_node.args[1]
             if not isinstance(second_arg, ast.Constant):
                 _emit("AST7", lineno, end_lineno)
-            elif (
-                isinstance(second_arg.value, str)
-                and second_arg.value in _DANGEROUS_GETATTR_NAMES
-            ):
+            elif isinstance(second_arg.value, str) and second_arg.value in _DANGEROUS_GETATTR_NAMES:
                 _emit("AST9", lineno, end_lineno)
 
     return findings

--- a/src/skillspector/nodes/meta_analyzer.py
+++ b/src/skillspector/nodes/meta_analyzer.py
@@ -67,6 +67,16 @@ class MetaAnalyzerFinding(BaseModel):
     # minimum/maximum, which some OpenAI-compatible structured-output endpoints
     # reject. The range is enforced by the validator below instead.
     confidence: float = Field(description="Confidence score between 0.0 and 1.0")
+
+    @field_validator("confidence", mode="before")
+    @classmethod
+    def _normalize_confidence(cls, v: object) -> float:
+        # Accept 0-100 scale values from some models, then clamp into [0, 1].
+        v = float(v)
+        if v > 2.0:
+            v = v / 100.0
+        return min(1.0, max(0.0, v))
+
     intent: Literal["malicious", "negligent", "benign"] = Field(
         description="Likely intent behind the finding"
     )
@@ -75,15 +85,6 @@ class MetaAnalyzerFinding(BaseModel):
     )
     explanation: str = Field(default="", description="Why this is dangerous (2-3 sentences)")
     remediation: str = Field(default="", description="How to fix the issue (actionable steps)")
-
-    @field_validator("confidence", mode="before")
-    @classmethod
-    def _normalize_confidence(cls, v: object) -> float:
-        """Accept 0-100 scale (e.g. from Ollama) and normalize to [0, 1]."""
-        v = float(v)  # raises TypeError/ValueError for non-numeric inputs
-        if v > 1.0:
-            v = v / 100.0
-        return max(0.0, min(1.0, v))
 
 
 class OverallAssessment(BaseModel):

--- a/src/skillspector/nodes/report.py
+++ b/src/skillspector/nodes/report.py
@@ -325,9 +325,7 @@ def _build_analysis_completeness(
 
     findings_dropped = len(findings_pre_filter) - len(findings_post_filter)
     if findings_dropped > 0:
-        limitations.append(
-            f"{findings_dropped} finding(s) filtered by meta-analyzer or heuristics"
-        )
+        limitations.append(f"{findings_dropped} finding(s) filtered by meta-analyzer or heuristics")
 
     completeness: dict[str, object] = {
         "total_components": total_components,
@@ -456,9 +454,9 @@ def _format_markdown(
 
 def report(state: SkillspectorState) -> dict[str, object]:
     """Generate SARIF, compute risk score, and set report_body from output_format."""
-    raw_findings = state.get("filtered_findings", state.get("findings", []))
-    findings_for_scoring = deduplicate(raw_findings)
-    filtered_findings = raw_findings
+    raw_findings = state.get("findings", [])
+    filtered_findings = state.get("filtered_findings", raw_findings)
+    findings_for_scoring = deduplicate(filtered_findings)
     component_metadata = state.get("component_metadata") or []
     components = state.get("components") or []
     file_cache = state.get("file_cache") or {}

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -186,7 +186,7 @@ class TestRunStaticPatternsSupplyChain:
         assert sc2[0].severity == "HIGH"
 
 
-class TestRunStaticPatternsAgentSnooping:
+class TestRunStaticPatternsAgentSnoopingAdditional:
     """run_static_patterns with agent_snooping: AS1, AS2, AS3."""
 
     def test_as1_agent_config_dir_access_python(self):
@@ -302,14 +302,14 @@ class TestRunStaticPatternsAgentSnooping:
         findings = static_runner.run_static_patterns(state, [agent_snooping_module])
         assert any(f.rule_id == "AS3" for f in findings)
 
-    def test_no_same_line_duplicate(self):
-        """A line matching one rule twice yields a single finding (built-in dedup)."""
+    def test_same_line_distinct_matches_preserved(self):
+        """Distinct same-line config reads are preserved as separate findings."""
         state = {
             "components": ["s.py"],
-            "file_cache": {"s.py": 'open("/Users/x/.claude/.codex/note")\n'},
+            "file_cache": {"s.py": 'open(".claude/settings.json"); open(".codex/config.json")\n'},
         }
         findings = static_runner.run_static_patterns(state, [agent_snooping_module])
-        assert len([f for f in findings if f.rule_id == "AS1"]) == 1
+        assert len([f for f in findings if f.rule_id == "AS1"]) == 2
 
     def test_normal_file_access_not_flagged(self):
         """Ordinary project file access produces no agent-snooping finding."""

--- a/tests/nodes/analyzers/test_static_yara.py
+++ b/tests/nodes/analyzers/test_static_yara.py
@@ -492,8 +492,8 @@ class TestContentHashInvalidation:
         rules_v2 = static_yara._load_rules(tmp_path)
         assert rules_v2 is not None
 
-        content_with_a = 'AAAA is here'
-        content_with_b = 'BBBB is here'
+        content_with_a = "AAAA is here"
+        content_with_b = "BBBB is here"
 
         matches_a = rules_v2.match(data=content_with_a.encode())
         matches_b = rules_v2.match(data=content_with_b.encode())

--- a/tests/nodes/test_analysis_completeness.py
+++ b/tests/nodes/test_analysis_completeness.py
@@ -59,8 +59,11 @@ class TestBuildAnalysisCompleteness:
         findings = [_make_finding()]
         with patch("skillspector.nodes.report.is_llm_available", return_value=(True, None)):
             result = _build_analysis_completeness(
-                components, file_cache, use_llm=True,
-                findings_pre_filter=findings, findings_post_filter=findings,
+                components,
+                file_cache,
+                use_llm=True,
+                findings_pre_filter=findings,
+                findings_post_filter=findings,
             )
         assert result["total_components"] == 2
         assert result["scanned_components"] == 2
@@ -74,8 +77,11 @@ class TestBuildAnalysisCompleteness:
         file_cache = {"a.py": "code"}
         with patch("skillspector.nodes.report.is_llm_available", return_value=(True, None)):
             result = _build_analysis_completeness(
-                components, file_cache, use_llm=True,
-                findings_pre_filter=[], findings_post_filter=[],
+                components,
+                file_cache,
+                use_llm=True,
+                findings_pre_filter=[],
+                findings_post_filter=[],
             )
         assert result["total_components"] == 3
         assert result["scanned_components"] == 1
@@ -89,8 +95,11 @@ class TestBuildAnalysisCompleteness:
             return_value=(False, "OPENAI_API_KEY not set"),
         ):
             result = _build_analysis_completeness(
-                ["a.py"], {"a.py": "code"}, use_llm=True,
-                findings_pre_filter=[], findings_post_filter=[],
+                ["a.py"],
+                {"a.py": "code"},
+                use_llm=True,
+                findings_pre_filter=[],
+                findings_post_filter=[],
             )
         assert result["llm_analysis"] == "skipped"
         assert result["is_complete"] is False
@@ -99,8 +108,11 @@ class TestBuildAnalysisCompleteness:
     def test_llm_disabled_noted(self) -> None:
         with patch("skillspector.nodes.report.is_llm_available", return_value=(True, None)):
             result = _build_analysis_completeness(
-                ["a.py"], {"a.py": "code"}, use_llm=False,
-                findings_pre_filter=[], findings_post_filter=[],
+                ["a.py"],
+                {"a.py": "code"},
+                use_llm=False,
+                findings_pre_filter=[],
+                findings_post_filter=[],
             )
         assert result["llm_analysis"] == "skipped"
         assert result["is_complete"] is False
@@ -111,8 +123,11 @@ class TestBuildAnalysisCompleteness:
         post = [_make_finding()]
         with patch("skillspector.nodes.report.is_llm_available", return_value=(True, None)):
             result = _build_analysis_completeness(
-                ["a.py"], {"a.py": "code"}, use_llm=True,
-                findings_pre_filter=pre, findings_post_filter=post,
+                ["a.py"],
+                {"a.py": "code"},
+                use_llm=True,
+                findings_pre_filter=pre,
+                findings_post_filter=post,
             )
         assert result["findings_before_filtering"] == 3
         assert result["findings_after_filtering"] == 1
@@ -121,8 +136,11 @@ class TestBuildAnalysisCompleteness:
     def test_empty_components_gives_100_coverage(self) -> None:
         with patch("skillspector.nodes.report.is_llm_available", return_value=(True, None)):
             result = _build_analysis_completeness(
-                [], {}, use_llm=True,
-                findings_pre_filter=[], findings_post_filter=[],
+                [],
+                {},
+                use_llm=True,
+                findings_pre_filter=[],
+                findings_post_filter=[],
             )
         assert result["coverage_percent"] == 100.0
         assert result["total_components"] == 0

--- a/tests/nodes/test_llm_analyzer_base.py
+++ b/tests/nodes/test_llm_analyzer_base.py
@@ -601,6 +601,14 @@ class TestLLMAnalysisResult:
         assert len(result.findings) == 1
         assert result.findings[0].confidence == 0.9
 
+    def test_confidence_is_clamped(self) -> None:
+        """Out-of-range confidence is clamped, not rejected, so a slightly off
+        model value does not fail the whole structured-output parse."""
+        hi = LLMFinding(rule_id="X", message="x", severity="LOW", start_line=1, confidence=1.5)
+        lo = LLMFinding(rule_id="X", message="x", severity="LOW", start_line=1, confidence=-0.3)
+        assert hi.confidence == 1.0
+        assert lo.confidence == 0.0
+
     def test_confidence_100_scale_normalized(self) -> None:
         """Ollama and some models return confidence on 0-100 scale; must be normalized."""
         f = LLMFinding(rule_id="X", message="x", severity="LOW", start_line=1, confidence=100)
@@ -713,10 +721,34 @@ class TestMetaAnalyzerResult:
         assert len(result.findings) == 1
         assert result.findings[0].confidence == 0.9
 
+    def test_confidence_is_clamped(self) -> None:
+        """Out-of-range confidence is clamped, not rejected, so a slightly off
+        model value does not fail the whole structured-output parse."""
+        high = MetaAnalyzerFinding(
+            pattern_id="E1",
+            is_vulnerability=True,
+            confidence=1.5,
+            intent="malicious",
+            impact="high",
+        )
+        low = MetaAnalyzerFinding(
+            pattern_id="E1",
+            is_vulnerability=True,
+            confidence=-0.2,
+            intent="malicious",
+            impact="high",
+        )
+        assert high.confidence == 1.0
+        assert low.confidence == 0.0
+
     def test_confidence_100_scale_normalized(self) -> None:
         """Ollama-style 0-100 scale must be normalized to 0-1."""
         f = MetaAnalyzerFinding(
-            pattern_id="E1", is_vulnerability=True, confidence=100, intent="malicious", impact="high"
+            pattern_id="E1",
+            is_vulnerability=True,
+            confidence=100,
+            intent="malicious",
+            impact="high",
         )
         assert f.confidence == pytest.approx(1.0)
 
@@ -822,12 +854,10 @@ class TestStructuredOutputSchema:
     def test_meta_finding_schema_has_no_numeric_bounds(self) -> None:
         assert self._numeric_keywords(MetaAnalyzerFinding.model_json_schema()) == set()
 
-    def test_llm_finding_normalizes_confidence(self) -> None:
-        # Values > 1.0 are treated as 0-100 scale and rescaled: 85 → 0.85
-        hi = LLMFinding(rule_id="R", message="m", severity="LOW", start_line=1, confidence=85)
-        # Negative values are clamped to 0.0
+    def test_llm_finding_clamps_confidence(self) -> None:
+        hi = LLMFinding(rule_id="R", message="m", severity="LOW", start_line=1, confidence=1.5)
         lo = LLMFinding(rule_id="R", message="m", severity="LOW", start_line=1, confidence=-0.3)
-        assert hi.confidence == pytest.approx(0.85)
+        assert hi.confidence == 1.0
         assert lo.confidence == 0.0
 
     def test_llm_finding_clamps_start_line(self) -> None:

--- a/tests/nodes/test_meta_analyzer_fallback.py
+++ b/tests/nodes/test_meta_analyzer_fallback.py
@@ -231,9 +231,7 @@ class TestLLMFailurePassthrough:
             "manifest": {},
             "model_config": {},
         }
-        with patch(
-            "skillspector.nodes.meta_analyzer.LLMMetaAnalyzer"
-        ) as mock_cls:
+        with patch("skillspector.nodes.meta_analyzer.LLMMetaAnalyzer") as mock_cls:
             mock_cls.return_value.get_batches.side_effect = RuntimeError("API timeout")
             result = meta_analyzer(state)
         assert len(result["filtered_findings"]) == 2

--- a/tests/nodes/test_sarif_rules_and_empty_findings.py
+++ b/tests/nodes/test_sarif_rules_and_empty_findings.py
@@ -17,8 +17,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from skillspector.models import Finding
 from skillspector.nodes.report import _build_sarif
 

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -205,6 +205,7 @@ class TestGetChatModel:
     def test_provider_credentials_use_provider_default_model(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "nv_build")
         monkeypatch.setenv("NVIDIA_INFERENCE_KEY", "nvapi-test")
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test-openai")
 

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -217,9 +217,7 @@ class TestOpenAIProvider:
         assert llm.model_name == "gpt-5.4"
         assert llm.max_tokens == 123
 
-    def test_openai_project_id_sets_default_header(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_openai_project_id_sets_default_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
         monkeypatch.setenv("OPENAI_PROJECT_ID", "proj_123")
         llm = OpenAIProvider().create_chat_model("gpt-5.4", max_tokens=123)

--- a/uv.lock
+++ b/uv.lock
@@ -1837,7 +1837,7 @@ wheels = [
 
 [[package]]
 name = "skillspector"
-version = "2.3.1"
+version = "2.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Refresh public SkillSpector from the internal OSS release snapshot.
- Source branch: `release/oss-2026-06-23`
- Source commit: `8aa06e0564f9571b7c30db23475786f9513b4e28`
- Public branch: `keshavp/oss-release-2026-06-23`

## Diff Notes

- Bumps package metadata and `uv.lock` from `2.3.1` to `2.3.5`.
- Carries over confidence normalization, report scoring/completeness behavior, SSRF/input-handler formatting, behavioral AST formatting, and related test updates.
- No `.github/` or other public-only automation/policy deletions were present in the staged diff.

## Verification

- `./scripts/create-oss-release.sh release/oss-2026-06-23` generated the orphan snapshot; after installing a Python 3.12 dev venv, the script's `make test-unit` gate passed on the generated snapshot: 881 passed, 12 skipped, 26 deselected.
- `make test-unit` passed again in the GitHub checkout with the temporary Python 3.12 venv: 881 passed, 12 skipped, 26 deselected.
