### PR TITLE
docs(mcp): document HTTP transport trust model

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,18 @@ Register it with Claude Code via:
 claude mcp add skillspector -- skillspector mcp
 ```
 
+> **Security — HTTP transport trust model**
+>
+> The HTTP transport ships **without authentication**. Any caller that can
+> reach the port can invoke `scan_skill`. Over stdio or `127.0.0.1` this is
+> the same trust boundary as the CLI. If you bind to a routable interface:
+>
+> - Sit the server behind an authenticating reverse proxy (e.g. nginx + mTLS)
+>   before exposing it externally.
+> - Local paths and `file://` URLs are **automatically rejected** over HTTP to
+>   prevent unauthenticated callers from reading arbitrary host files. Only
+>   remote Git and `.zip` URLs are accepted.
+
 ## Vulnerability Patterns
 
 SkillSpector detects **68 vulnerability patterns** across 17 categories:


### PR DESCRIPTION
Closes #191

Follow-up from @rng1995's review on #36:
https://github.com/NVIDIA/SkillSpector/pull/36#pullrequestreview-4539956136

> *"the streamable-HTTP transport is unauthenticated … If an operator binds it to a routable interface, an unauthenticated caller could request `file:///…` or a local path and get file contents reflected back in `findings`/`report` (local file disclosure), or use it to drive outbound fetches (SSRF)."*

## What

Adds a security callout to the MCP Server section of the README documenting the HTTP transport trust model.

## Changes

**`README.md`**
- Add a security callout under the MCP Server section: HTTP transport ships without authentication, should sit behind an authenticating proxy before any public exposure, and callers must be aware that `scan_skill` accepts local paths and file URLs.

No code changes — local path restriction was considered but deemed too aggressive; an operator running behind a proper authenticating proxy has a legitimate reason to scan local paths.

## Test results

No code changes. Existing test suite passes.