### PR TITLE
docs(mcp): surface install extra in quick-start and add stdio caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,17 @@ SkillSpector helps you answer: **"Is this skill safe to install?"**
 
 Create and activate a virtual environment first (all `make` targets assume the venv is active). Use **uv** or **pip**; the Makefile uses `uv` if available, otherwise `pip`.
 
-**Quick install with uv (no clone required):**
+**Quick install with uv (CLI-only):**
 
 ```bash
 uv tool install git+https://github.com/NVIDIA/skillspector.git
 # Update later: uv tool update skillspector
+```
+
+If you plan to run `skillspector mcp`, install the MCP extra at install time:
+
+```bash
+uv tool install 'skillspector[mcp] @ git+https://github.com/NVIDIA/skillspector.git'
 ```
 
 **From source:**
@@ -228,16 +234,21 @@ runtime can call scanning as a tool and **gate skill/MCP installs on the
 result** — turning SkillSpector into a runtime guardrail instead of an
 out-of-band audit step.
 
-```bash
-# Install the optional MCP dependency
-pip install "skillspector[mcp]"
+`skillspector mcp` requires `skillspector[mcp]`.
 
-# stdio transport — for local CLI agents
+```bash
+# Install, or reinstall if you already used the CLI-only path
+uv tool install --force 'skillspector[mcp] @ git+https://github.com/NVIDIA/skillspector.git'
+
+# FastMCP stdio transport for local CLI agents
 skillspector mcp
 
-# streamable HTTP/SSE transport — for remote / A2A callers
+# streamable HTTP/SSE transport for remote / A2A callers
 skillspector mcp --transport http --host 127.0.0.1 --port 8000
 ```
+
+The stdio transport is the current FastMCP path for local CLI agents, and the
+initialize hang reported in issue #199 still applies there.
 
 The server exposes a single tool:
 

--- a/src/skillspector/cli.py
+++ b/src/skillspector/cli.py
@@ -440,7 +440,7 @@ def mcp(
         typer.Option(
             "--transport",
             "-t",
-            help="Transport: stdio for local CLI agents, http for remote/A2A callers.",
+            help="Transport: FastMCP stdio for local CLI agents, http for remote/A2A callers.",
             case_sensitive=False,
         ),
     ] = TransportChoice.stdio,
@@ -460,12 +460,13 @@ def mcp(
     Codex CLI, Gemini CLI) or remote runtime can scan a skill and gate installs
     on the verdict.
 
+    Requires the optional mcp extra. Reinstall the GitHub tool package with
+    that extra enabled, as shown in the README Quick Start section.
+
     Examples:
 
-        skillspector mcp                      # stdio (local agents)
+        skillspector mcp                      # FastMCP stdio for local CLI agents
         skillspector mcp --transport http --port 8000
-
-    Requires the optional ``mcp`` dependency: pip install "skillspector[mcp]".
     """
     try:
         from skillspector.mcp_server import run as run_mcp


### PR DESCRIPTION
## Summary

Surface the MCP-capable install path at the first Quick Start decision point, then tighten the README and CLI help so `skillspector mcp` is described as the current FastMCP stdio path that requires `skillspector[mcp]`.

Refs #199

## Root cause

The README leads with a base-only `uv tool install` command, while the MCP-specific install requirement appears later in the MCP section. The `skillspector mcp` help text repeats that split by describing stdio before users see the optional-extra requirement, so they can hit the missing-dependency path before they ever learn which install command they needed.

## Diff Notes

- `README.md`
  - Make the first `uv` install path explicitly CLI-only.
  - Add an MCP-capable direct-URL install command beside it so users can choose the right path before invoking `skillspector mcp`.
  - State plainly that `skillspector mcp` requires `skillspector[mcp]`.
  - Narrow the stdio wording to the current FastMCP transport scope and call out the existing initialize hang in issue `#199` without framing it as fixed.
- `src/skillspector/cli.py`
  - Update the `mcp` command help text so the optional `mcp` extra is visible before the import-failure path.
  - Align the transport wording with the README by naming FastMCP stdio for local CLI agents and `http` for remote or A2A callers.

## Scope

This PR changes only `README.md` and `src/skillspector/cli.py`. It does not change `src/skillspector/mcp_server.py`, add transport diagnostics, or claim to resolve the stdio initialize hang from `#199`.

## Verification

- [x] `rtk git -C "D:\Repos\SkillSpector-pr-mcp-docs-install-scope" diff -- README.md src\skillspector\cli.py` - keeps the slice to the intended README and CLI help surfaces.
- [x] `Select-String -Pattern 'skillspector[mcp]' -SimpleMatch -Path 'D:\Repos\SkillSpector-pr-mcp-docs-install-scope\README.md','D:\Repos\SkillSpector-pr-mcp-docs-install-scope\src\skillspector\cli.py'` - confirms the optional-extra guidance is visible on both user-facing surfaces.
- [x] `rtk grep "skillspector mcp" "D:\Repos\SkillSpector-pr-mcp-docs-install-scope\README.md" "D:\Repos\SkillSpector-pr-mcp-docs-install-scope\src\skillspector\cli.py"` - confirms the updated MCP wording appears in both places users read it.
- [x] `cmd /d /s /c "cd /d D:\Repos\SkillSpector-pr-mcp-docs-install-scope && rtk uv run skillspector mcp --help"` - verifies the rendered help surfaces the optional extra before the runtime import-failure path.
- [ ] CI `Lint & Test (Python 3.12)`, `Lint & Test (Python 3.13)`, and `DCO Check` - pending maintainer approval if fork checks are gated.

## Notes

This is the repo-owned docs and help-text slice only. The runtime stdio initialize hang remains outside this PR.
