### PR TITLE
feat(analyzer): detect Docker socket access as PE4 privilege escalation

### DIFF
--- a/src/skillspector/nodes/analyzers/static_patterns_privilege_escalation.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_privilege_escalation.py
@@ -162,24 +162,28 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
                     matched_text=match.group(0)[:200],
                 )
             )
+    # Collect best-confidence PE4 finding per line to avoid double-counting lines
+    # that match multiple patterns (e.g. DockerClient(base_url=".../docker.sock")).
+    pe4_best: dict[int, AnalyzerFinding] = {}
     for pattern, confidence in PE4_PATTERNS:
         for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
             line_num = get_line_number(content, match.start())
             context = get_context(content, match.start())
             if _is_documentation_example(context, file_type):
                 continue
-            findings.append(
-                AnalyzerFinding(
-                    rule_id="PE4",
-                    message="Docker Socket Access",
-                    severity=Severity.HIGH,
-                    location=loc(line_num),
-                    confidence=confidence,
-                    tags=tag,
-                    context=context,
-                    matched_text=match.group(0)[:200],
-                )
+            if line_num in pe4_best and pe4_best[line_num].confidence >= confidence:
+                continue
+            pe4_best[line_num] = AnalyzerFinding(
+                rule_id="PE4",
+                message="Docker Socket Access",
+                severity=Severity.HIGH,
+                location=loc(line_num),
+                confidence=confidence,
+                tags=tag,
+                context=context,
+                matched_text=match.group(0)[:200],
             )
+    findings.extend(pe4_best.values())
     return findings
 
 

--- a/src/skillspector/nodes/analyzers/static_patterns_privilege_escalation.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_privilege_escalation.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Static patterns: privilege escalation (PE1–PE3). Node and analyze() in one module."""
+"""Static patterns: privilege escalation (PE1–PE4). Node and analyze() in one module."""
 
 from __future__ import annotations
 
@@ -93,10 +93,16 @@ PE3_PATTERNS = [
     (r"access\s+(?:the\s+)?(?:credentials?|secrets?|tokens?)", 0.7),
     (r"(?:extract|copy|get)\s+(?:api\s+)?keys?\s+from", 0.7),
 ]
+PE4_PATTERNS = [
+    (r"/var/run/docker\.sock", 0.9),
+    (r"docker\.from_env\(\)", 0.85),
+    (r"\bDockerClient\s*\(", 0.85),
+    (r"http\+unix://.*docker\.sock", 0.9),
+]
 
 
 def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFinding]:
-    """Analyze content for privilege escalation patterns (PE1–PE3)."""
+    """Analyze content for privilege escalation patterns (PE1–PE4)."""
     findings: list[AnalyzerFinding] = []
 
     def loc(ln: int) -> Location:
@@ -148,6 +154,24 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
                 AnalyzerFinding(
                     rule_id="PE3",
                     message="Credential Access",
+                    severity=Severity.HIGH,
+                    location=loc(line_num),
+                    confidence=confidence,
+                    tags=tag,
+                    context=context,
+                    matched_text=match.group(0)[:200],
+                )
+            )
+    for pattern, confidence in PE4_PATTERNS:
+        for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
+            line_num = get_line_number(content, match.start())
+            context = get_context(content, match.start())
+            if _is_documentation_example(context, file_type):
+                continue
+            findings.append(
+                AnalyzerFinding(
+                    rule_id="PE4",
+                    message="Docker Socket Access",
                     severity=Severity.HIGH,
                     location=loc(line_num),
                     confidence=confidence,

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -354,6 +354,23 @@ class TestRunStaticPatternsPrivilegeEscalationPE4:
         assert pe4[0].context is not None
         assert pe4[0].matched_text is not None
 
+    def test_pe4_combined_line_produces_exactly_one_finding(self):
+        """A line matching multiple PE4 patterns must produce exactly one PE4 finding."""
+        state = {
+            "components": ["skill.py"],
+            "file_cache": {
+                "skill.py": 'client = docker.DockerClient(base_url="unix:///var/run/docker.sock")\n',
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [privilege_escalation_module])
+        pe4 = [f for f in findings if f.rule_id == "PE4"]
+        assert len(pe4) == 1, (
+            f"Expected 1 PE4 finding, got {len(pe4)}: {[f.matched_text for f in pe4]}"
+        )
+        assert (
+            pe4[0].confidence == 0.9
+        )  # /var/run/docker.sock has higher confidence than DockerClient(
+
     def test_pe4_docker_from_env_produces_finding(self):
         """docker.from_env() yields PE4 (HIGH)."""
         state = {
@@ -406,11 +423,7 @@ class TestRunStaticPatternsPrivilegeEscalationPE4:
             "components": ["SKILL.md"],
             "file_cache": {
                 "SKILL.md": (
-                    "# Docker SDK\n\n"
-                    "For example:\n"
-                    "```python\n"
-                    "client = docker.from_env()\n"
-                    "```\n"
+                    "# Docker SDK\n\nFor example:\n```python\nclient = docker.from_env()\n```\n"
                 ),
             },
         }

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -328,3 +328,99 @@ class TestRunStaticPatternsAgentSnooping:
         }
         result = agent_snooping_module.node(state)
         assert any(f.rule_id == "AS1" for f in result["findings"])
+
+
+class TestRunStaticPatternsPrivilegeEscalationPE4:
+    """run_static_patterns with privilege_escalation: PE4 (Docker socket access)."""
+
+    def test_pe4_docker_sock_path_produces_finding(self):
+        """Direct reference to /var/run/docker.sock yields PE4 (HIGH)."""
+        state = {
+            "components": ["skill.py"],
+            "file_cache": {
+                "skill.py": 'client = docker.DockerClient(base_url="unix:///var/run/docker.sock")\n',
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [privilege_escalation_module])
+        pe4 = [f for f in findings if f.rule_id == "PE4"]
+        assert len(pe4) >= 1
+        assert pe4[0].severity == "HIGH"
+        assert pe4[0].file == "skill.py"
+        assert pe4[0].start_line >= 1
+        assert pe4[0].remediation is not None
+        assert pe4[0].context is not None
+        assert pe4[0].matched_text is not None
+
+    def test_pe4_docker_from_env_produces_finding(self):
+        """docker.from_env() yields PE4 (HIGH)."""
+        state = {
+            "components": ["skill.py"],
+            "file_cache": {
+                "skill.py": "import docker\nclient = docker.from_env()\n",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [privilege_escalation_module])
+        pe4 = [f for f in findings if f.rule_id == "PE4"]
+        assert len(pe4) >= 1
+        assert pe4[0].severity == "HIGH"
+
+    def test_pe4_docker_client_constructor_produces_finding(self):
+        """DockerClient( instantiation yields PE4 (HIGH)."""
+        state = {
+            "components": ["skill.py"],
+            "file_cache": {
+                "skill.py": "from docker import DockerClient\nclient = DockerClient(base_url='tcp://...')\n",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [privilege_escalation_module])
+        assert any(f.rule_id == "PE4" for f in findings)
+
+    def test_pe4_http_unix_socket_produces_finding(self):
+        """http+unix:// reference to docker.sock yields PE4 (HIGH)."""
+        state = {
+            "components": ["skill.py"],
+            "file_cache": {
+                "skill.py": 'url = "http+unix://%2Fvar%2Frun%2Fdocker.sock/containers/json"\n',
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [privilege_escalation_module])
+        assert any(f.rule_id == "PE4" for f in findings)
+
+    def test_pe4_safe_docker_subprocess_not_flagged(self):
+        """subprocess call to docker CLI without socket reference produces no PE4."""
+        state = {
+            "components": ["skill.py"],
+            "file_cache": {
+                "skill.py": "subprocess.run(['docker', 'ps', '--format', 'json'])\n",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [privilege_escalation_module])
+        assert not any(f.rule_id == "PE4" for f in findings)
+
+    def test_pe4_documentation_example_not_flagged(self):
+        """docker.from_env() inside a markdown code block is filtered as documentation."""
+        state = {
+            "components": ["SKILL.md"],
+            "file_cache": {
+                "SKILL.md": (
+                    "# Docker SDK\n\n"
+                    "For example:\n"
+                    "```python\n"
+                    "client = docker.from_env()\n"
+                    "```\n"
+                ),
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [privilege_escalation_module])
+        assert not any(f.rule_id == "PE4" for f in findings)
+
+    def test_pe4_node_runs_over_state(self):
+        """The node entrypoint runs PE4 detection over state and returns findings."""
+        state = {
+            "components": ["skill.py"],
+            "file_cache": {
+                "skill.py": "client = docker.from_env()\n",
+            },
+        }
+        result = privilege_escalation_module.node(state)
+        assert any(f.rule_id == "PE4" for f in result["findings"])


### PR DESCRIPTION
## Summary

Closes #188

Adds `PE4_PATTERNS` to the static privilege escalation analyzer to detect Docker socket access. This attack allows a containerized skill to gain full host root access without triggering any of the existing PE1–PE3 rules.

Four patterns are added to `src/skillspector/nodes/analyzers/static_patterns_privilege_escalation.py`:

| Pattern | Technique | Confidence |
|---------|-----------|------------|
| `/var/run/docker\.sock` | Socket path reference | 0.9 |
| `docker\.from_env\(\)` | Standard SDK entry point | 0.85 |
| `\bDockerClient\s*\(` | Explicit client construction | 0.85 |
| `http\+unix://.*docker\.sock` | Raw HTTP-over-Unix-socket | 0.9 |

## Before / After

**Before (static analysis only, `--no-llm`)**

```
$ skillspector scan ./skill-dir/ --no-llm

Risk Assessment
 Score           4/100
 Severity        LOW
 Recommendation  SAFE

Issues (2)
  LOW: LP4 - Permission 'shell' is declared but no corresponding code capability detected.
  LOW: LP4 - Permission 'env' is declared but no corresponding code capability detected.
```

`docker.from_env()` in a Python skill file produced zero findings — the skill installed without any warning.

**After (static analysis only, `--no-llm`)**

```
$ skillspector scan ./skill-dir/ --no-llm

Risk Assessment
 Score           31/100
 Severity        MEDIUM
 Recommendation  CAUTION

Issues (3)
  LOW:  LP4 - Permission 'shell' is declared but no corresponding code capability detected.
  LOW:  LP4 - Permission 'env' is declared but no corresponding code capability detected.
  HIGH: PE4 - Docker Socket Access
        Location: skill.py:5
        Confidence: 85%
```

Docker socket access is now caught by the static layer without requiring LLM analysis.

## Testing

7 new unit tests in `TestRunStaticPatternsPrivilegeEscalationPE4`: positive cases for all four patterns (`/var/run/docker.sock`, `docker.from_env()`, `DockerClient(`, `http+unix://...docker.sock`), a negative case for `subprocess.run(['docker', 'ps'])` which carries no socket reference, a filter case confirming `docker.from_env()` inside a markdown code block is suppressed by `_is_documentation_example()`, and a node entrypoint test confirming `privilege_escalation_module.node()` returns PE4 findings.

`make lint` and `make format` passed. `make test` — 937 passed (2 pre-existing failures in `test_meta_analyzer.py` unrelated to this change).