### PR TITLE
feat(analyzer): detect untrusted container image pull as SC7

### DIFF
--- a/src/skillspector/nodes/analyzers/pattern_defaults.py
+++ b/src/skillspector/nodes/analyzers/pattern_defaults.py
@@ -88,6 +88,7 @@ DEFAULT_EXPLANATIONS: dict[str, str] = {
     "SC4": "Dependency has known vulnerabilities (CVEs). Using packages with unpatched security flaws exposes the environment to known exploits.",
     "SC5": "Dependency appears abandoned or unmaintained. Abandoned packages no longer receive security patches, leaving known and future vulnerabilities unaddressed.",
     "SC6": "Package name closely resembles a popular package, suggesting possible typosquatting. Attackers publish malicious packages with similar names to trick developers into installing them.",
+    "SC7": "Code pulls a container image with signature or registry verification disabled (--disable-content-trust, DOCKER_CONTENT_TRUST=0, --insecure-registry). This accepts tampered or unverified images and is a container supply-chain risk.",
     # Trigger Abuse
     "TR1": "Skill uses overly broad trigger patterns that match common words or phrases, causing it to activate in unintended contexts and potentially shadow other skills.",
     "TR2": "Skill trigger shadows a common built-in command or another skill's trigger, potentially intercepting requests meant for trusted functionality.",
@@ -175,6 +176,7 @@ RULE_ID_TO_CATEGORY: dict[str, str] = {
     "SC4": PatternCategory.SUPPLY_CHAIN.value,
     "SC5": PatternCategory.SUPPLY_CHAIN.value,
     "SC6": PatternCategory.SUPPLY_CHAIN.value,
+    "SC7": PatternCategory.SUPPLY_CHAIN.value,
     "TR1": PatternCategory.TRIGGER_ABUSE.value,
     "TR2": PatternCategory.TRIGGER_ABUSE.value,
     "TR3": PatternCategory.TRIGGER_ABUSE.value,
@@ -250,6 +252,7 @@ PATTERN_NAMES: dict[str, str] = {
     "SC4": "Known Vulnerable Dependency",
     "SC5": "Abandoned Dependency",
     "SC6": "Typosquatting Dependency",
+    "SC7": "Untrusted Container Image",
     "TR1": "Overly Broad Trigger",
     "TR2": "Shadow Command Trigger",
     "TR3": "Keyword Baiting Trigger",
@@ -332,6 +335,7 @@ DEFAULT_REMEDIATIONS: dict[str, str] = {
     "SC4": "Update the dependency to a patched version that addresses the known CVE. Check OSV (osv.dev) or NVD for details on the vulnerability.",
     "SC5": "Replace the abandoned dependency with an actively maintained alternative. Check the package's repository for last commit date and open issues.",
     "SC6": "Verify the package name is correct and not a typosquatting variant. Compare against the official package name on PyPI or npm.",
+    "SC7": "Keep image signature verification (Docker Content Trust / cosign) and registry TLS enabled. Pull only signed images from trusted registries; never disable content-trust or use insecure registries in skill code.",
     # Trigger Abuse
     "TR1": "Use specific, narrow trigger patterns that match only the skill's intended use case. Avoid single-word or common-phrase triggers.",
     "TR2": "Choose triggers that do not conflict with built-in commands or other skills. Prefix with a unique namespace if necessary.",

--- a/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
@@ -103,7 +103,10 @@ SC3_PATTERNS = [
 # (`--tls-verify=false` is intentionally omitted: TM3's `verify=False` already
 # covers it; SC7 targets the image-specific bypasses TM3 does not see.)
 SC7_PATTERNS = [
-    (r"--disable-content-trust", 0.85),  # Docker Content Trust signature check off
+    (
+        r"--disable-content-trust\b(?!=false)",
+        0.85,
+    ),  # Content Trust off (exclude =false, which keeps it on)
     (r"DOCKER_CONTENT_TRUST\s*=\s*0", 0.85),  # signature verification disabled via env
     (r"--insecure-registry", 0.8),  # registry TLS verification off
 ]

--- a/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
@@ -13,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Static patterns: supply chain (SC1–SC6) and trigger analysis (TR1–TR3).
+"""Static patterns: supply chain (SC1–SC7) and trigger analysis (TR1–TR3).
 
 SC1–SC3: regex-based pattern matching (original implementation).
 SC4: Known vulnerable dependencies — live OSV.dev lookup with static fallback.
 SC5: Abandoned dependencies — flags known-abandoned or archived packages.
 SC6: Typosquatting — flags package names similar to popular packages.
+SC7: Untrusted container image — flags image signature / registry-verification bypass.
 TR1–TR3: Trigger analysis — flags overly broad, shadowing, or baiting triggers.
 
 Node and analyze() in one module.
@@ -36,7 +37,7 @@ from skillspector.models import AnalyzerFinding, Finding, Location, Severity
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 from . import static_runner
-from .common import get_context, get_line_number
+from .common import get_context, get_line_number, is_code_example
 from .osv_client import ECOSYSTEM_NPM, ECOSYSTEM_PYPI, VulnResult, query_batch, was_osv_reachable
 from .pattern_defaults import PatternCategory
 from .static_runner import analyzer_finding_to_finding
@@ -94,6 +95,17 @@ SC3_PATTERNS = [
     (r"\(lambda\s+_:\s*exec\s*\(", 0.9),
     (r"__import__\s*\(['\"]os['\"]\s*\)\.system", 0.85),
     (r"decode\s+(?:this|the)\s+(?:base64|hex)\s+(?:and\s+)?(?:run|execute)", 0.8),
+]
+
+# SC7: Untrusted Container Image — pulling images with signature/registry
+# verification turned off. These flags disable image trust regardless of the
+# registry, so they are a strong supply-chain signal with near-zero FP.
+# (`--tls-verify=false` is intentionally omitted: TM3's `verify=False` already
+# covers it; SC7 targets the image-specific bypasses TM3 does not see.)
+SC7_PATTERNS = [
+    (r"--disable-content-trust", 0.85),  # Docker Content Trust signature check off
+    (r"DOCKER_CONTENT_TRUST\s*=\s*0", 0.85),  # signature verification disabled via env
+    (r"--insecure-registry", 0.8),  # registry TLS verification off
 ]
 
 # ---------------------------------------------------------------------------
@@ -504,7 +516,7 @@ def _version_lt(v1: str, v2: str) -> bool:
 
 
 def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFinding]:
-    """Analyze content for supply chain patterns (SC1–SC3)."""
+    """Analyze content for supply chain patterns (SC1–SC3, SC7)."""
     findings: list[AnalyzerFinding] = []
 
     def loc(ln: int) -> Location:
@@ -573,6 +585,26 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
                         matched_text=match.group(0)[:200],
                     )
                 )
+    # SC7: untrusted container image. Filtered through is_code_example() because
+    # these flags appear in SKILL.md docs and "never do this" warnings.
+    for pattern, confidence in SC7_PATTERNS:
+        for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
+            context_text = ctx(match.start())
+            if is_code_example(context_text):
+                continue
+            line_num = get_line_number(content, match.start())
+            findings.append(
+                AnalyzerFinding(
+                    rule_id="SC7",
+                    message="Untrusted Container Image",
+                    severity=Severity.HIGH,
+                    location=loc(line_num),
+                    confidence=confidence,
+                    tags=tag,
+                    context=context_text,
+                    matched_text=match.group(0)[:200],
+                )
+            )
     return findings
 
 

--- a/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
@@ -37,7 +37,7 @@ from skillspector.models import AnalyzerFinding, Finding, Location, Severity
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 from . import static_runner
-from .common import get_context, get_line_number, is_code_example
+from .common import get_context, get_line_number
 from .osv_client import ECOSYSTEM_NPM, ECOSYSTEM_PYPI, VulnResult, query_batch, was_osv_reachable
 from .pattern_defaults import PatternCategory
 from .static_runner import analyzer_finding_to_finding
@@ -585,13 +585,9 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
                         matched_text=match.group(0)[:200],
                     )
                 )
-    # SC7: untrusted container image. Filtered through is_code_example() because
-    # these flags appear in SKILL.md docs and "never do this" warnings.
+    # SC7: untrusted container image. Example filtering is delegated to the runner.
     for pattern, confidence in SC7_PATTERNS:
         for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
-            context_text = ctx(match.start())
-            if is_code_example(context_text):
-                continue
             line_num = get_line_number(content, match.start())
             findings.append(
                 AnalyzerFinding(
@@ -601,7 +597,7 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
                     location=loc(line_num),
                     confidence=confidence,
                     tags=tag,
-                    context=context_text,
+                    context=ctx(match.start()),
                     matched_text=match.group(0)[:200],
                 )
             )

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -254,6 +254,17 @@ class TestRunStaticPatternsSupplyChain:
         findings = static_runner.run_static_patterns(state, [supply_chain_module])
         assert any(f.rule_id == "SC7" for f in findings)
 
+    def test_sc7_content_trust_explicitly_enabled_no_finding(self):
+        """`--disable-content-trust=false` keeps verification ON — must NOT yield SC7."""
+        state = {
+            "components": ["setup.sh"],
+            "file_cache": {
+                "setup.sh": "docker pull --disable-content-trust=false registry.io/base:1.0",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [supply_chain_module])
+        assert not any(f.rule_id == "SC7" for f in findings)
+
 
 class TestRunStaticPatternsAgentSnoopingAdditional:
     """run_static_patterns with agent_snooping: AS1, AS2, AS3."""

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -188,6 +188,57 @@ class TestRunStaticPatternsSupplyChain:
         assert len(sc2) >= 1
         assert sc2[0].severity == "HIGH"
 
+    def test_sc7_disable_content_trust_produces_finding(self):
+        """docker pull --disable-content-trust yields SC7, HIGH severity."""
+        state = {
+            "components": ["setup.sh"],
+            "file_cache": {
+                "setup.sh": "docker pull --disable-content-trust registry.io/base:latest"
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [supply_chain_module])
+        sc7 = [f for f in findings if f.rule_id == "SC7"]
+        assert len(sc7) >= 1
+        assert sc7[0].severity == "HIGH"
+
+    def test_sc7_content_trust_env_produces_finding(self):
+        """DOCKER_CONTENT_TRUST=0 yields SC7."""
+        state = {
+            "components": ["setup.sh"],
+            "file_cache": {"setup.sh": "export DOCKER_CONTENT_TRUST=0"},
+        }
+        findings = static_runner.run_static_patterns(state, [supply_chain_module])
+        assert any(f.rule_id == "SC7" for f in findings)
+
+    def test_sc7_insecure_registry_produces_finding(self):
+        """--insecure-registry yields SC7."""
+        state = {
+            "components": ["setup.sh"],
+            "file_cache": {"setup.sh": "docker pull --insecure-registry 10.0.0.5:5000/tools"},
+        }
+        findings = static_runner.run_static_patterns(state, [supply_chain_module])
+        assert any(f.rule_id == "SC7" for f in findings)
+
+    def test_sc7_documentation_example_excluded(self):
+        """Verification-bypass flags in documentation do not yield SC7."""
+        state = {
+            "components": ["README.md"],
+            "file_cache": {
+                "README.md": "For example, never use --disable-content-trust in production."
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [supply_chain_module])
+        assert not any(f.rule_id == "SC7" for f in findings)
+
+    def test_sc7_benign_pull_no_finding(self):
+        """A normal docker pull with verification on does not yield SC7."""
+        state = {
+            "components": ["setup.sh"],
+            "file_cache": {"setup.sh": "docker pull nginx:1.25"},
+        }
+        findings = static_runner.run_static_patterns(state, [supply_chain_module])
+        assert not any(f.rule_id == "SC7" for f in findings)
+
 
 class TestRunStaticPatternsAgentSnoopingAdditional:
     """run_static_patterns with agent_snooping: AS1, AS2, AS3."""

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -239,6 +239,21 @@ class TestRunStaticPatternsSupplyChain:
         findings = static_runner.run_static_patterns(state, [supply_chain_module])
         assert not any(f.rule_id == "SC7" for f in findings)
 
+    def test_sc7_example_marker_in_executable_still_fires(self):
+        """An 'example' marker near a bypass in an executable .sh must NOT suppress SC7.
+
+        Example filtering belongs to the runner, which only downweights (does not
+        skip) executables — so a nearby '# for example' cannot be used to evade SC7.
+        """
+        state = {
+            "components": ["setup.sh"],
+            "file_cache": {
+                "setup.sh": "# for example\ndocker pull --disable-content-trust registry.io/x",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [supply_chain_module])
+        assert any(f.rule_id == "SC7" for f in findings)
+
 
 class TestRunStaticPatternsAgentSnoopingAdditional:
     """run_static_patterns with agent_snooping: AS1, AS2, AS3."""


### PR DESCRIPTION
## Summary

The `supply_chain` analyzer (SC1–SC6) covers package dependencies (PyPI/npm) but has no detection for the **container-image supply chain**. A skill that pulls images with verification turned off — `--disable-content-trust`, `DOCKER_CONTENT_TRUST=0`, `--insecure-registry` — accepts tampered or unverified images yet scored **9/100 SAFE** (#223). This adds **SC7**, the image-layer counterpart of SC1 (unpinned) / SC6 (typosquatting).

## Changes

`static_patterns_supply_chain.py` gains `SC7_PATTERNS` (three image-trust bypass flags) and an SC7 pass filtered through the shared `is_code_example()` helper. `pattern_defaults.py` registers the SC7 explanation, category, message, and remediation alongside SC1–SC6.

## Before / After

A "fast image loader" skill that sets `DOCKER_CONTENT_TRUST=0` and pulls with `--disable-content-trust` / `--insecure-registry`:

- **Before:** `9/100 SAFE` — only the unrelated `--tls-verify=false` line is caught (as a generic TM3 `verify=False`); the image-trust bypass is invisible
- **After:** `57/100 HIGH`, **SC7 ×3** on the content-trust and insecure-registry lines

With the LLM layer (Qwen3.6-35B-A3B-FP8 via vLLM) the same skill scores `78/HIGH` (SDI-1: *"disables Docker Content Trust, TLS verification …"*), so `--no-llm` / air-gapped deployments were the exposed surface this closes.

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Category = `supply_chain` (not new) | A container image is a supply-chain artifact; SC7 is the image-layer version of SC1/SC6. No new category needed. |
| `--tls-verify=false` **excluded** | TM3's existing `verify=False` pattern already catches it. SC7 targets only the image-specific bypasses TM3 cannot see (`--disable-content-trust`, `DOCKER_CONTENT_TRUST=0`, `--insecure-registry`) — avoids duplicate findings on the same line. |
| Severity HIGH, confidence 0.8–0.85 | Disabling verification is dangerous regardless of registry. A normal `docker pull nginx:1.25` does not fire. |

## Testing

5 new tests: detection of `--disable-content-trust`, `DOCKER_CONTENT_TRUST=0`, and `--insecure-registry`; a documentation-example exclusion (`is_code_example`); and a benign-pull negative. `make format` and `make lint` pass; `uv run pytest -m "not integration and not provider"` reports 1003 passed, 0 failed.

Closes #223
