### PR TITLE
fix(cli): write concatenated multi-skill report to --output for non-JSON formats

### DIFF
--- a/src/skillspector/cli.py
+++ b/src/skillspector/cli.py
@@ -139,15 +139,17 @@ def _scan_state(
     return state
 
 
+def _result_body(result: dict) -> str:
+    return result.get("report_body") or json.dumps(result.get("sarif_report"), indent=2) or ""
+
+
 def _write_result(
     result: dict[str, object],
     output: Path | None,
     format: FormatChoice,
 ) -> None:
     """Write report_body to file or stdout. Uses sarif_report if report_body missing."""
-    report_body = result.get("report_body") or ""
-    if not report_body and result.get("sarif_report") is not None:
-        report_body = json.dumps(result["sarif_report"], indent=2)
+    report_body = _result_body(result)
     if output:
         Path(output).write_text(report_body, encoding="utf-8")
         if format == FormatChoice.terminal:
@@ -429,9 +431,13 @@ def _scan_multi_skill(
         Path(output).write_text(json.dumps(combined, indent=2), encoding="utf-8")
         console.print(f"[green]Combined report saved to:[/green] {output}")
     elif output:
-        for _skill, result in zip(skills, results, strict=True):
+        # concatenated non-JSON output: not merged SARIF
+        sections = []
+        for skill, result in zip(skills, results, strict=True):
             if "error" not in result:
-                _write_result(result, None, format)
+                sections.append(f"--- {skill.relative_path} ---\n\n{_result_body(result)}")
+        Path(output).write_text("\n\n".join(sections), encoding="utf-8")
+        console.print(f"[green]Combined report saved to:[/green] {output}")
 
     if max_score > 50:
         raise typer.Exit(code=1)

--- a/src/skillspector/cli.py
+++ b/src/skillspector/cli.py
@@ -140,7 +140,10 @@ def _scan_state(
 
 
 def _result_body(result: dict) -> str:
-    return result.get("report_body") or json.dumps(result.get("sarif_report"), indent=2) or ""
+    report_body = result.get("report_body") or ""
+    if not report_body and result.get("sarif_report") is not None:
+        report_body = json.dumps(result["sarif_report"], indent=2)
+    return report_body
 
 
 def _write_result(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -17,10 +17,13 @@
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
+import pytest
 from typer.testing import CliRunner
 
-from skillspector.cli import app
+from skillspector.cli import FormatChoice, _scan_multi_skill, app
+from skillspector.multi_skill import MultiSkillDetectionResult, SkillDirectory
 
 runner = CliRunner()
 
@@ -113,3 +116,76 @@ def test_cli_baseline_generate_then_scan_round_trip(tmp_path: Path) -> None:
     data = json.loads(scan.output)
     assert data["issues"] == []
     assert data["risk_assessment"]["score"] == 0
+
+
+def test_scan_multi_skill_markdown_output_to_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """Non-JSON recursive scan writes concatenated report to file, not stdout."""
+    s1 = SkillDirectory(path=tmp_path / "skill1", name="skill1", relative_path="skill1")
+    s2 = SkillDirectory(path=tmp_path / "skill2", name="skill2", relative_path="skill2")
+    detection = MultiSkillDetectionResult(
+        is_multi_skill=True, skills=[s1, s2], has_root_skill=False
+    )
+
+    result1 = {
+        "report_body": "# Report ALPHA for skill1",
+        "risk_score": 10,
+        "risk_severity": "LOW",
+        "findings": [],
+    }
+    result2 = {
+        "report_body": "# Report BETA for skill2",
+        "risk_score": 10,
+        "risk_severity": "LOW",
+        "findings": [],
+    }
+    out = tmp_path / "report.md"
+
+    with patch("skillspector.cli.graph.invoke", side_effect=[result1, result2]):
+        _scan_multi_skill(
+            detection, FormatChoice.markdown, out, no_llm=True, yara_rules_dir=None, verbose=False
+        )
+
+    assert out.exists()
+    text = out.read_text()
+    assert "ALPHA" in text
+    assert "BETA" in text
+    assert "---" in text
+
+    captured = capsys.readouterr()
+    assert "ALPHA" not in captured.out
+    assert "BETA" not in captured.out
+
+
+def test_scan_multi_skill_json_output_unchanged(tmp_path: Path) -> None:
+    """JSON recursive scan still produces a valid combined JSON file."""
+    s1 = SkillDirectory(path=tmp_path / "skill1", name="skill1", relative_path="skill1")
+    s2 = SkillDirectory(path=tmp_path / "skill2", name="skill2", relative_path="skill2")
+    detection = MultiSkillDetectionResult(
+        is_multi_skill=True, skills=[s1, s2], has_root_skill=False
+    )
+
+    result1 = {
+        "report_body": "# Report ALPHA for skill1",
+        "risk_score": 10,
+        "risk_severity": "LOW",
+        "findings": [],
+    }
+    result2 = {
+        "report_body": "# Report BETA for skill2",
+        "risk_score": 10,
+        "risk_severity": "LOW",
+        "findings": [],
+    }
+    out = tmp_path / "combined.json"
+
+    with patch("skillspector.cli.graph.invoke", side_effect=[result1, result2]):
+        _scan_multi_skill(
+            detection, FormatChoice.json, out, no_llm=True, yara_rules_dir=None, verbose=False
+        )
+
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert data["multi_skill"] is True
+    assert "skills" in data


### PR DESCRIPTION
## Summary

`skillspector scan ./skills/ --recursive --format markdown --output report.md` prints to stdout instead of writing `report.md`. The JSON recursive path and single-skill mode both write the file correctly; only the recursive + non-JSON combination silently ignores `--output`.

Closes #203

## Root cause

`_scan_multi_skill()` (`cli.py:434-437`) passes `None` instead of `output` to `_write_result()`, so `_write_result()` routes to stdout unconditionally. A naive `None → output` substitution would also fail: `_write_result` calls `Path(output).write_text(...)` per skill, truncating the file on each call and leaving only the last skill's report.

## Diff Notes

- `src/skillspector/cli.py`: add private `_result_body()` helper (extracts `report_body` or SARIF fallback); refactor `_write_result` body resolution to use it (no behavior change); rewrite `cli.py:434-437` to concatenate per-skill bodies with `--- {skill.relative_path} ---` separators and write once via `Path(output).write_text()`; file is always created when `-o` is given. JSON branch (lines 410-433) and single-skill path (line 321) untouched.
- `tests/unit/test_cli.py`: two new tests — one asserts the file is created with both skills' content and stdout is not the destination; one locks the JSON branch behavior.

## Scope

No change to the JSON multi-skill branch, single-skill path, `_scan_multi_skill()` signature, or summary-table stdout output. No new dependencies. Concatenated non-JSON output is not valid SARIF; this matches the issue's Option 1 scope.

## Before / After

| Invocation | Before | After |
|-----------|--------|-------|
| `scan ./skills/ --recursive --format markdown --output report.md` | `report.md` not created; output to stdout | `report.md` written with per-skill sections |
| `scan ./skills/ --recursive --format json --output combined.json` | `combined.json` written (unchanged) | `combined.json` written (unchanged) |
| `scan ./skill --format markdown --output report.md` | `report.md` written (unchanged) | `report.md` written (unchanged) |

## Verification

- [x] `.\.venv\Scripts\python.exe -m pytest tests/unit/test_cli.py -v` — **9 passed**, 0 failed (7 pre-existing + 2 new)
- [x] `uv run ruff check src/skillspector/cli.py tests/unit/test_cli.py` — exit 0
- [x] `uv run ruff format --check src/skillspector/cli.py tests/unit/test_cli.py` — 2 files already formatted, exit 0
- [ ] CI `Lint & Test (Python 3.12)`, `Lint & Test (Python 3.13)`, and `DCO Check` — pending maintainer approval if fork checks are gated

## Notes

DCO sign-off required on every commit (`git commit -s`). Known existing failures (`tests/nodes/test_meta_analyzer.py`) are unrelated to this surface.
