### PR TITLE
fix(input): support scp-style SSH Git URLs in host validation

### DIFF
--- a/src/skillspector/input_handler.py
+++ b/src/skillspector/input_handler.py
@@ -29,6 +29,7 @@ Ported from legacy implementation.
 from __future__ import annotations
 
 import ipaddress
+import re
 import shutil
 import socket
 import subprocess
@@ -160,6 +161,13 @@ class InputHandler:
             return False
         return not self._is_git_url(path)
 
+    def _extract_scp_host(self, url: str) -> str | None:
+        """Return the host from an scp-style Git URL, or None if not scp form."""
+        if "://" in url:
+            return None
+        m = re.match(r"^[^@/]+@([^:/]+):.+$", url)
+        return m.group(1) if m else None
+
     def _validate_url_host(self, url: str, allowed_hosts: frozenset[str]) -> str:
         """Validate URL host against allowlist and SSRF protections.
 
@@ -167,6 +175,8 @@ class InputHandler:
         """
         parsed = urlparse(url)
         host = parsed.hostname or ""
+        if not host:
+            host = self._extract_scp_host(url) or ""
         if not host:
             raise ValueError(f"URL has no valid hostname: {url}")
         if not any(host == allowed or host.endswith("." + allowed) for allowed in allowed_hosts):

--- a/tests/unit/test_input_handler.py
+++ b/tests/unit/test_input_handler.py
@@ -130,7 +130,7 @@ def test_scp_disallowed_host_raises() -> None:
 
 
 def test_scp_private_ip_raises() -> None:
-    """_validate_url_host rejects an scp URL with a link-local IP host."""
+    """_validate_url_host rejects an scp URL whose extracted host is not in the allowlist."""
     with pytest.raises(ValueError):
         InputHandler()._validate_url_host("git@169.254.169.254:org/repo.git", ALLOWED_GIT_HOSTS)
 

--- a/tests/unit/test_input_handler.py
+++ b/tests/unit/test_input_handler.py
@@ -139,3 +139,10 @@ def test_https_url_unchanged() -> None:
     """https URLs continue to extract the host via urlparse without hitting the scp fallback."""
     host = InputHandler()._validate_url_host("https://github.com/org/repo.git", ALLOWED_GIT_HOSTS)
     assert host == "github.com"
+
+
+def test_scp_ssrf_gate_fires() -> None:
+    """SSRF gate raises ValueError for an scp URL whose host resolves to a private IP."""
+    with patch("skillspector.input_handler._is_private_ip", return_value=True):
+        with pytest.raises(ValueError, match="private/internal IP"):
+            InputHandler()._validate_url_host("git@github.com:org/repo.git", ALLOWED_GIT_HOSTS)

--- a/tests/unit/test_input_handler.py
+++ b/tests/unit/test_input_handler.py
@@ -16,10 +16,11 @@
 """Tests for skillspector input_handler (resolve directory, zip, single file)."""
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from skillspector.input_handler import InputHandler
+from skillspector.input_handler import ALLOWED_GIT_HOSTS, InputHandler
 
 
 def test_resolve_directory(tmp_path: Path) -> None:
@@ -94,3 +95,47 @@ def test_cleanup_idempotent(tmp_path: Path) -> None:
     handler.resolve(str(tmp_path / "a.md"))
     handler.cleanup()
     handler.cleanup()
+
+
+def test_scp_url_is_git_url() -> None:
+    """scp-style SSH URL is recognised as a Git URL."""
+    assert InputHandler()._is_git_url("git@github.com:org/repo.git") is True
+
+
+def test_validate_url_host_scp_extracts_github() -> None:
+    """_validate_url_host extracts 'github.com' from an scp-style URL."""
+    host = InputHandler()._validate_url_host("git@github.com:org/repo.git", ALLOWED_GIT_HOSTS)
+    assert host == "github.com"
+
+
+def test_scp_valid_host_clones() -> None:
+    """resolve() calls git clone with the scp URL when the host is allowed."""
+    handler = InputHandler()
+    try:
+        with patch(
+            "skillspector.input_handler.subprocess.run", return_value=MagicMock()
+        ) as mock_run:
+            handler.resolve("git@github.com:org/repo.git")
+        assert mock_run.called
+        call_args = mock_run.call_args[0][0]
+        assert "git@github.com:org/repo.git" in call_args
+    finally:
+        handler.cleanup()
+
+
+def test_scp_disallowed_host_raises() -> None:
+    """_validate_url_host rejects an scp URL whose host is not in the allowlist."""
+    with pytest.raises(ValueError, match="not in the allowed hosts"):
+        InputHandler()._validate_url_host("git@malicious.internal:org/repo.git", ALLOWED_GIT_HOSTS)
+
+
+def test_scp_private_ip_raises() -> None:
+    """_validate_url_host rejects an scp URL with a link-local IP host."""
+    with pytest.raises(ValueError):
+        InputHandler()._validate_url_host("git@169.254.169.254:org/repo.git", ALLOWED_GIT_HOSTS)
+
+
+def test_https_url_unchanged() -> None:
+    """https URLs continue to extract the host via urlparse without hitting the scp fallback."""
+    host = InputHandler()._validate_url_host("https://github.com/org/repo.git", ALLOWED_GIT_HOSTS)
+    assert host == "github.com"


### PR DESCRIPTION
## Summary

scp-style SSH Git URLs (`git@github.com:org/repo.git`) are silently admitted by `_is_git_url()` then rejected by `_validate_url_host()` with the misleading error `URL has no valid hostname`. This makes every GitHub/GitLab/Bitbucket SSH clone URL unusable even though `git clone` supports the format natively.

Closes #202

## Root cause

`_validate_url_host()` (`input_handler.py:163-181`) uses `urlparse(url).hostname` for host extraction. scp-style syntax has no `//` authority separator, so `urlparse().hostname` returns `None`, `host` becomes `""`, and the function raises at line 171 before reaching the allowlist or SSRF checks. The `_clone_git()` call at line 190 would handle the format correctly if validation passed.

## Diff Notes

- `src/skillspector/input_handler.py`: add `import re`; add private `_extract_scp_host()` helper matching `^[^@/]+@([^:/]+):.+$`; add scp fallback inside `_validate_url_host()` after `urlparse` — scp host flows through existing allowlist and `_is_private_ip()` SSRF checks unchanged. No change to `_is_git_url()`, `_clone_git()`, or `ALLOWED_GIT_HOSTS`.
- `tests/unit/test_input_handler.py`: seven new test cases covering scp detection, valid-host extraction, disallowed-host rejection, private-IP rejection, https regression, and SSRF gate for scp-extracted hosts (mocked).

## Before / After

| Input | Before | After |
|-------|--------|-------|
| `git@github.com:org/repo.git` | `ValueError: URL has no valid hostname` | host `github.com` extracted, clone proceeds |
| `git@malicious.internal:org/repo.git` | `ValueError: URL has no valid hostname` | host extracted, fails allowlist, `ValueError` |
| `git@169.254.169.254:org/repo.git` | `ValueError: URL has no valid hostname` | host extracted, fails allowlist, `ValueError` |
| `https://github.com/org/repo.git` | `"github.com"` (unchanged) | `"github.com"` (scp fallback not reached) |

## Scope

No expansion of `ALLOWED_GIT_HOSTS`. No change to SSRF protections or their order. No new runtime dependency (`re` is stdlib). `_is_git_url()` and `_clone_git()` unchanged.

## Verification

- `uv sync --all-extras` — exit 0
- `.\.venv\Scripts\python.exe -m pytest tests/unit/test_input_handler.py -v` — **13 passed**, 1 warning, 0.50s (6 original + 7 new)
- `uv run ruff check src/skillspector/input_handler.py tests/unit/test_input_handler.py` — exit 0
- `uv run ruff format --check src/skillspector/input_handler.py tests/unit/test_input_handler.py` — 2 files already formatted, exit 0

Proof matrix:

| Test | Base (7bc9c0f) | Head |
|------|----------------|------|
| `test_validate_url_host_scp_extracts_github` | raises `ValueError` | returns `"github.com"` |
| `test_scp_valid_host_clones` | raises before clone | subprocess called with scp URL |
| `test_scp_url_is_git_url` | `True` | `True` |
| `test_scp_disallowed_host_raises` | raises `ValueError` | raises `ValueError` (allowlist) |
| `test_scp_private_ip_raises` | raises `ValueError` | raises `ValueError` |
| `test_https_url_unchanged` | `"github.com"` | `"github.com"` |
| `test_scp_ssrf_gate_fires` | N/A (new test) | raises `ValueError` matching `"private/internal IP"` |

CI `Lint & Test (Python 3.12)`, `Lint & Test (Python 3.13)`, and `DCO Check` pending maintainer approval if fork checks are gated.

## Notes

DCO sign-off required on every commit (`git commit -s`). Known existing failures (`tests/nodes/test_meta_analyzer.py`) are unrelated to this surface.
