### PR TITLE
feat(analyzer): add phase-1 structured skill summaries

### DIFF
--- a/src/skillspector/multi_skill.py
+++ b/src/skillspector/multi_skill.py
@@ -32,6 +32,7 @@ from skillspector.input_handler import (
     validate_local_input_path,
 )
 from skillspector.logging_config import get_logger
+from skillspector.structured_skill import extract_structured_skill_context
 
 logger = get_logger(__name__)
 
@@ -83,7 +84,7 @@ def detect_skills(directory: Path) -> MultiSkillDetectionResult:
             continue
         if child.name.startswith("."):
             continue
-        if _has_skill_md(child):
+        if _has_skill_md(child) or _is_structured_skill_bundle(child):
             name = _extract_skill_name(child)
             skills.append(
                 SkillDirectory(
@@ -99,6 +100,11 @@ def detect_skills(directory: Path) -> MultiSkillDetectionResult:
         skills=skills,
         has_root_skill=False,
     )
+
+
+def _is_structured_skill_bundle(child_dir: Path) -> bool:
+    """Return true when a child directory contains a valid AISOP/AISP bundle."""
+    return extract_structured_skill_context(child_dir) is not None
 
 
 def _has_skill_md(directory: Path) -> bool:

--- a/src/skillspector/multi_skill.py
+++ b/src/skillspector/multi_skill.py
@@ -32,7 +32,7 @@ from skillspector.input_handler import (
     validate_local_input_path,
 )
 from skillspector.logging_config import get_logger
-from skillspector.structured_skill import extract_structured_skill_context
+from skillspector.structured_skill import _SKIP_DIRS, extract_structured_skill_context
 
 logger = get_logger(__name__)
 
@@ -81,6 +81,8 @@ def detect_skills(directory: Path) -> MultiSkillDetectionResult:
     skills: list[SkillDirectory] = []
     for child in sorted(directory.iterdir()):
         if _is_link_or_junction(child) or not child.is_dir():
+            continue
+        if child.name in _SKIP_DIRS:
             continue
         if child.name.startswith("."):
             continue

--- a/src/skillspector/nodes/analyzers/__init__.py
+++ b/src/skillspector/nodes/analyzers/__init__.py
@@ -79,6 +79,9 @@ from skillspector.nodes.analyzers.static_patterns_tool_misuse import (
     node as static_patterns_tool_misuse_node,
 )
 from skillspector.nodes.analyzers.static_yara import node as static_yara_node
+from skillspector.nodes.analyzers.structured_skill_roles import (
+    node as structured_skill_roles_node,
+)
 
 ANALYZER_NODE_IDS: list[str] = [
     "static_patterns_prompt_injection",
@@ -102,6 +105,7 @@ ANALYZER_NODE_IDS: list[str] = [
     "mcp_least_privilege",
     "mcp_tool_poisoning",
     "mcp_rug_pull",
+    "structured_skill_roles",
     "semantic_security_discovery",
     "semantic_developer_intent",
     "semantic_quality_policy",
@@ -129,6 +133,7 @@ ANALYZER_NODES = {
     "mcp_least_privilege": mcp_least_privilege_node,
     "mcp_tool_poisoning": mcp_tool_poisoning_node,
     "mcp_rug_pull": mcp_rug_pull_node,
+    "structured_skill_roles": structured_skill_roles_node,
     "semantic_security_discovery": semantic_security_discovery_node,
     "semantic_developer_intent": semantic_developer_intent_node,
     "semantic_quality_policy": semantic_quality_policy_node,

--- a/src/skillspector/nodes/analyzers/structured_skill_roles.py
+++ b/src/skillspector/nodes/analyzers/structured_skill_roles.py
@@ -17,59 +17,46 @@
 
 from __future__ import annotations
 
-from skillspector.models import Finding
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 ANALYZER_ID = "structured_skill_roles"
 
 
-def _build_finding(context: dict[str, object]) -> Finding:
-    """Build a single SSR-1 finding from validated structured-skill context."""
+def _string_list(value: object) -> list[str]:
+    """Return a compact list of string values for summary payload fields."""
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _build_summary(context: dict[str, object]) -> dict[str, object]:
+    """Build a single SSR-1 structured summary from validated context."""
     protocol = str(context.get("protocol", "AISOP/AISP"))
     layout_kind = str(context.get("layout_kind", "structured"))
     bundle_path = str(context.get("bundle_path", ""))
-    tools = context.get("declared_tools") or []
-    tools_text = ", ".join(sorted(str(t) for t in tools)) if isinstance(tools, list) else ""
-    if not tools_text:
-        tools_text = "(no declared tools)"
+    declared_tools = sorted(_string_list(context.get("declared_tools")))
+    workflow_nodes = _string_list(context.get("workflow_nodes"))
+    constraints = _string_list(context.get("constraint_anchors"))
+    resources = _string_list(context.get("resource_anchors"))
 
-    workflow_nodes = context.get("workflow_nodes") or []
-    workflow_text = ", ".join(str(n) for n in workflow_nodes) if workflow_nodes else "(none)"
-
-    constraints = context.get("constraint_anchors") or []
-    constraints_text = ", ".join(str(c) for c in constraints) if constraints else "(none)"
-
-    resources = context.get("resource_anchors") or []
-    resources_text = ", ".join(str(r) for r in resources) if resources else "(none)"
-
-    return Finding(
-        rule_id="SSR-1",
-        message=f"Structured {layout_kind} bundle detected ({protocol})",
-        severity="LOW",
-        confidence=1.0,
-        file=bundle_path,
-        tags=["AISOP", "AISP", "structured-skill"],
-        context=(
-            "Detected structured AISOP/AISP workflow for scan context. "
-            f"declared_tools=[{tools_text}], workflow_nodes=[{workflow_text}], "
-            f"constraints=[{constraints_text}], resources=[{resources_text}]"
-        ),
-        matched_text=(
-            f"layout_kind={layout_kind}, protocol={protocol}, "
-            f"bundle={bundle_path}, declared_tools={tools_text}"
-        ),
-        explanation=(
-            "This scan target appears to define a structured AISOP/AISP workflow. "
-            "The detector found a valid two-message AISOP/AISP contract and summarized "
-            "workflow roles, declared tool set, constraints, and resource anchors."
-        ),
-    )
+    return {
+        "id": "SSR-1",
+        "message": f"Structured {layout_kind} bundle detected ({protocol})",
+        "file": bundle_path,
+        "protocol": protocol,
+        "layout_kind": layout_kind,
+        "declared_tools": declared_tools,
+        "workflow_nodes": workflow_nodes,
+        "constraints": constraints,
+        "resources": resources,
+        "tags": ["AISOP", "AISP", "structured-skill"],
+    }
 
 
 def node(state: SkillspectorState) -> AnalyzerNodeResponse:
-    """Emit one LOW SSR-1 summary finding when structured context is present."""
+    """Emit one SSR-1 structured summary when structured context is present."""
     context = state.get("structured_skill_context")
     if not isinstance(context, dict):
         return {"findings": []}
 
-    return {"findings": [_build_finding(context)]}
+    return {"findings": [], "structured_summaries": [_build_summary(context)]}

--- a/src/skillspector/nodes/analyzers/structured_skill_roles.py
+++ b/src/skillspector/nodes/analyzers/structured_skill_roles.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structured skill role summary analyzer (SSR-*)."""
+
+from __future__ import annotations
+
+from skillspector.models import Finding
+from skillspector.state import AnalyzerNodeResponse, SkillspectorState
+
+ANALYZER_ID = "structured_skill_roles"
+
+
+def _build_finding(context: dict[str, object]) -> Finding:
+    """Build a single SSR-1 finding from validated structured-skill context."""
+    protocol = str(context.get("protocol", "AISOP/AISP"))
+    layout_kind = str(context.get("layout_kind", "structured"))
+    bundle_path = str(context.get("bundle_path", ""))
+    tools = context.get("declared_tools") or []
+    tools_text = ", ".join(sorted(str(t) for t in tools)) if isinstance(tools, list) else ""
+    if not tools_text:
+        tools_text = "(no declared tools)"
+
+    workflow_nodes = context.get("workflow_nodes") or []
+    workflow_text = ", ".join(str(n) for n in workflow_nodes) if workflow_nodes else "(none)"
+
+    constraints = context.get("constraint_anchors") or []
+    constraints_text = ", ".join(str(c) for c in constraints) if constraints else "(none)"
+
+    resources = context.get("resource_anchors") or []
+    resources_text = ", ".join(str(r) for r in resources) if resources else "(none)"
+
+    return Finding(
+        rule_id="SSR-1",
+        message=f"Structured {layout_kind} bundle detected ({protocol})",
+        severity="LOW",
+        confidence=1.0,
+        file=bundle_path,
+        tags=["AISOP", "AISP", "structured-skill"],
+        context=(
+            "Detected structured AISOP/AISP workflow for scan context. "
+            f"declared_tools=[{tools_text}], workflow_nodes=[{workflow_text}], "
+            f"constraints=[{constraints_text}], resources=[{resources_text}]"
+        ),
+        matched_text=(
+            f"layout_kind={layout_kind}, protocol={protocol}, "
+            f"bundle={bundle_path}, declared_tools={tools_text}"
+        ),
+        explanation=(
+            "This scan target appears to define a structured AISOP/AISP workflow. "
+            "The detector found a valid two-message AISOP/AISP contract and summarized "
+            "workflow roles, declared tool set, constraints, and resource anchors."
+        ),
+    )
+
+
+def node(state: SkillspectorState) -> AnalyzerNodeResponse:
+    """Emit one LOW SSR-1 summary finding when structured context is present."""
+    context = state.get("structured_skill_context")
+    if not isinstance(context, dict):
+        return {"findings": []}
+
+    return {"findings": [_build_finding(context)]}

--- a/src/skillspector/nodes/build_context.py
+++ b/src/skillspector/nodes/build_context.py
@@ -48,6 +48,7 @@ from skillspector.inspection_ledger import (
 from skillspector.logging_config import get_logger
 from skillspector.python_ast import prewarm_python_ast_cache
 from skillspector.state import SkillspectorState
+from skillspector.structured_skill import extract_structured_skill_context
 
 logger = get_logger(__name__)
 
@@ -579,8 +580,9 @@ def build_context(state: SkillspectorState) -> dict[str, object]:
     component_metadata, has_executable_scripts = _build_component_metadata(
         skill_dir, metadata_components, file_cache, recognized_oms_signatures
     )
+    structured_skill_context = extract_structured_skill_context(skill_dir)
 
-    return {
+    result = {
         "components": components,
         "file_cache": file_cache,
         "inspection_ledger": [
@@ -597,3 +599,8 @@ def build_context(state: SkillspectorState) -> dict[str, object]:
         "component_metadata": component_metadata,
         "has_executable_scripts": has_executable_scripts,
     }
+
+    if structured_skill_context is not None:
+        result["structured_skill_context"] = structured_skill_context
+
+    return result

--- a/src/skillspector/nodes/report.py
+++ b/src/skillspector/nodes/report.py
@@ -136,6 +136,24 @@ def _build_sarif_properties(finding: Finding) -> dict[str, object] | None:
     return cleaned or None
 
 
+def _sanitize_summary_value(value: object) -> object:
+    """Return a recursively sanitized copy of structured-summary content."""
+    if isinstance(value, str):
+        return _clean_text(value)
+    if isinstance(value, list):
+        return [_sanitize_summary_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_sanitize_summary_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _sanitize_summary_value(item) for key, item in value.items()}
+    return value
+
+
+def _sanitize_structured_summary(summary: dict[str, object]) -> dict[str, object]:
+    """Return a structured summary with control/ANSI bytes stripped from text fields."""
+    return {str(key): _sanitize_summary_value(value) for key, value in summary.items()}
+
+
 def _severity_to_sarif_level(severity: str) -> Literal["error", "warning", "note"]:
     """Map Finding.severity to SARIF result level."""
     return {
@@ -144,6 +162,36 @@ def _severity_to_sarif_level(severity: str) -> Literal["error", "warning", "note
         "MEDIUM": "warning",
         "LOW": "note",
     }.get(severity.upper(), "note")  # type: ignore[return-value]
+
+
+def _summary_display_value(value: object) -> str | None:
+    """Format a summary field for terminal / markdown output."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        values = [str(item) for item in value if str(item)]
+        return ", ".join(values) if values else None
+    text = str(value)
+    return text or None
+
+
+def _structured_summary_notification(summary: dict[str, object]) -> str:
+    """Build a note-level SARIF notification message for a structured summary."""
+    summary_id = str(summary.get("id") or "SSR")
+    message = str(summary.get("message") or "Structured skill summary")
+    bits = [f"{summary_id}: {message}"]
+
+    file = _summary_display_value(summary.get("file"))
+    if file:
+        bits.append(f"file={file}")
+    protocol = _summary_display_value(summary.get("protocol"))
+    if protocol:
+        bits.append(f"protocol={protocol}")
+    layout_kind = _summary_display_value(summary.get("layout_kind"))
+    if layout_kind:
+        bits.append(f"layout={layout_kind}")
+
+    return " | ".join(bits)
 
 
 _SEVERITY_POINTS: dict[str, int] = {
@@ -250,6 +298,7 @@ def _build_sarif(
     degraded_notice: str | None = None,
     analysis_completeness: Mapping[str, object] | None = None,
     execution_successful: bool = True,
+    structured_summaries: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
     """Build one SARIF invocation with canonical inspection notifications."""
     results: list[SarifResult] = []
@@ -316,6 +365,14 @@ def _build_sarif(
 
     notifications: list[SarifNotification] = []
     completeness = analysis_completeness or {}
+    for summary in structured_summaries or []:
+        notifications.append(
+            SarifNotification(
+                message=SarifMessage(text=_structured_summary_notification(summary)),
+                level="note",
+                properties={"kind": "structured_summary"},
+            )
+        )
 
     def notification_from_exception(
         exception: Mapping[str, object], level: Literal["error", "warning", "note"]
@@ -474,6 +531,7 @@ def _format_terminal(
     use_llm: bool = True,
     llm_call_log: Sequence[Mapping[str, object]] | None = None,
     suppressed: list[SuppressedFinding] | None = None,
+    structured_summaries: list[dict[str, object]] | None = None,
     show_suppressed: bool = False,
     analysis_completeness: Mapping[str, object] | None = None,
     execution_successful: bool = True,
@@ -561,6 +619,30 @@ def _format_terminal(
             console.print()
     else:
         console.print("\n[green]No security issues detected.[/green]\n")
+
+    if structured_summaries:
+        console.print("\n")
+        console.print(f"[bold]Structured Skill Summary ({len(structured_summaries)})[/bold]\n")
+        for summary in structured_summaries:
+            console.print(
+                f"  [cyan]{summary.get('id', 'SSR-1')}[/cyan]: {summary.get('message', '')}"
+            )
+            file = _summary_display_value(summary.get("file"))
+            if file:
+                console.print(f"    [dim]File:[/dim] {file}")
+            for key, label in (
+                ("protocol", "Protocol"),
+                ("layout_kind", "Layout"),
+                ("declared_tools", "Declared tools"),
+                ("workflow_nodes", "Workflow nodes"),
+                ("constraints", "Constraints"),
+                ("resources", "Resources"),
+                ("tags", "Tags"),
+            ):
+                value = _summary_display_value(summary.get(key))
+                if value:
+                    console.print(f"    [dim]{label}:[/dim] {value}")
+            console.print()
 
     if suppressed:
         console.print(
@@ -675,6 +757,7 @@ def _format_json(
     analysis_completeness: Mapping[str, object] | None = None,
     suppressed: list[SuppressedFinding] | None = None,
     execution_successful: bool = True,
+    structured_summaries: list[dict[str, object]] | None = None,
 ) -> str:
     """Generate JSON report string."""
     suppressed = suppressed or []
@@ -700,6 +783,7 @@ def _format_json(
             }
             for c in component_metadata
         ],
+        "structured_summaries": structured_summaries or [],
         "issues": [f.to_dict() for f in findings],
         "suppressed_count": len(suppressed),
         "suppressed": [sf.to_dict() for sf in suppressed],
@@ -786,6 +870,7 @@ def _format_markdown(
     use_llm: bool = True,
     llm_call_log: Sequence[Mapping[str, object]] | None = None,
     suppressed: list[SuppressedFinding] | None = None,
+    structured_summaries: list[dict[str, object]] | None = None,
     show_suppressed: bool = False,
     analysis_completeness: Mapping[str, object] | None = None,
     execution_successful: bool = True,
@@ -826,6 +911,28 @@ def _format_markdown(
         exec_marker = "Yes" if exec_flag else "No"
         lines.append(f"| `{path}` | {typ} | {line_count} | {exec_marker} |")
     lines.append("")
+
+    if structured_summaries:
+        lines.append(f"## Structured Skill Summary ({len(structured_summaries)})\n")
+        for summary in structured_summaries:
+            lines.append(f"### {summary.get('id', 'SSR-1')}\n")
+            lines.append(f"**Message:** {summary.get('message', '')}  ")
+            file = _summary_display_value(summary.get("file"))
+            if file:
+                lines.append(f"**File:** `{file}`  ")
+            for key, label in (
+                ("protocol", "Protocol"),
+                ("layout_kind", "Layout"),
+                ("declared_tools", "Declared tools"),
+                ("workflow_nodes", "Workflow nodes"),
+                ("constraints", "Constraints"),
+                ("resources", "Resources"),
+                ("tags", "Tags"),
+            ):
+                value = _summary_display_value(summary.get(key))
+                if value:
+                    lines.append(f"**{label}:** {value}  ")
+            lines.append("")
 
     lines.append(f"## Issues ({len(findings)})\n")
     if not findings:
@@ -891,6 +998,13 @@ def report(state: SkillspectorState) -> dict[str, object]:
         # `effective_finding_ids` from finalize_inspection_ledger.
         selected_findings = state.get("filtered_findings", raw_findings)
     selected_findings = [_sanitize_finding(finding) for finding in selected_findings]
+
+    raw_structured_summaries = state.get("structured_summaries") or []
+    structured_summaries = [
+        _sanitize_structured_summary(summary)
+        for summary in raw_structured_summaries
+        if isinstance(summary, dict)
+    ]
 
     empty_completeness: AnalysisCompleteness = {
         "total_components": 0,
@@ -966,6 +1080,7 @@ def report(state: SkillspectorState) -> dict[str, object]:
         degraded_notice=degraded_notice,
         analysis_completeness=analysis_completeness,
         execution_successful=execution_successful,
+        structured_summaries=structured_summaries,
     )
     if output_format == "terminal":
         report_body = _format_terminal(
@@ -980,6 +1095,7 @@ def report(state: SkillspectorState) -> dict[str, object]:
             use_llm=use_llm,
             llm_call_log=llm_call_log,
             suppressed=suppressed,
+            structured_summaries=structured_summaries,
             show_suppressed=show_suppressed,
             analysis_completeness=analysis_completeness,
             execution_successful=execution_successful,
@@ -1000,6 +1116,7 @@ def report(state: SkillspectorState) -> dict[str, object]:
             analysis_completeness=analysis_completeness,
             suppressed=suppressed,
             execution_successful=execution_successful,
+            structured_summaries=structured_summaries,
         )
     elif output_format == "markdown":
         report_body = _format_markdown(
@@ -1014,6 +1131,7 @@ def report(state: SkillspectorState) -> dict[str, object]:
             use_llm=use_llm,
             llm_call_log=llm_call_log,
             suppressed=suppressed,
+            structured_summaries=structured_summaries,
             show_suppressed=show_suppressed,
             analysis_completeness=analysis_completeness,
             execution_successful=execution_successful,
@@ -1036,4 +1154,5 @@ def report(state: SkillspectorState) -> dict[str, object]:
         "filtered_findings": selected_findings,
         "suppressed_findings": suppressed,
         "execution_successful": execution_successful,
+        "structured_summaries": structured_summaries,
     }

--- a/src/skillspector/nodes/report.py
+++ b/src/skillspector/nodes/report.py
@@ -1154,5 +1154,4 @@ def report(state: SkillspectorState) -> dict[str, object]:
         "filtered_findings": selected_findings,
         "suppressed_findings": suppressed,
         "execution_successful": execution_successful,
-        "structured_summaries": structured_summaries,
     }

--- a/src/skillspector/state.py
+++ b/src/skillspector/state.py
@@ -112,6 +112,8 @@ class SkillspectorState(TypedDict, total=False):
     # Component metadata for reporting and risk scoring (from build_context)
     component_metadata: list[dict[str, object]]
     has_executable_scripts: bool
+    # Structured workflow context for phase-1 AISOP/AISP summaries
+    structured_skill_context: dict[str, object]
 
     # Output: report node writes formatted string here
     output_format: str

--- a/src/skillspector/state.py
+++ b/src/skillspector/state.py
@@ -114,6 +114,8 @@ class SkillspectorState(TypedDict, total=False):
     has_executable_scripts: bool
     # Structured workflow context for phase-1 AISOP/AISP summaries
     structured_skill_context: dict[str, object]
+    # Report-only structured skill summaries emitted outside the finding pipeline
+    structured_summaries: Annotated[list[dict[str, object]], operator.add]
 
     # Output: report node writes formatted string here
     output_format: str
@@ -160,6 +162,7 @@ class AnalyzerNodeResponse(TypedDict):
     findings: list[Finding]
     inspection_ledger: NotRequired[list[InspectionLedgerEvent]]
     analyzer_status_events: NotRequired[list[AnalyzerStatusEvent]]
+    structured_summaries: NotRequired[list[dict[str, object]]]
     # LLM-backed analyzers also report one telemetry record; static analyzers
     # omit it (NotRequired keeps the key optional for them).
     llm_call_log: NotRequired[list[LLMCallRecord]]

--- a/src/skillspector/structured_skill.py
+++ b/src/skillspector/structured_skill.py
@@ -153,10 +153,11 @@ def _first_non_empty(values: tuple[object, ...]) -> list[str]:
     return result
 
 
-def _extract_function_names(functions: object) -> list[str]:
+def _extract_function_names(functions: object, seen: set[str] | None = None) -> list[str]:
     """Extract function names from a dictionary/list of workflow nodes."""
     names: list[str] = []
-    seen: set[str] = set()
+    if seen is None:
+        seen = set()
 
     if isinstance(functions, dict):
         items = functions.items()
@@ -167,7 +168,7 @@ def _extract_function_names(functions: object) -> list[str]:
                     seen.add(n)
                     names.append(n)
             if isinstance(node, dict):
-                names.extend(_extract_function_names(node.get("functions")))
+                names.extend(_extract_function_names(node.get("functions"), seen))
     elif isinstance(functions, list):
         for item in functions:
             if not isinstance(item, dict):
@@ -178,7 +179,7 @@ def _extract_function_names(functions: object) -> list[str]:
                 if n and n not in seen:
                     seen.add(n)
                     names.append(n)
-            names.extend(_extract_function_names(item.get("functions")))
+            names.extend(_extract_function_names(item.get("functions"), seen))
 
     return names
 

--- a/src/skillspector/structured_skill.py
+++ b/src/skillspector/structured_skill.py
@@ -25,6 +25,7 @@ _SKIP_DIRS = frozenset(
 )
 
 _AISOP_PROTOCOL_PREFIXES = ("AISOP V", "AISP V")
+_MAX_BUNDLE_NESTING = 128
 
 
 def extract_structured_skill_context(skill_dir: Path) -> dict[str, object] | None:
@@ -58,9 +59,9 @@ def _parse_bundle_path(bundle_path: Path) -> dict[str, object] | None:
     """Parse and validate one AISOP/AISP bundle path."""
     try:
         data = json.loads(bundle_path.read_text(encoding="utf-8", errors="replace"))
-    except (OSError, json.JSONDecodeError):
+        return _parse_bundle_payload(bundle_path, data)
+    except (OSError, json.JSONDecodeError, RecursionError, ValueError):
         return None
-    return _parse_bundle_payload(bundle_path, data)
 
 
 def _parse_bundle_payload(bundle_path: Path, payload: object) -> dict[str, object] | None:
@@ -157,8 +158,11 @@ def _first_non_empty(values: tuple[object, ...]) -> list[str]:
     return result
 
 
-def _extract_function_names(functions: object, seen: set[str] | None = None) -> list[str]:
+def _extract_function_names(
+    functions: object, seen: set[str] | None = None, depth: int = 0
+) -> list[str]:
     """Extract function names from a dictionary/list of workflow nodes."""
+    _ensure_supported_nesting(depth)
     names: list[str] = []
     if seen is None:
         seen = set()
@@ -172,7 +176,7 @@ def _extract_function_names(functions: object, seen: set[str] | None = None) -> 
                     seen.add(n)
                     names.append(n)
             if isinstance(node, dict):
-                names.extend(_extract_function_names(node.get("functions"), seen))
+                names.extend(_extract_function_names(node.get("functions"), seen, depth + 1))
     elif isinstance(functions, list):
         for item in functions:
             if not isinstance(item, dict):
@@ -183,7 +187,7 @@ def _extract_function_names(functions: object, seen: set[str] | None = None) -> 
                 if n and n not in seen:
                     seen.add(n)
                     names.append(n)
-            names.extend(_extract_function_names(item.get("functions"), seen))
+            names.extend(_extract_function_names(item.get("functions"), seen, depth + 1))
 
     return names
 
@@ -206,7 +210,8 @@ def _extract_constraint_anchors(functions: object) -> list[str]:
             seen.add(anchor)
             anchors.append(anchor)
 
-    def _walk(nodes: object) -> None:
+    def _walk(nodes: object, depth: int = 0) -> None:
+        _ensure_supported_nesting(depth)
         if isinstance(nodes, dict):
             for maybe_node in nodes.values():
                 if isinstance(maybe_node, dict):
@@ -214,9 +219,9 @@ def _extract_constraint_anchors(functions: object) -> list[str]:
                     if isinstance(constraints, list):
                         for constraint in constraints:
                             _collect(constraint)
-                    _walk(maybe_node.get("functions"))
+                    _walk(maybe_node.get("functions"), depth + 1)
                 elif isinstance(maybe_node, list):
-                    _walk(maybe_node)
+                    _walk(maybe_node, depth + 1)
         elif isinstance(nodes, list):
             for item in nodes:
                 if isinstance(item, dict):
@@ -224,7 +229,7 @@ def _extract_constraint_anchors(functions: object) -> list[str]:
                     if isinstance(constraints, list):
                         for constraint in constraints:
                             _collect(constraint)
-                    _walk(item.get("functions"))
+                    _walk(item.get("functions"), depth + 1)
 
     _walk(functions)
     return anchors
@@ -241,14 +246,15 @@ def _extract_resource_anchors(resources: object) -> list[str]:
             seen.add(p)
             paths.append(p)
 
-    def _walk(value: object) -> None:
+    def _walk(value: object, depth: int = 0) -> None:
+        _ensure_supported_nesting(depth)
         if isinstance(value, dict):
             for val in value.values():
                 if isinstance(val, dict):
                     resource_path = val.get("path")
                     if isinstance(resource_path, str):
                         _collect(resource_path)
-                    _walk(val.get("resources"))
+                    _walk(val.get("resources"), depth + 1)
                 elif isinstance(val, str):
                     _collect(val)
         elif isinstance(value, list):
@@ -259,7 +265,13 @@ def _extract_resource_anchors(resources: object) -> list[str]:
                     resource_path = item.get("path")
                     if isinstance(resource_path, str):
                         _collect(resource_path)
-                    _walk(item.get("resources"))
+                    _walk(item.get("resources"), depth + 1)
 
     _walk(resources)
     return paths
+
+
+def _ensure_supported_nesting(depth: int) -> None:
+    """Reject bundles whose nested workflow metadata exceeds the supported depth."""
+    if depth > _MAX_BUNDLE_NESTING:
+        raise ValueError("structured bundle nesting exceeds supported depth")

--- a/src/skillspector/structured_skill.py
+++ b/src/skillspector/structured_skill.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structured AISOP/AISP bundle detection helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_SKIP_DIRS = frozenset(
+    {".git", "__pycache__", "node_modules", ".venv", "venv", ".tox", ".pytest_cache"}
+)
+
+_AISOP_PROTOCOL_PREFIXES = ("AISOP V", "AISP V")
+
+
+def extract_structured_skill_context(skill_dir: Path) -> dict[str, object] | None:
+    """Return structured-skill context for the first valid bundle under *skill_dir*."""
+    if not skill_dir.is_dir():
+        return None
+
+    for path in _iter_aisop_files(skill_dir):
+        context = _parse_bundle_path(path)
+        if context is not None:
+            return context
+
+    return None
+
+
+def _iter_aisop_files(skill_dir: Path) -> list[Path]:
+    """Yield candidate *.aisop.json files under a directory, skipping noisy paths."""
+    files: list[Path] = []
+    for path in sorted(skill_dir.rglob("*.aisop.json")):
+        if any(part in _SKIP_DIRS for part in path.parts):
+            continue
+        if any(part.startswith(".") and part != ".aisop" for part in path.parts[:-1]):
+            # Keep hidden metadata directories out of structured-skill detection.
+            continue
+        if path.is_file():
+            files.append(path)
+    return files
+
+
+def _parse_bundle_path(bundle_path: Path) -> dict[str, object] | None:
+    """Parse and validate one AISOP/AISP bundle path."""
+    try:
+        data = json.loads(bundle_path.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return _parse_bundle_payload(bundle_path, data)
+
+
+def _parse_bundle_payload(bundle_path: Path, payload: object) -> dict[str, object] | None:
+    """Parse the minimal phase-1 AISOP/AISP payload contract."""
+    if not isinstance(payload, list) or len(payload) != 2:
+        return None
+
+    system_msg = _normalize_mapping(payload[0])
+    user_msg = _normalize_mapping(payload[1])
+    if system_msg is None or user_msg is None:
+        return None
+
+    system_content = _normalize_mapping(system_msg.get("content"))
+    if system_content is None:
+        return None
+
+    protocol = system_content.get("protocol")
+    if not isinstance(protocol, str) or not protocol.startswith(_AISOP_PROTOCOL_PREFIXES):
+        return None
+    if system_msg.get("role") != "system":
+        return None
+
+    user_content = user_msg.get("content")
+    contract = _find_contract_payload(user_content)
+    if contract is None:
+        return None
+
+    if user_msg.get("role") != "user":
+        return None
+
+    layout_kind = protocol.split()[0]
+    declared_tools = _first_non_empty(
+        (
+            system_content.get("declared_tools"),
+            system_content.get("tools"),
+            contract.get("declared_tools"),
+            contract.get("tools"),
+        )
+    )
+    functions = contract.get("functions")
+    function_names = _extract_function_names(functions)
+    constraint_anchors = _extract_constraint_anchors(functions)
+    resource_anchors = _extract_resource_anchors(contract.get("resources"))
+
+    return {
+        "layout_kind": layout_kind,
+        "format": system_content.get("format", layout_kind),
+        "protocol": protocol,
+        "bundle_path": str(bundle_path.resolve()),
+        "declared_tools": declared_tools,
+        "workflow_nodes": function_names,
+        "constraint_anchors": constraint_anchors,
+        "resource_anchors": resource_anchors,
+    }
+
+
+def _normalize_mapping(value: object) -> dict[str, object] | None:
+    """Return a dict if *value* is a mapping object."""
+    return value if isinstance(value, dict) else None
+
+
+def _find_contract_payload(content: object) -> dict[str, object] | None:
+    """Locate the AISOP/AISP contract payload in a user message."""
+    container = _normalize_mapping(content)
+    if container is None:
+        return None
+
+    for key in ("aisop", "aisp_contract"):
+        value = container.get(key)
+        if isinstance(value, dict):
+            return value
+    return None
+
+
+def _first_non_empty(values: tuple[object, ...]) -> list[str]:
+    """Return a stable deduplicated string list from candidate values."""
+    result: list[str] = []
+    seen = set[str]()
+    for value in values:
+        if not isinstance(value, list):
+            continue
+        for item in value:
+            if not isinstance(item, str):
+                continue
+            normalized = item.strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            result.append(normalized)
+    return result
+
+
+def _extract_function_names(functions: object) -> list[str]:
+    """Extract function names from a dictionary/list of workflow nodes."""
+    names: list[str] = []
+    seen: set[str] = set()
+
+    if isinstance(functions, dict):
+        items = functions.items()
+        for name, node in items:
+            if isinstance(name, str):
+                n = name.strip()
+                if n and n not in seen:
+                    seen.add(n)
+                    names.append(n)
+            if isinstance(node, dict):
+                names.extend(_extract_function_names(node.get("functions")))
+    elif isinstance(functions, list):
+        for item in functions:
+            if not isinstance(item, dict):
+                continue
+            node_name = item.get("name")
+            if isinstance(node_name, str):
+                n = node_name.strip()
+                if n and n not in seen:
+                    seen.add(n)
+                    names.append(n)
+            names.extend(_extract_function_names(item.get("functions")))
+
+    return names
+
+
+def _extract_constraint_anchors(functions: object) -> list[str]:
+    """Extract anchors from content.functions.*.constraints."""
+    anchors: list[str] = []
+    seen: set[str] = set()
+
+    def _walk(nodes: object) -> None:
+        if isinstance(nodes, dict):
+            for maybe_node in nodes.values():
+                if isinstance(maybe_node, dict):
+                    constraints = maybe_node.get("constraints")
+                    if isinstance(constraints, list):
+                        for constraint in constraints:
+                            if not isinstance(constraint, dict):
+                                continue
+                            anchor = constraint.get("anchor")
+                            if isinstance(anchor, str):
+                                a = anchor.strip()
+                                if a and a not in seen:
+                                    seen.add(a)
+                                    anchors.append(a)
+                    _walk(maybe_node.get("functions"))
+                elif isinstance(maybe_node, list):
+                    _walk(maybe_node)
+        elif isinstance(nodes, list):
+            for item in nodes:
+                if isinstance(item, dict):
+                    _walk(item)
+
+    _walk(functions)
+    return anchors
+
+
+def _extract_resource_anchors(resources: object) -> list[str]:
+    """Extract resource path anchors from content.aisp_contract.resources."""
+    paths: list[str] = []
+    seen: set[str] = set()
+
+    def _collect(path: str) -> None:
+        p = path.strip()
+        if p and p not in seen:
+            seen.add(p)
+            paths.append(p)
+
+    def _walk(value: object) -> None:
+        if isinstance(value, dict):
+            for val in value.values():
+                if isinstance(val, dict):
+                    resource_path = val.get("path")
+                    if isinstance(resource_path, str):
+                        _collect(resource_path)
+                    _walk(val.get("resources"))
+                elif isinstance(val, str):
+                    _collect(val)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, str):
+                    _collect(item)
+                elif isinstance(item, dict):
+                    resource_path = item.get("path")
+                    if isinstance(resource_path, str):
+                        _collect(resource_path)
+                    _walk(item.get("resources"))
+
+    _walk(resources)
+    return paths

--- a/src/skillspector/structured_skill.py
+++ b/src/skillspector/structured_skill.py
@@ -83,12 +83,16 @@ def _parse_bundle_payload(bundle_path: Path, payload: object) -> dict[str, objec
     if system_msg.get("role") != "system":
         return None
 
-    user_content = user_msg.get("content")
-    contract = _find_contract_payload(user_content)
-    if contract is None:
+    user_content = _normalize_mapping(user_msg.get("content"))
+    if user_content is None:
         return None
 
     if user_msg.get("role") != "user":
+        return None
+
+    aisop_payload = _normalize_mapping(user_content.get("aisop"))
+    aisp_contract = _normalize_mapping(user_content.get("aisp_contract"))
+    if aisop_payload is None and aisp_contract is None:
         return None
 
     layout_kind = protocol.split()[0]
@@ -96,14 +100,27 @@ def _parse_bundle_payload(bundle_path: Path, payload: object) -> dict[str, objec
         (
             system_content.get("declared_tools"),
             system_content.get("tools"),
-            contract.get("declared_tools"),
-            contract.get("tools"),
+            user_content.get("declared_tools"),
+            user_content.get("tools"),
+            aisop_payload.get("declared_tools") if aisop_payload else None,
+            aisop_payload.get("tools") if aisop_payload else None,
+            aisp_contract.get("declared_tools") if aisp_contract else None,
+            aisp_contract.get("tools") if aisp_contract else None,
         )
     )
-    functions = contract.get("functions")
+    functions = user_content.get("functions")
+    if functions is None and aisop_payload is not None:
+        functions = aisop_payload.get("functions")
+    if functions is None and aisp_contract is not None:
+        functions = aisp_contract.get("functions")
     function_names = _extract_function_names(functions)
     constraint_anchors = _extract_constraint_anchors(functions)
-    resource_anchors = _extract_resource_anchors(contract.get("resources"))
+    resource_anchors = _extract_resource_anchors(
+        aisp_contract.get("resources") if aisp_contract is not None else None
+    )
+
+    if not function_names and not resource_anchors:
+        return None
 
     return {
         "layout_kind": layout_kind,
@@ -120,19 +137,6 @@ def _parse_bundle_payload(bundle_path: Path, payload: object) -> dict[str, objec
 def _normalize_mapping(value: object) -> dict[str, object] | None:
     """Return a dict if *value* is a mapping object."""
     return value if isinstance(value, dict) else None
-
-
-def _find_contract_payload(content: object) -> dict[str, object] | None:
-    """Locate the AISOP/AISP contract payload in a user message."""
-    container = _normalize_mapping(content)
-    if container is None:
-        return None
-
-    for key in ("aisop", "aisp_contract"):
-        value = container.get(key)
-        if isinstance(value, dict):
-            return value
-    return None
 
 
 def _first_non_empty(values: tuple[object, ...]) -> list[str]:
@@ -189,6 +193,19 @@ def _extract_constraint_anchors(functions: object) -> list[str]:
     anchors: list[str] = []
     seen: set[str] = set()
 
+    def _collect(constraint: object) -> None:
+        if isinstance(constraint, str):
+            anchor = constraint.strip()
+        elif isinstance(constraint, dict):
+            raw_anchor = constraint.get("anchor")
+            anchor = raw_anchor.strip() if isinstance(raw_anchor, str) else ""
+        else:
+            anchor = ""
+
+        if anchor and anchor not in seen:
+            seen.add(anchor)
+            anchors.append(anchor)
+
     def _walk(nodes: object) -> None:
         if isinstance(nodes, dict):
             for maybe_node in nodes.values():
@@ -196,21 +213,18 @@ def _extract_constraint_anchors(functions: object) -> list[str]:
                     constraints = maybe_node.get("constraints")
                     if isinstance(constraints, list):
                         for constraint in constraints:
-                            if not isinstance(constraint, dict):
-                                continue
-                            anchor = constraint.get("anchor")
-                            if isinstance(anchor, str):
-                                a = anchor.strip()
-                                if a and a not in seen:
-                                    seen.add(a)
-                                    anchors.append(a)
+                            _collect(constraint)
                     _walk(maybe_node.get("functions"))
                 elif isinstance(maybe_node, list):
                     _walk(maybe_node)
         elif isinstance(nodes, list):
             for item in nodes:
                 if isinstance(item, dict):
-                    _walk(item)
+                    constraints = item.get("constraints")
+                    if isinstance(constraints, list):
+                        for constraint in constraints:
+                            _collect(constraint)
+                    _walk(item.get("functions"))
 
     _walk(functions)
     return anchors

--- a/src/skillspector/structured_skill.py
+++ b/src/skillspector/structured_skill.py
@@ -45,9 +45,10 @@ def _iter_aisop_files(skill_dir: Path) -> list[Path]:
     """Yield candidate *.aisop.json files under a directory, skipping noisy paths."""
     files: list[Path] = []
     for path in sorted(skill_dir.rglob("*.aisop.json")):
-        if any(part in _SKIP_DIRS for part in path.parts):
+        relative_parts = path.relative_to(skill_dir).parts
+        if any(part in _SKIP_DIRS for part in relative_parts):
             continue
-        if any(part.startswith(".") and part != ".aisop" for part in path.parts[:-1]):
+        if any(part.startswith(".") and part != ".aisop" for part in relative_parts[:-1]):
             # Keep hidden metadata directories out of structured-skill detection.
             continue
         if path.is_file():

--- a/tests/nodes/analyzers/test_registry.py
+++ b/tests/nodes/analyzers/test_registry.py
@@ -43,6 +43,7 @@ EXPECTED_ANALYZER_NODE_IDS: list[str] = [
     "mcp_least_privilege",
     "mcp_tool_poisoning",
     "mcp_rug_pull",
+    "structured_skill_roles",
     "semantic_security_discovery",
     "semantic_developer_intent",
     "semantic_quality_policy",

--- a/tests/nodes/analyzers/test_structured_skill_roles.py
+++ b/tests/nodes/analyzers/test_structured_skill_roles.py
@@ -38,11 +38,12 @@ def _write_aisop_bundle(path: Path) -> None:
     "role": "user",
     "content": {
       "aisop": {
-        "declared_tools": ["search", "calendar"],
-        "functions": {
-          "lookup": {"constraints": [{"anchor": "query"}]}
-        }
-      }
+        "main": "graph TD"
+      },
+      "functions": {
+        "lookup": {"constraints": ["query"]}
+      },
+      "declared_tools": ["search", "calendar"]
     }
   }
 ]

--- a/tests/nodes/analyzers/test_structured_skill_roles.py
+++ b/tests/nodes/analyzers/test_structured_skill_roles.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the structured_skill_roles analyzer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from skillspector.nodes.analyzers import structured_skill_roles as module
+from skillspector.structured_skill import extract_structured_skill_context
+
+
+def _write_aisop_bundle(path: Path) -> None:
+    path.write_text(
+        """
+[
+  {
+    "role": "system",
+    "content": {
+      "protocol": "AISOP V1",
+      "format": "workflow"
+    }
+  },
+  {
+    "role": "user",
+    "content": {
+      "aisop": {
+        "declared_tools": ["search", "calendar"],
+        "functions": {
+          "lookup": {"constraints": [{"anchor": "query"}]}
+        }
+      }
+    }
+  }
+]
+""",
+        encoding="utf-8",
+    )
+
+
+def test_no_structured_context_returns_no_findings() -> None:
+    """A skill without structured-skill context yields no SSR-1 findings."""
+    assert module.node({})["findings"] == []
+
+
+def test_structured_bundle_emits_single_low_ssr1(tmp_path: Path) -> None:
+    """Valid structured bundle context produces one LOW SSR-1 finding."""
+    path = tmp_path / "bundle.aisop.json"
+    _write_aisop_bundle(path)
+    context = extract_structured_skill_context(tmp_path)
+    assert context is not None
+
+    result = module.node({"structured_skill_context": context})
+    assert len(result["findings"]) == 1
+
+    finding = result["findings"][0]
+    assert finding.rule_id == "SSR-1"
+    assert finding.severity == "LOW"
+    assert finding.file == str(path.resolve())
+    assert finding.matched_text is not None
+    assert finding.context is not None
+    assert "declared_tools" in finding.context
+
+
+def test_malformed_context_does_not_raise_no_findings(tmp_path: Path) -> None:
+    """Malformed bundle parsing failure surfaces as no structured context and no finding."""
+    (tmp_path / "bundle.aisop.json").write_text("{bad", encoding="utf-8")
+    context = extract_structured_skill_context(tmp_path)
+    assert context is None
+
+    result = module.node({"structured_skill_context": context})
+    assert result["findings"] == []
+
+
+def test_analyzer_does_not_require_llm_credentials(tmp_path: Path) -> None:
+    """Structured-skill analyzer is static and works without any LLM credentials."""
+    path = tmp_path / "bundle.aisop.json"
+    _write_aisop_bundle(path)
+    context = extract_structured_skill_context(tmp_path)
+    assert context is not None
+    result = module.node({"structured_skill_context": context})
+    assert result["findings"][0].rule_id == "SSR-1"

--- a/tests/nodes/analyzers/test_structured_skill_roles.py
+++ b/tests/nodes/analyzers/test_structured_skill_roles.py
@@ -53,27 +53,34 @@ def _write_aisop_bundle(path: Path) -> None:
 
 
 def test_no_structured_context_returns_no_findings() -> None:
-    """A skill without structured-skill context yields no SSR-1 findings."""
+    """A skill without structured-skill context yields no SSR-1 summary."""
     assert module.node({})["findings"] == []
 
 
-def test_structured_bundle_emits_single_low_ssr1(tmp_path: Path) -> None:
-    """Valid structured bundle context produces one LOW SSR-1 finding."""
+def test_structured_bundle_emits_single_report_only_ssr1(tmp_path: Path) -> None:
+    """Valid structured bundle context produces one report-only SSR-1 summary."""
     path = tmp_path / "bundle.aisop.json"
     _write_aisop_bundle(path)
     context = extract_structured_skill_context(tmp_path)
     assert context is not None
 
     result = module.node({"structured_skill_context": context})
-    assert len(result["findings"]) == 1
+    assert result["findings"] == []
+    assert len(result["structured_summaries"]) == 1
 
-    finding = result["findings"][0]
-    assert finding.rule_id == "SSR-1"
-    assert finding.severity == "LOW"
-    assert finding.file == str(path.resolve())
-    assert finding.matched_text is not None
-    assert finding.context is not None
-    assert "declared_tools" in finding.context
+    summary = result["structured_summaries"][0]
+    assert summary["id"] == "SSR-1"
+    assert summary["message"] == f"Structured {summary['layout_kind']} bundle detected (AISOP V1)"
+    assert summary["file"] == str(path.resolve())
+    assert summary["protocol"] == "AISOP V1"
+    assert summary["layout_kind"] == context["layout_kind"]
+    assert summary["declared_tools"] == ["calendar", "search"]
+    assert summary["workflow_nodes"] == context["workflow_nodes"]
+    assert summary["constraints"] == context["constraint_anchors"]
+    assert summary["resources"] == context["resource_anchors"]
+    assert summary["tags"] == ["AISOP", "AISP", "structured-skill"]
+    assert "severity" not in summary
+    assert "confidence" not in summary
 
 
 def test_malformed_context_does_not_raise_no_findings(tmp_path: Path) -> None:
@@ -93,4 +100,5 @@ def test_analyzer_does_not_require_llm_credentials(tmp_path: Path) -> None:
     context = extract_structured_skill_context(tmp_path)
     assert context is not None
     result = module.node({"structured_skill_context": context})
-    assert result["findings"][0].rule_id == "SSR-1"
+    assert result["findings"] == []
+    assert result["structured_summaries"][0]["id"] == "SSR-1"

--- a/tests/nodes/test_build_context.py
+++ b/tests/nodes/test_build_context.py
@@ -390,7 +390,7 @@ def test_build_context_parses_parameters_from_frontmatter(tmp_path: Path) -> Non
         "parameters:\n"
         "  - name: path\n"
         "    description: file path to read\n"
-        "  - not-a-dict\n"  # non-dict entries are dropped
+        "  - not-a-dict\n"
         "---\n",
         encoding="utf-8",
     )
@@ -667,3 +667,134 @@ def test_build_context_rejects_symlinked_manifest(tmp_path: Path) -> None:
     assert result["manifest"] == {}
     assert "SKILL.md" not in result["components"]
     assert "SKILL.md" not in result["file_cache"]
+def _write_aisop_bundle(path: Path) -> None:
+    """Write a valid minimal AISOP/AISP bundle file."""
+    bundle = [
+        {
+            "role": "system",
+            "content": {
+                "protocol": "AISP V1",
+                "format": "contract",
+            },
+        },
+        {
+            "role": "user",
+            "content": {
+                "functions": {
+                    "inbox": {"constraints": ["Read-only inspection must not modify files."]}
+                },
+                "aisp_contract": {
+                    "resources": {
+                        "state": {"path": "resources/state.json"},
+                    },
+                    "declared_tools": ["mail", "search"],
+                },
+            },
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(bundle), encoding="utf-8")
+
+
+def _make_nested_functions(depth: int) -> dict[str, object]:
+    """Build a deeply nested functions tree for recursion-guard tests."""
+    current: dict[str, object] = {"constraints": ["depth.guard"]}
+    for idx in range(depth, -1, -1):
+        current = {f"node_{idx}": {"constraints": [f"depth_{idx}"], "functions": current}}
+    return current
+
+
+def test_build_context_populates_structured_skill_context(tmp_path: Path) -> None:
+    """Valid AISOP/AISP bundle yields structured_skill_context metadata in scan context."""
+    _write_aisop_bundle(tmp_path / "workflow.aisop.json")
+    state: SkillspectorState = {"skill_path": str(tmp_path)}
+    result = build_context(state)
+
+    assert "structured_skill_context" in result
+    context = result["structured_skill_context"]
+    assert isinstance(context, dict)
+    assert context["protocol"] == "AISP V1"
+    assert context["layout_kind"] == "AISP"
+    assert context["format"] == "contract"
+    assert context["bundle_path"] == str((tmp_path / "workflow.aisop.json").resolve())
+    assert context["workflow_nodes"] == ["inbox"]
+    assert context["constraint_anchors"] == ["Read-only inspection must not modify files."]
+    assert context["resource_anchors"] == ["resources/state.json"]
+    assert context["declared_tools"] == ["mail", "search"]
+
+
+def test_build_context_manifest_may_be_empty_when_only_structured(tmp_path: Path) -> None:
+    """A structured bundle can populate context while manifest stays empty."""
+    _write_aisop_bundle(tmp_path / "workflow.aisop.json")
+    state: SkillspectorState = {"skill_path": str(tmp_path)}
+    result = build_context(state)
+    assert result["manifest"] == {}
+    assert "structured_skill_context" in result
+
+
+def test_build_context_structured_context_absent_for_malformed_bundle(tmp_path: Path) -> None:
+    """Malformed AISOP/AISP JSON leaves structured_skill_context unset."""
+    (tmp_path / "bad.aisop.json").write_text(
+        json.dumps([{"role": "system", "content": {"protocol": "AISOP V1"}}, {}]),
+        encoding="utf-8",
+    )
+    state: SkillspectorState = {"skill_path": str(tmp_path)}
+    result = build_context(state)
+    assert "structured_skill_context" not in result
+
+
+def test_build_context_deduplicates_nested_workflow_names(tmp_path: Path) -> None:
+    """Nested function names stay unique in structured_skill_context."""
+    bundle = [
+        {
+            "role": "system",
+            "content": {
+                "protocol": "AISOP V1",
+                "format": "workflow",
+            },
+        },
+        {
+            "role": "user",
+            "content": {
+                "aisop": {"main": "graph TD"},
+                "functions": {
+                    "lookup": {
+                        "functions": {
+                            "lookup": {
+                                "constraints": ["nested.query"],
+                            }
+                        }
+                    }
+                },
+            },
+        },
+    ]
+    (tmp_path / "nested.aisop.json").write_text(json.dumps(bundle), encoding="utf-8")
+    result = build_context({"skill_path": str(tmp_path)})
+    context = result["structured_skill_context"]
+    assert context["workflow_nodes"] == ["lookup"]
+
+
+def test_build_context_ignores_over_nested_structured_bundle(tmp_path: Path) -> None:
+    """Over-nested structured bundles fail closed instead of crashing build_context."""
+    bundle = [
+        {
+            "role": "system",
+            "content": {
+                "protocol": "AISOP V1",
+                "format": "workflow",
+            },
+        },
+        {
+            "role": "user",
+            "content": {
+                "aisop": {"main": "graph TD"},
+                "functions": _make_nested_functions(140),
+            },
+        },
+    ]
+    (tmp_path / "deep.aisop.json").write_text(json.dumps(bundle), encoding="utf-8")
+
+    result = build_context({"skill_path": str(tmp_path)})
+
+assert "structured_skill_context" not in result

--- a/tests/nodes/test_build_context.py
+++ b/tests/nodes/test_build_context.py
@@ -667,6 +667,8 @@ def test_build_context_rejects_symlinked_manifest(tmp_path: Path) -> None:
     assert result["manifest"] == {}
     assert "SKILL.md" not in result["components"]
     assert "SKILL.md" not in result["file_cache"]
+
+
 def _write_aisop_bundle(path: Path) -> None:
     """Write a valid minimal AISOP/AISP bundle file."""
     bundle = [
@@ -721,6 +723,19 @@ def test_build_context_populates_structured_skill_context(tmp_path: Path) -> Non
     assert context["constraint_anchors"] == ["Read-only inspection must not modify files."]
     assert context["resource_anchors"] == ["resources/state.json"]
     assert context["declared_tools"] == ["mail", "search"]
+
+
+@pytest.mark.parametrize("ancestor", [".claude", "venv"])
+def test_build_context_structured_bundle_under_ancestor(tmp_path: Path, ancestor: str) -> None:
+    """Scan-root-relative filters keep bundles under external ancestors."""
+    skill_dir = tmp_path / ancestor / "skills" / "foo"
+    skill_dir.mkdir(parents=True)
+    _write_aisop_bundle(skill_dir / "workflow.aisop.json")
+
+    result = build_context({"skill_path": str(skill_dir)})
+
+    assert "workflow.aisop.json" in result["components"]
+    assert "structured_skill_context" in result
 
 
 def test_build_context_manifest_may_be_empty_when_only_structured(tmp_path: Path) -> None:
@@ -797,4 +812,4 @@ def test_build_context_ignores_over_nested_structured_bundle(tmp_path: Path) -> 
 
     result = build_context({"skill_path": str(tmp_path)})
 
-assert "structured_skill_context" not in result
+    assert "structured_skill_context" not in result

--- a/tests/nodes/test_report.py
+++ b/tests/nodes/test_report.py
@@ -51,6 +51,25 @@ def _finding(
     )
 
 
+def _structured_summary(
+    *,
+    message: str = "Structured structured bundle detected (AISOP V1)",
+    file: str = "bundle.aisop.json",
+) -> dict[str, object]:
+    return {
+        "id": "SSR-1",
+        "message": message,
+        "file": file,
+        "protocol": "AISOP V1",
+        "layout_kind": "structured",
+        "declared_tools": ["calendar", "search"],
+        "workflow_nodes": ["system", "user"],
+        "constraints": ["query"],
+        "resources": ["docs"],
+        "tags": ["AISOP", "AISP", "structured-skill"],
+    }
+
+
 # --- Risk score computation tests ---
 
 
@@ -438,6 +457,7 @@ class TestReportNode:
         """output_format json produces valid JSON with expected structure."""
         state: SkillspectorState = {
             "filtered_findings": [_finding("P1", "HIGH", confidence=1.0)],
+            "structured_summaries": [_structured_summary()],
             "component_metadata": [
                 {
                     "path": "a.md",
@@ -461,6 +481,9 @@ class TestReportNode:
         assert "severity" in data["risk_assessment"]
         assert "recommendation" in data["risk_assessment"]
         assert "components" in data
+        assert "structured_summaries" in data
+        assert len(data["structured_summaries"]) == 1
+        assert data["structured_summaries"][0]["id"] == "SSR-1"
         assert "issues" in data
         assert len(data["issues"]) == 1
         assert data["issues"][0]["id"] == "P1"
@@ -469,6 +492,7 @@ class TestReportNode:
         """output_format markdown produces expected headings."""
         state: SkillspectorState = {
             "filtered_findings": [],
+            "structured_summaries": [_structured_summary()],
             "component_metadata": [],
             "has_executable_scripts": False,
             "manifest": {},
@@ -480,6 +504,7 @@ class TestReportNode:
         assert "# SkillSpector Security Report" in body
         assert "## Risk Assessment" in body
         assert "## Components" in body
+        assert "## Structured Skill Summary (1)" in body
         assert "## Issues" in body
 
     def test_report_markdown_lists_nonfatal_llm_validation_exception(self) -> None:
@@ -532,6 +557,7 @@ class TestReportNode:
         """output_format terminal produces Rich-formatted output."""
         state: SkillspectorState = {
             "filtered_findings": [],
+            "structured_summaries": [_structured_summary()],
             "component_metadata": [],
             "has_executable_scripts": False,
             "manifest": {"name": "cli-test"},
@@ -543,11 +569,13 @@ class TestReportNode:
         assert "SkillSpector" in body
         assert "Risk Assessment" in body
         assert "cli-test" in body
+        assert "Structured Skill Summary" in body
 
     def test_report_output_format_sarif(self) -> None:
         """output_format sarif produces valid SARIF JSON."""
         state: SkillspectorState = {
-            "filtered_findings": [_finding("E2", "HIGH", "env harvest", confidence=1.0)],
+            "structured_summaries": [_structured_summary()],
+            "filtered_findings": [],
             "component_metadata": [],
             "has_executable_scripts": False,
             "manifest": {},
@@ -559,6 +587,33 @@ class TestReportNode:
         data = json.loads(body)
         assert "runs" in data
         assert data.get("$schema") or "runs" in data
+        run = data["runs"][0]
+        assert run["results"] == []
+        assert "invocations" in run
+        notifications = run["invocations"][0]["toolExecutionNotifications"]
+        assert notifications[0]["level"] == "note"
+        assert "SSR-1" in notifications[0]["message"]["text"]
+
+    def test_report_json_structured_summary_survives_llm_mode(self) -> None:
+        """A structured-only scan keeps SSR-1 visible when use_llm is true."""
+        state: SkillspectorState = {
+            "filtered_findings": [],
+            "structured_summaries": [_structured_summary()],
+            "component_metadata": [],
+            "has_executable_scripts": False,
+            "manifest": {},
+            "skill_path": None,
+            "output_format": "json",
+            "use_llm": True,
+            "llm_call_log": [],
+        }
+        result = report(state)
+        assert result["risk_score"] == 0
+        assert result["risk_recommendation"] == "SAFE"
+        assert len(result["structured_summaries"]) == 1
+        data = json.loads(result["report_body"])
+        assert data["issues"] == []
+        assert data["structured_summaries"][0]["id"] == "SSR-1"
 
     def test_report_output_format_sarif_includes_finding_properties(self) -> None:
         finding = _finding("E2", "HIGH", "env harvest", confidence=0.85, file="tool.py")

--- a/tests/nodes/test_report.py
+++ b/tests/nodes/test_report.py
@@ -610,7 +610,7 @@ class TestReportNode:
         result = report(state)
         assert result["risk_score"] == 0
         assert result["risk_recommendation"] == "SAFE"
-        assert len(result["structured_summaries"]) == 1
+        assert "structured_summaries" not in result
         data = json.loads(result["report_body"])
         assert data["issues"] == []
         assert data["structured_summaries"][0]["id"] == "SSR-1"

--- a/tests/test_mcp_least_privilege.py
+++ b/tests/test_mcp_least_privilege.py
@@ -94,12 +94,12 @@ def _make_state(fixture_name: str) -> dict:
     for item in fixture_dir.rglob("*"):
         if not item.is_file():
             continue
-        if any(skip in item.parts for skip in _SKIP_DIRS):
+        rel = item.relative_to(fixture_dir)
+        if any(skip in rel.parts for skip in _SKIP_DIRS):
             continue
         if item.name.startswith(".") and not item.name.startswith(".claude"):
             continue
-        rel = item.relative_to(fixture_dir).as_posix()  # forward slashes on every OS
-        components.append(rel)
+        components.append(rel.as_posix())  # forward slashes on every OS
     components.sort()
 
     # Build file_cache

--- a/tests/test_mcp_tool_poisoning.py
+++ b/tests/test_mcp_tool_poisoning.py
@@ -121,12 +121,12 @@ def _make_state(
     for item in fixture_dir.rglob("*"):
         if not item.is_file():
             continue
-        if any(skip in item.parts for skip in _SKIP_DIRS):
+        rel = item.relative_to(fixture_dir)
+        if any(skip in rel.parts for skip in _SKIP_DIRS):
             continue
         if item.name.startswith(".") and not item.name.startswith(".claude"):
             continue
-        rel = item.relative_to(fixture_dir).as_posix()  # forward slashes on every OS
-        components.append(rel)
+        components.append(rel.as_posix())  # forward slashes on every OS
     components.sort()
 
     # Build file_cache

--- a/tests/test_multi_skill.py
+++ b/tests/test_multi_skill.py
@@ -97,6 +97,14 @@ def _write_aisop_bundle(path: Path) -> None:
     path.write_text(json.dumps(bundle), encoding="utf-8")
 
 
+def _make_nested_resources(depth: int) -> dict[str, object]:
+    """Build a deeply nested resources tree for recursion-guard tests."""
+    current: dict[str, object] = {"path": "resources/final.json"}
+    for idx in range(depth, -1, -1):
+        current = {f"resource_{idx}": {"resources": current}}
+    return current
+
+
 class TestDetectSkills:
     """Tests for detect_skills()."""
 
@@ -151,6 +159,33 @@ class TestDetectSkills:
             encoding="utf-8",
         )
         result = detect_skills(tmp_path)
+        assert result.is_multi_skill is False
+        assert len(result.skills) == 0
+
+    def test_structured_bundle_ignored_when_over_nested(self, tmp_path: Path) -> None:
+        """Over-nested structured bundles fail closed instead of crashing detection."""
+        nested = tmp_path / "deep-bundle"
+        nested.mkdir()
+        bundle = [
+            {
+                "role": "system",
+                "content": {
+                    "protocol": "AISP V1",
+                    "format": "contract",
+                },
+            },
+            {
+                "role": "user",
+                "content": {
+                    "functions": {"lookup": {"constraints": ["query"]}},
+                    "aisp_contract": {"resources": _make_nested_resources(140)},
+                },
+            },
+        ]
+        (nested / "workflow.aisop.json").write_text(json.dumps(bundle), encoding="utf-8")
+
+        result = detect_skills(tmp_path)
+
         assert result.is_multi_skill is False
         assert len(result.skills) == 0
 

--- a/tests/test_multi_skill.py
+++ b/tests/test_multi_skill.py
@@ -142,6 +142,36 @@ class TestDetectSkills:
         assert result.is_multi_skill is False
         assert len(result.skills) == 1
 
+    @pytest.mark.parametrize("ancestor", [".claude", "venv"])
+    def test_structured_child_under_ancestor_detected(self, tmp_path: Path, ancestor: str) -> None:
+        """Structured children remain discoverable under external ancestors."""
+        skills_dir = tmp_path / ancestor / "skills"
+        sub = skills_dir / "workflow-bundle"
+        sub.mkdir(parents=True)
+        _write_aisop_bundle(sub / "workflow.aisop.json")
+
+        result = detect_skills(skills_dir)
+
+        assert len(result.skills) == 1
+        assert result.skills[0].path == sub
+
+    @pytest.mark.parametrize("skip_dir", ["venv", "node_modules", "__pycache__"])
+    def test_skip_dir_children_with_bundles_ignored(self, tmp_path: Path, skip_dir: str) -> None:
+        """Skip-dir children do not become phantom skills from vendored bundles."""
+        real_skill = tmp_path / "real-skill"
+        real_skill.mkdir()
+        (real_skill / "SKILL.md").write_text("---\nname: real\n---\n", encoding="utf-8")
+
+        bundled_child = tmp_path / skip_dir / "pkg"
+        bundled_child.mkdir(parents=True)
+        _write_aisop_bundle(bundled_child / "workflow.aisop.json")
+
+        result = detect_skills(tmp_path)
+
+        assert result.is_multi_skill is False
+        assert len(result.skills) == 1
+        assert result.skills[0].path == real_skill
+
     def test_structured_bundle_ignored_when_partial(self, tmp_path: Path) -> None:
         """Malformed AISOP/AISP JSON does not count as a structured child skill."""
         malformed = tmp_path / "bad-bundle"

--- a/tests/test_multi_skill.py
+++ b/tests/test_multi_skill.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -65,6 +66,38 @@ def nested_with_root(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def _write_aisop_bundle(path: Path) -> None:
+    """Write a valid minimal AISOP/AISP bundle file."""
+    bundle = [
+        {
+            "role": "system",
+            "content": {
+                "protocol": "AISOP V1",
+                "format": "AIModal",
+            },
+        },
+        {
+            "role": "user",
+            "content": {
+                "aisop": {
+                    "declared_tools": ["search", "calendar"],
+                    "functions": {
+                        "lookup": {"constraints": [{"anchor": "query"}]},
+                        "schedule": {"constraints": [{"anchor": "time"}]},
+                    },
+                },
+                "aisp_contract": {
+                    "resources": {
+                        "calendar": {"path": "resources/calendar.json"},
+                        "memory": {"path": "resources/memory.md"},
+                    }
+                },
+            },
+        },
+    ]
+    path.write_text(json.dumps(bundle), encoding="utf-8")
+
+
 class TestDetectSkills:
     """Tests for detect_skills()."""
 
@@ -80,6 +113,58 @@ class TestDetectSkills:
         result = detect_skills(multi_skill_dir)
         names = {s.name for s in result.skills}
         assert names == {"weather-lookup", "email-sender", "file-manager"}
+
+    def test_structured_skill_subdir_detected(self, tmp_path: Path) -> None:
+        """An immediate subdirectory with a valid AISOP/AISP bundle is detected."""
+        sub = tmp_path / "workflow-bundle"
+        sub.mkdir()
+        _write_aisop_bundle(sub / "workflow.aisop.json")
+        result = detect_skills(tmp_path)
+        assert result.is_multi_skill is False
+        assert result.has_root_skill is False
+        assert len(result.skills) == 1
+        assert result.skills[0].name == "workflow-bundle"
+        assert result.skills[0].path == sub
+
+    def test_single_structured_child_not_multi(self, tmp_path: Path) -> None:
+        """One structured subdirectory should not force multi-skill mode."""
+        sub = tmp_path / "only-structured"
+        sub.mkdir()
+        _write_aisop_bundle(sub / "workflow.aisop.json")
+        result = detect_skills(tmp_path)
+        assert result.is_multi_skill is False
+        assert len(result.skills) == 1
+
+    def test_structured_bundle_ignored_when_partial(self, tmp_path: Path) -> None:
+        """Malformed AISOP/AISP JSON does not count as a structured child skill."""
+        malformed = tmp_path / "bad-bundle"
+        malformed.mkdir()
+        (malformed / "workflow.aisop.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "role": "system",
+                        "content": {"protocol": "AISOP V1"},
+                    },
+                    {"content": {"functions": []}},
+                ]
+            ),
+            encoding="utf-8",
+        )
+        result = detect_skills(tmp_path)
+        assert result.is_multi_skill is False
+        assert len(result.skills) == 0
+
+    def test_root_skill_still_overrides_structured_nested(self, tmp_path: Path) -> None:
+        """A root SKILL.md still forces single-skill mode with nested structured bundles."""
+        (tmp_path / "SKILL.md").write_text("---\nname: root-skill\n---\n# Root\n", encoding="utf-8")
+        nested = tmp_path / "nested-structured"
+        nested.mkdir()
+        _write_aisop_bundle(nested / "workflow.aisop.json")
+        result = detect_skills(tmp_path)
+        assert result.is_multi_skill is False
+        assert result.has_root_skill is True
+        assert len(result.skills) == 0
 
     def test_single_skill_not_multi(self, single_skill_dir: Path) -> None:
         """Directory with root SKILL.md is not multi-skill."""

--- a/tests/test_multi_skill.py
+++ b/tests/test_multi_skill.py
@@ -79,13 +79,12 @@ def _write_aisop_bundle(path: Path) -> None:
         {
             "role": "user",
             "content": {
-                "aisop": {
-                    "declared_tools": ["search", "calendar"],
-                    "functions": {
-                        "lookup": {"constraints": [{"anchor": "query"}]},
-                        "schedule": {"constraints": [{"anchor": "time"}]},
-                    },
+                "aisop": {"main": "graph TD"},
+                "functions": {
+                    "lookup": {"constraints": ["query"]},
+                    "schedule": {"constraints": ["time"]},
                 },
+                "declared_tools": ["search", "calendar"],
                 "aisp_contract": {
                     "resources": {
                         "calendar": {"path": "resources/calendar.json"},

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -913,8 +913,8 @@ def test_cli_scan_json_preserves_single_skill_contract(
     assert payload["suppressed"] == []
 
 
-def test_cli_scan_structured_skill_aisop_no_llm_produces_ssr1_issue(tmp_path: Path) -> None:
-    """--no-llm JSON scan reports SSR-1 when a valid AISOP/AISP bundle is present."""
+def test_cli_scan_structured_skill_aisop_no_llm_reports_summary(tmp_path: Path) -> None:
+    """--no-llm JSON scan reports SSR-1 through the structured summary channel."""
     (tmp_path / "workflow.aisop.json").write_text(
         """
 [
@@ -943,4 +943,6 @@ def test_cli_scan_structured_skill_aisop_no_llm_produces_ssr1_issue(tmp_path: Pa
     result = runner.invoke(app, ["scan", str(tmp_path), "--format", "json", "--no-llm"])
     assert result.exit_code == 0
     data = json.loads(result.output)
-    assert any(issue["id"] == "SSR-1" for issue in data["issues"])
+    assert data["issues"] == []
+    assert data["risk_assessment"]["score"] == 0
+    assert data["structured_summaries"][0]["id"] == "SSR-1"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -911,3 +911,36 @@ def test_cli_scan_json_preserves_single_skill_contract(
     assert payload["issues"] == [{"id": "X-1", "severity": "low"}]
     assert payload["suppressed_count"] == 0
     assert payload["suppressed"] == []
+
+
+def test_cli_scan_structured_skill_aisop_no_llm_produces_ssr1_issue(tmp_path: Path) -> None:
+    """--no-llm JSON scan reports SSR-1 when a valid AISOP/AISP bundle is present."""
+    (tmp_path / "workflow.aisop.json").write_text(
+        """
+[
+  {
+    "role": "system",
+    "content": {
+      "protocol": "AISOP V1",
+      "format": "workflow"
+    }
+  },
+  {
+    "role": "user",
+    "content": {
+      "aisop": {
+        "main": "graph TD"
+      },
+      "functions": {
+        "lookup": {"constraints": ["query"]}
+      }
+    }
+  }
+]
+""",
+        encoding="utf-8",
+    )
+    result = runner.invoke(app, ["scan", str(tmp_path), "--format", "json", "--no-llm"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert any(issue["id"] == "SSR-1" for issue in data["issues"])


### PR DESCRIPTION
## Summary

SkillSpector now recognizes valid `*.aisop.json` AISOP/AISP bundles during recursive discovery and build-context creation, including skills scanned from installed `.claude/...` paths or from roots nested under skip-named ancestors such as `venv`. Recursive discovery still ignores actual skip-dir children such as `venv`, `node_modules`, and `__pycache__`, so vendored bundles in those trees do not become phantom skills. The scan still surfaces one report-only structured summary through `structured_summaries`, and the report node no longer re-appends its sanitized copy into final graph state.

Refs #130

This follows the phased implementation sketch and AISOP/AISP bundle examples in [#130](https://github.com/NVIDIA/SkillSpector/issues/130). The review updates keep SSR-1 visible as context instead of modeling it as a LOW finding, and keep discovery keyed to the actual scan root instead of absolute ancestors above it.

## Root cause

`src/skillspector/multi_skill.py` only recognized root `SKILL.md` layouts or immediate subdirectories that contain `SKILL.md` or `skill.md`, so `--recursive` missed structured subdirectories expressed only through valid AISOP/AISP bundle files. The original detector and sibling build-context walker were both checking absolute path components, which meant ancestors above the scan root could silently suppress valid bundles or even empty `components` when a skill lived under paths such as `.claude/...` or `venv/...`. Once the detector was corrected to be root-relative, `detect_skills()` also needed to skip actual `_SKIP_DIRS` children explicitly so vendored bundles inside `venv`, `node_modules`, or `__pycache__` would not be promoted into skills. The branch also returned `structured_summaries` from `report()` even though that channel is additive, so final graph state kept both the analyzer copy and the sanitized report copy.

## Diff Notes

- Add `src/skillspector/structured_skill.py` as the shared detector for valid `*.aisop.json` AISOP/AISP bundles and their summarized metadata, reading workflow nodes from `user.content.functions` and AISP resources from `user.content.aisp_contract.resources`.
- Bound structured bundle metadata walking and fail closed on over-nested bundles, so adversarial `functions` or `resources` trees are ignored instead of crashing `build_context()` or recursive skill detection.
- Reuse that detector in `src/skillspector/multi_skill.py` so `--recursive` can treat immediate structured subdirectories as skills while preserving root `SKILL.md` precedence.
- Skip child directories whose names are in `_SKIP_DIRS` before structured-bundle detection in `src/skillspector/multi_skill.py`, so vendored bundle trees do not become phantom skills once discovery is correctly root-relative.
- Evaluate structured-bundle and build-context skip filters relative to `skill_dir`, which restores detection for installed skills under `.claude/...` and scan roots nested under skip-named ancestors such as `venv`.
- Populate `structured_skill_context` and add `structured_summaries` as a separate state channel.
- Add `src/skillspector/nodes/analyzers/structured_skill_roles.py` and register it so the graph emits one SSR-1 structured summary without adding it to ordinary findings.
- Render structured summaries in terminal, markdown, JSON, and SARIF notifications while keeping them out of risk score inputs, meta analyzer inputs, JSON `issues`, SARIF `results`, and MCP `findings`.
- Stop `report()` from returning `structured_summaries` into final graph state after sanitization; rendered output still includes the summary, but the additive channel keeps only the analyzer copy.
- Add focused coverage in `tests/test_multi_skill.py`, `tests/nodes/test_build_context.py`, `tests/nodes/analyzers/test_registry.py`, `tests/nodes/analyzers/test_structured_skill_roles.py`, `tests/nodes/test_report.py`, and `tests/unit/test_cli.py`.

## Scope

- Phase 1 only. This PR detects valid AISOP/AISP bundles and summarizes their workflow shape through a report-only channel.
- No severity adjustments, no meta analyzer policy changes, and no changes to existing static, behavioral, MCP, or semantic findings.
- No Pi extension changes in `extensions/skillspector.ts`.
- No full role-aware score downgrades, no malformed-bundle warning surface, and no claim of complete AISOP/AISP spec coverage.

## Verification

- [x] `python -m pytest tests/nodes/test_build_context.py tests/test_multi_skill.py tests/nodes/test_report.py -q`
- [x] `python -m pytest tests/test_multi_skill.py tests/nodes/test_build_context.py tests/nodes/analyzers/test_registry.py tests/nodes/analyzers/test_structured_skill_roles.py tests/nodes/test_report.py tests/unit/test_cli.py -q`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`

## Notes

This slice stops at detection and report-visible summary context. Role-aware severity adjustments remain follow-up work on top of the new structured context.
