### PR TITLE
feat(scan): add opt-in transitive reference scanning

### DIFF
--- a/src/skillspector/cli.py
+++ b/src/skillspector/cli.py
@@ -24,23 +24,29 @@ from __future__ import annotations
 import json
 import os
 import sys
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from pathlib import Path
+from time import monotonic
 from typing import Annotated, cast
 
 import typer
 from langchain_core.runnables import RunnableConfig
 from rich.console import Console
 
-from skillspector import __version__
+from skillspector import __version__, transitive
 from skillspector.cleanup import cleanup_result
 from skillspector.constants import RISK_THRESHOLD
 from skillspector.graph import graph
 from skillspector.input_handler import validate_local_input_path
+from skillspector.inspection_ledger import finalize_ledger
 from skillspector.logging_config import get_logger, set_level
 from skillspector.mcp_registry import scan_registry
+from skillspector.models import Finding
 from skillspector.multi_skill import MultiSkillDetectionResult, detect_skills
+from skillspector.nodes.report import report
 from skillspector.suppression import (
+    Baseline,
     build_baseline_dict,
     discover_baseline,
     dump_baseline,
@@ -79,6 +85,10 @@ app = typer.Typer(
 console = Console()
 err_console = Console(stderr=True)
 
+_TRANSITIVE_MAX_TARGETS = 32
+_TRANSITIVE_MAX_BYTES = 10 * 1024 * 1024
+_TRANSITIVE_MAX_SECONDS = 60.0
+
 
 class FormatChoice(StrEnum):
     """Output format choices for the CLI."""
@@ -94,6 +104,100 @@ class TransportChoice(StrEnum):
 
     stdio = "stdio"
     http = "http"
+
+
+@dataclass(slots=True)
+class _TransitiveBudget:
+    max_targets: int = _TRANSITIVE_MAX_TARGETS
+    max_bytes: int = _TRANSITIVE_MAX_BYTES
+    max_seconds: float = _TRANSITIVE_MAX_SECONDS
+
+
+@dataclass(slots=True)
+class _CachedTransitiveResult:
+    filtered_findings: list[Finding]
+    findings: list[Finding]
+    effective_finding_ids: list[str]
+    inspection_ledger: list[dict[str, object]]
+    analyzer_status_events: list[dict[str, object]]
+    llm_call_log: list[dict[str, object]]
+    inference_usage: list[dict[str, object]]
+    components: list[str]
+    component_metadata: list[dict[str, object]]
+    file_cache: dict[str, str]
+    has_executable_scripts: bool
+    refs: list[str]
+
+
+@dataclass(slots=True)
+class _TransitiveTraversalState:
+    cache: dict[str, _CachedTransitiveResult] = field(default_factory=dict)
+    budget: _TransitiveBudget = field(default_factory=_TransitiveBudget)
+    started_at: float | None = None
+    scanned_targets: int = 0
+    scanned_bytes: int = 0
+    truncation_reasons: list[str] = field(default_factory=list)
+    budget_exhausted: bool = False
+    paused_at: float | None = None
+
+    def note_truncation(self, reason: str) -> None:
+        if reason not in self.truncation_reasons:
+            self.truncation_reasons.append(reason)
+        if "budget" in reason or "time budget" in reason:
+            self.budget_exhausted = True
+
+    def note_child_scan_failure(self, target: str) -> None:
+        self.note_truncation(f"transitive child scan failed for {target}")
+
+    def _ensure_started(self) -> None:
+        if self.started_at is None:
+            self.started_at = monotonic()
+
+    def can_scan_more(self) -> bool:
+        self._ensure_started()
+        if self.budget_exhausted:
+            return False
+        if self.scanned_targets >= self.budget.max_targets:
+            self.note_truncation(f"target budget {self.budget.max_targets} reached")
+            return False
+        if self.remaining_bytes() <= 0:
+            self.note_truncation(f"byte budget {self.budget.max_bytes} reached")
+            return False
+        if self.remaining_seconds() <= 0:
+            self.note_truncation(f"time budget {self.budget.max_seconds:.0f}s reached")
+            return False
+        return True
+
+    def record_scan(self) -> None:
+        self._ensure_started()
+        self.scanned_targets += 1
+        if self.remaining_bytes() <= 0:
+            self.note_truncation(f"byte budget {self.budget.max_bytes} reached")
+        if self.remaining_seconds() <= 0:
+            self.note_truncation(f"time budget {self.budget.max_seconds:.0f}s reached")
+
+    def record_bytes(self, bytes_scanned: int) -> None:
+        self._ensure_started()
+        self.scanned_bytes += max(0, bytes_scanned)
+
+    def remaining_seconds(self) -> float:
+        self._ensure_started()
+        assert self.started_at is not None
+        end = self.paused_at if self.paused_at is not None else monotonic()
+        return max(0.0, self.budget.max_seconds - (end - self.started_at))
+
+    def remaining_bytes(self) -> int:
+        return max(0, self.budget.max_bytes - self.scanned_bytes)
+
+    def pause_deadline(self) -> None:
+        if self.started_at is not None and self.paused_at is None:
+            self.paused_at = monotonic()
+
+    def resume_deadline(self) -> None:
+        if self.paused_at is not None:
+            assert self.started_at is not None
+            self.started_at += monotonic() - self.paused_at
+            self.paused_at = None
 
 
 def version_callback(value: bool) -> None:
@@ -265,6 +369,36 @@ def scan(
             "is given.",
         ),
     ] = False,
+    transitive_enabled: Annotated[
+        bool,
+        typer.Option(
+            "--transitive",
+            help="Follow transitive external references after the initial scan.",
+        ),
+    ] = False,
+    transitive_depth: Annotated[
+        int,
+        typer.Option(
+            "--transitive-depth",
+            help="Maximum transitive depth to scan for external references.",
+        ),
+    ] = 1,
+    transitive_allow_prefix: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--transitive-allow-prefix",
+            help=(
+                "Only scan transitive targets matching at least one canonical prefix. Repeatable."
+            ),
+        ),
+    ] = None,
+    transitive_deny_prefix: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--transitive-deny-prefix",
+            help=("Skip transitive targets matching any canonical prefix. Repeatable."),
+        ),
+    ] = None,
     verbose: Annotated[
         bool,
         typer.Option(
@@ -348,6 +482,14 @@ def scan(
         except ValueError as e:
             console.print(f"[red]Error:[/red] {e}")
             raise typer.Exit(code=2) from e
+    try:
+        transitive_allow_prefix, transitive_deny_prefix = transitive.normalize_prefixes(
+            transitive_allow_prefix, transitive_deny_prefix
+        )
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] invalid transitive prefix: {exc}")
+        raise typer.Exit(code=2) from exc
+    yara_dir = str(yara_rules_dir.resolve()) if yara_rules_dir else None
     if recursive and resolved_path.is_dir():
         detection = detect_skills(resolved_path)
         if detection.is_multi_skill:
@@ -357,7 +499,20 @@ def scan(
                     "multi-skill scans; scan each sub-skill with its own baseline"
                 )
                 raise typer.Exit(code=2)
-            _scan_multi_skill(detection, format, output, no_llm, yara_rules_dir, verbose)
+            _scan_multi_skill(
+                detection,
+                format=format,
+                output=output,
+                no_llm=no_llm,
+                baseline=baseline,
+                show_suppressed=show_suppressed,
+                transitive_enabled=transitive_enabled,
+                transitive_depth=transitive_depth,
+                transitive_allow_prefix=transitive_allow_prefix,
+                transitive_deny_prefix=transitive_deny_prefix,
+                yara_dir=yara_dir,
+                verbose=verbose,
+            )
             return
         if not detection.has_root_skill and len(detection.skills) == 0:
             console.print(
@@ -399,26 +554,19 @@ def scan(
 
     result = None
     try:
-        yara_dir = str(yara_rules_dir.resolve()) if yara_rules_dir else None
-        state = _scan_state(
-            input_path,
-            format,
-            no_llm,
-            yara_rules_dir=yara_dir,
+        result = _scan_skill(
+            input_path=input_path,
+            format=format,
+            no_llm=no_llm,
             baseline=baseline,
+            yara_rules_dir=Path(yara_dir) if yara_dir else None,
+            verbose=verbose,
             show_suppressed=show_suppressed,
+            transitive_enabled=transitive_enabled,
+            transitive_depth=transitive_depth,
+            transitive_allow_prefix=transitive_allow_prefix,
+            transitive_deny_prefix=transitive_deny_prefix,
         )
-        if verbose:
-            console.print("[dim]Running scan...[/dim]")
-        logger.debug(
-            "Scan started: input_path=%s, format=%s, use_llm=%s",
-            input_path,
-            format,
-            not no_llm,
-        )
-        trace_config = _build_trace_config(input_path, format, no_llm)
-        result = graph.invoke(state, config=trace_config)
-
         _write_result(result, output, format)
 
         if result.get("execution_successful") is False:
@@ -459,38 +607,503 @@ def _build_trace_config(input_path: str, format: FormatChoice, no_llm: bool) -> 
     }
 
 
+def _coerce_str_path_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if isinstance(item, str)]
+
+
+def _coerce_findings_list(value: object) -> list[Finding]:
+    if not isinstance(value, list):
+        return []
+    return [finding for finding in value if isinstance(finding, Finding)]
+
+
+def _coerce_finding_ids(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _effective_finding_ids(result: dict[str, object]) -> list[str]:
+    effective_ids = _coerce_finding_ids(result.get("effective_finding_ids"))
+    if effective_ids:
+        return effective_ids
+    return [
+        finding.finding_id for finding in _coerce_findings_list(result.get("filtered_findings"))
+    ]
+
+
+def _coerce_llm_call_log(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _coerce_dict_list(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _source_aware_ledger(value: object, source_url: str) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    for event in _coerce_dict_list(value):
+        entry = dict(event)
+        path = entry.get("path")
+        if isinstance(path, str) and path:
+            entry["path"] = _transitive_component_key(source_url, path)
+        events.append(entry)
+    return events
+
+
+def _source_aware_status_events(value: object, source_url: str) -> list[dict[str, object]]:
+    statuses: list[dict[str, object]] = []
+    for status in _coerce_dict_list(value):
+        entry = dict(status)
+        planned_work = entry.get("planned_work")
+        if isinstance(planned_work, list):
+            scoped_work: list[dict[str, object]] = []
+            for target in planned_work:
+                if not isinstance(target, dict):
+                    continue
+                scoped_target = dict(target)
+                path = scoped_target.get("path")
+                if isinstance(path, str) and path:
+                    scoped_target["path"] = _transitive_component_key(source_url, path)
+                scoped_work.append(scoped_target)
+            entry["planned_work"] = scoped_work
+        statuses.append(entry)
+    return statuses
+
+
+def _coerce_file_cache(value: object) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        str(path): content
+        for path, content in value.items()
+        if isinstance(path, str) and isinstance(content, str)
+    }
+
+
+def _transitive_component_key(source_url: str | None, path: str) -> str:
+    return f"{source_url}::{path}" if source_url else path
+
+
+def _decorate_component_metadata(
+    metadata: list[dict[str, object]], source_url: str | None
+) -> list[dict[str, object]]:
+    decorated: list[dict[str, object]] = []
+    for item in metadata:
+        path = str(item.get("path", ""))
+        entry = {**item, "coverage_key": _transitive_component_key(source_url, path)}
+        if source_url:
+            entry["source_url"] = source_url
+        decorated.append(entry)
+    return decorated
+
+
+def _source_aware_components(paths: list[str], source_url: str | None) -> list[str]:
+    return [_transitive_component_key(source_url, path) for path in paths]
+
+
+def _source_aware_file_cache(file_cache: dict[str, str], source_url: str | None) -> dict[str, str]:
+    return {
+        _transitive_component_key(source_url, path): content for path, content in file_cache.items()
+    }
+
+
+def _component_identity(item: dict[str, object]) -> str:
+    coverage_key = item.get("coverage_key")
+    if isinstance(coverage_key, str) and coverage_key:
+        return coverage_key
+    path = str(item.get("path", ""))
+    source_url = item.get("source_url")
+    return _transitive_component_key(source_url if isinstance(source_url, str) else None, path)
+
+
+def _merge_unique_component_metadata(items: list[dict[str, object]]) -> list[dict[str, object]]:
+    merged: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for item in items:
+        identity = _component_identity(item)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        merged.append(item)
+    return merged
+
+
+def _cache_transitive_result(
+    target: str, child_result: dict[str, object]
+) -> _CachedTransitiveResult:
+    child_file_cache = _coerce_file_cache(child_result.get("file_cache"))
+    child_metadata = _decorate_component_metadata(
+        _coerce_component_metadata(child_result.get("component_metadata")), target
+    )
+    return _CachedTransitiveResult(
+        filtered_findings=_coerce_findings_list(child_result.get("filtered_findings")),
+        findings=_coerce_findings_list(child_result.get("findings")),
+        effective_finding_ids=_effective_finding_ids(child_result),
+        inspection_ledger=_source_aware_ledger(child_result.get("inspection_ledger"), target),
+        analyzer_status_events=_source_aware_status_events(
+            child_result.get("analyzer_status_events"), target
+        ),
+        llm_call_log=_coerce_llm_call_log(child_result.get("llm_call_log")),
+        inference_usage=_coerce_dict_list(child_result.get("inference_usage")),
+        components=_source_aware_components(
+            _coerce_str_path_list(child_result.get("components")), target
+        ),
+        component_metadata=child_metadata,
+        file_cache=_source_aware_file_cache(child_file_cache, target),
+        has_executable_scripts=bool(child_result.get("has_executable_scripts", False))
+        or any(bool(entry.get("executable", False)) for entry in child_metadata),
+        refs=transitive.extract_external_refs(child_file_cache),
+    )
+
+
+def _run_graph_scan(
+    input_path: str,
+    format: FormatChoice,
+    no_llm: bool,
+    yara_dir: str | None = None,
+    baseline: Path | None = None,
+    show_suppressed: bool = False,
+    transitive_traversal: _TransitiveTraversalState | None = None,
+) -> dict[str, object]:
+    state = _scan_state(
+        input_path=input_path,
+        format=format,
+        no_llm=no_llm,
+        yara_rules_dir=yara_dir,
+        baseline=baseline,
+        show_suppressed=show_suppressed,
+    )
+    if transitive_traversal is not None:
+        state["transitive_traversal_state"] = transitive_traversal
+    trace_config = _build_trace_config(input_path, format, no_llm)
+    return graph.invoke(state, config=trace_config)
+
+
+def _annotate_transitive_findings(
+    findings: list[Finding],
+    source_url: str,
+    transitive_depth: int,
+) -> list[Finding]:
+    return [
+        replace(finding, transitive_depth=transitive_depth, source_url=source_url)
+        for finding in findings
+    ]
+
+
+def _scan_transitive(
+    initial_result: dict[str, object],
+    format: FormatChoice,
+    no_llm: bool,
+    max_depth: int,
+    transitive_allow_prefix: tuple[str, ...] | list[str] | None,
+    transitive_deny_prefix: tuple[str, ...] | list[str] | None,
+    baseline: Path | None,
+    show_suppressed: bool,
+    visited: set[str],
+    scan_cache: dict[str, _CachedTransitiveResult] | None = None,
+    budget: _TransitiveBudget | None = None,
+    yara_dir: str | None = None,
+    traversal: _TransitiveTraversalState | None = None,
+) -> dict[str, object]:
+    if max_depth <= 0:
+        report_result = report(initial_result)
+        report_result["temp_dir_for_cleanup"] = initial_result.get("temp_dir_for_cleanup")
+        report_result["transitive_finding_count"] = 0
+        report_result["transitive_sources"] = []
+        report_result["transitive_targets_scanned"] = 0
+        report_result["transitive_bytes_scanned"] = 0
+        report_result["transitive_truncated"] = False
+        report_result["transitive_truncation_reasons"] = []
+        return report_result
+
+    if traversal is None:
+        traversal = _TransitiveTraversalState(
+            cache=scan_cache if scan_cache is not None else {},
+            budget=budget if budget is not None else _TransitiveBudget(),
+        )
+    elif scan_cache is not None and traversal.cache is not scan_cache:
+        traversal.cache = scan_cache
+    transitive_sources: set[str] = set()
+    merged_filtered_findings: list[Finding] = _coerce_findings_list(
+        initial_result.get("filtered_findings")
+    )
+    merged_findings: list[Finding] = _coerce_findings_list(initial_result.get("findings"))
+    merged_llm_call_log: list[dict[str, object]] = _coerce_llm_call_log(
+        initial_result.get("llm_call_log")
+    )
+    merged_inference_usage = _coerce_dict_list(initial_result.get("inference_usage"))
+    merged_effective_finding_ids = _effective_finding_ids(initial_result)
+    merged_inspection_ledger = _coerce_dict_list(initial_result.get("inspection_ledger"))
+    merged_analyzer_status_events = _coerce_dict_list(initial_result.get("analyzer_status_events"))
+    merged_components = _source_aware_components(
+        _coerce_str_path_list(initial_result.get("components")), None
+    )
+    file_cache = _coerce_file_cache(initial_result.get("file_cache"))
+    merged_file_cache = _source_aware_file_cache(file_cache, None)
+    component_metadata = _decorate_component_metadata(
+        _coerce_component_metadata(initial_result.get("component_metadata")), None
+    )
+    has_executable_scripts = bool(initial_result.get("has_executable_scripts", False))
+
+    frontier: list[tuple[int, list[str]]] = [(1, transitive.extract_external_refs(file_cache))]
+
+    while frontier:
+        if not traversal.can_scan_more():
+            break
+        current_depth, refs = frontier.pop(0)
+        targets = transitive.plan_transitive_targets(
+            refs=refs,
+            visited=visited,
+            current_depth=current_depth,
+            max_depth=max_depth,
+            allow_prefixes=transitive_allow_prefix,
+            deny_prefixes=transitive_deny_prefix,
+        )
+        for target in targets:
+            if not traversal.can_scan_more():
+                break
+            child_result: dict[str, object] | None = None
+            try:
+                cached = traversal.cache.get(target)
+                if cached is None:
+                    child_result = _run_graph_scan(
+                        input_path=target,
+                        format=format,
+                        no_llm=no_llm,
+                        yara_dir=yara_dir,
+                        baseline=baseline,
+                        show_suppressed=show_suppressed,
+                        transitive_traversal=traversal,
+                    )
+                    cached = _cache_transitive_result(target, child_result)
+                    traversal.cache[target] = cached
+                    traversal.record_scan()
+                    if child_result.get("execution_successful") is False:
+                        traversal.note_child_scan_failure(target)
+                    child_completeness = child_result.get("analysis_completeness")
+                    if (
+                        isinstance(child_completeness, dict)
+                        and child_completeness.get("is_complete") is False
+                    ):
+                        traversal.note_truncation(f"transitive child scan incomplete for {target}")
+                transitive_sources.add(target)
+                merged_inspection_ledger.extend(cached.inspection_ledger)
+                merged_analyzer_status_events.extend(cached.analyzer_status_events)
+                merged_llm_call_log.extend(cached.llm_call_log)
+                merged_inference_usage.extend(cached.inference_usage)
+                merged_effective_finding_ids.extend(cached.effective_finding_ids)
+                merged_filtered_findings.extend(
+                    _annotate_transitive_findings(
+                        cached.filtered_findings, source_url=target, transitive_depth=current_depth
+                    )
+                )
+                merged_findings.extend(
+                    _annotate_transitive_findings(
+                        cached.findings, source_url=target, transitive_depth=current_depth
+                    )
+                )
+
+                component_metadata.extend(cached.component_metadata)
+                if cached.has_executable_scripts:
+                    has_executable_scripts = True
+                merged_components.extend(cached.components)
+                merged_file_cache.update(cached.file_cache)
+
+                if current_depth < max_depth:
+                    frontier.append((current_depth + 1, cached.refs))
+            except Exception:
+                transitive_sources.add(target)
+                traversal.note_child_scan_failure(target)
+                if format == FormatChoice.json:
+                    logger.warning("Transitive scan failed for %s", target)
+                else:
+                    console.print(f"[yellow]Warning:[/yellow] Transitive scan failed for {target}")
+            finally:
+                if child_result is not None:
+                    cleanup_result(child_result)
+
+    merged_result: dict[str, object] = {
+        **initial_result,
+        "filtered_findings": merged_filtered_findings,
+        "findings": merged_findings,
+        "components": merged_components,
+        "component_metadata": _merge_unique_component_metadata(component_metadata),
+        "file_cache": merged_file_cache,
+        "has_executable_scripts": has_executable_scripts,
+        "llm_call_log": merged_llm_call_log,
+        "inference_usage": merged_inference_usage,
+        "effective_finding_ids": list(dict.fromkeys(merged_effective_finding_ids)),
+        "inspection_ledger": merged_inspection_ledger,
+        "analyzer_status_events": merged_analyzer_status_events,
+        "baseline": initial_result.get(
+            "baseline", baseline if isinstance(baseline, Baseline) else None
+        ),
+        "show_suppressed": initial_result.get("show_suppressed", show_suppressed),
+        "transitive_targets_scanned": traversal.scanned_targets,
+        "transitive_bytes_scanned": traversal.scanned_bytes,
+        "transitive_truncated": bool(traversal.truncation_reasons),
+        "transitive_truncation_reasons": traversal.truncation_reasons,
+    }
+    if merged_inspection_ledger or merged_analyzer_status_events:
+        completeness, effective_ids = finalize_ledger(merged_result)
+        merged_result["analysis_completeness"] = completeness
+        merged_result["execution_successful"] = completeness["execution_successful"]
+        merged_result["effective_finding_ids"] = effective_ids
+    report_result = report(merged_result)
+    report_result["temp_dir_for_cleanup"] = initial_result.get("temp_dir_for_cleanup")
+    active_findings = report_result.get("active_findings") or []
+    report_result["transitive_finding_count"] = sum(
+        1
+        for finding in active_findings
+        if isinstance(finding, Finding) and finding.source_url is not None
+    )
+    report_result["transitive_sources"] = sorted(transitive_sources)
+    report_result["transitive_targets_scanned"] = traversal.scanned_targets
+    report_result["transitive_bytes_scanned"] = traversal.scanned_bytes
+    report_result["transitive_truncated"] = bool(traversal.truncation_reasons)
+    report_result["transitive_truncation_reasons"] = traversal.truncation_reasons
+    return report_result
+
+
+def _coerce_component_metadata(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _scan_skill(
+    input_path: str,
+    format: FormatChoice,
+    no_llm: bool,
+    baseline: Path | None,
+    yara_rules_dir: Path | None,
+    verbose: bool,
+    show_suppressed: bool,
+    transitive_enabled: bool,
+    transitive_depth: int,
+    transitive_allow_prefix: tuple[str, ...] | list[str] | None,
+    transitive_deny_prefix: tuple[str, ...] | list[str] | None,
+    transitive_cache: dict[str, _CachedTransitiveResult] | None = None,
+    transitive_traversal: _TransitiveTraversalState | None = None,
+) -> dict[str, object]:
+    yara_dir = str(yara_rules_dir.resolve()) if yara_rules_dir else None
+    active_visited: set[str] = set()
+    if verbose:
+        console.print("[dim]Running scan...[/dim]")
+    logger.debug(
+        "Scan started: input_path=%s, format=%s, use_llm=%s, transitive=%s",
+        input_path,
+        format,
+        not no_llm,
+        transitive_enabled,
+    )
+    if transitive_traversal is not None:
+        transitive_traversal.pause_deadline()
+    try:
+        result = _run_graph_scan(
+            input_path=input_path,
+            format=format,
+            no_llm=no_llm,
+            yara_dir=yara_dir,
+            baseline=baseline,
+            show_suppressed=show_suppressed,
+            transitive_traversal=None,
+        )
+    finally:
+        if transitive_traversal is not None:
+            transitive_traversal.resume_deadline()
+    if not transitive_enabled:
+        return result
+    if transitive_traversal is None:
+        transitive_traversal = _TransitiveTraversalState(cache=transitive_cache or {})
+    transitive_allow_prefix, transitive_deny_prefix = transitive.normalize_prefixes(
+        transitive_allow_prefix, transitive_deny_prefix
+    )
+    try:
+        active_visited.add(transitive.canonicalize_source_identity(input_path))
+    except ValueError:
+        pass
+    return _scan_transitive(
+        initial_result=result,
+        format=format,
+        no_llm=no_llm,
+        max_depth=transitive_depth,
+        transitive_allow_prefix=transitive_allow_prefix,
+        transitive_deny_prefix=transitive_deny_prefix,
+        baseline=baseline,
+        show_suppressed=show_suppressed,
+        visited=active_visited,
+        scan_cache=transitive_cache,
+        yara_dir=yara_dir,
+        traversal=transitive_traversal,
+    )
+
+
 def _scan_multi_skill(
     detection: MultiSkillDetectionResult,
     format: FormatChoice,
     output: Path | None,
     no_llm: bool,
-    yara_rules_dir: Path | None,
-    verbose: bool,
+    baseline: Path | None = None,
+    show_suppressed: bool = False,
+    transitive_enabled: bool = False,
+    transitive_depth: int = 1,
+    transitive_allow_prefix: tuple[str, ...] | list[str] | None = None,
+    transitive_deny_prefix: tuple[str, ...] | list[str] | None = None,
+    yara_dir: str | None = None,
+    verbose: bool = False,
+    **legacy_kwargs: object,
 ) -> None:
     """Scan each detected sub-skill independently and produce a combined report."""
+    if yara_dir is None and isinstance(legacy_kwargs.get("yara_rules_dir"), Path):
+        yara_dir = str(legacy_kwargs["yara_rules_dir"])
     skills = detection.skills
     console.print(f"[bold]Multi-skill directory detected:[/bold] {len(skills)} skills found\n")
 
+    shared_transitive_cache: dict[str, _CachedTransitiveResult] = {}
+    shared_transitive_traversal = _TransitiveTraversalState(cache=shared_transitive_cache)
     results: list[dict[str, object]] = []
     max_score = 0
     execution_failed = False
+    transitive_finding_count = 0
+    transitive_sources: set[str] = set()
 
     for i, skill in enumerate(skills, 1):
         console.print(
             f"  [{i}/{len(skills)}] Scanning [bold]{skill.name}[/bold] ({skill.relative_path}/)"
         )
-        yara_dir = str(yara_rules_dir.resolve()) if yara_rules_dir else None
-        state = _scan_state(str(skill.path), format, no_llm, yara_rules_dir=yara_dir)
-        trace_config = _build_trace_config(str(skill.path), format, no_llm)
-
         try:
-            result = graph.invoke(state, config=trace_config)
+            result = _scan_skill(
+                input_path=str(skill.path),
+                format=format,
+                no_llm=no_llm,
+                baseline=baseline,
+                yara_rules_dir=Path(yara_dir) if yara_dir else None,
+                verbose=verbose,
+                show_suppressed=show_suppressed,
+                transitive_enabled=transitive_enabled,
+                transitive_depth=transitive_depth,
+                transitive_allow_prefix=transitive_allow_prefix,
+                transitive_deny_prefix=transitive_deny_prefix,
+                transitive_cache=shared_transitive_cache,
+                transitive_traversal=shared_transitive_traversal,
+            )
             results.append(result)
             if result.get("execution_successful") is False:
                 execution_failed = True
             score = result.get("risk_score") or 0
             if isinstance(score, int) and score > max_score:
                 max_score = score
+            transitive_finding_count += int(result.get("transitive_finding_count") or 0)
+            for source in _coerce_str_path_list(result.get("transitive_sources")):
+                transitive_sources.add(source)
             severity = result.get("risk_severity") or "LOW"
             console.print(f"         Score: {score}/100 ({severity})\n")
         except Exception as e:
@@ -517,14 +1130,14 @@ def _scan_multi_skill(
             f"  {skill.name:<30} {score:<8} {severity:<12} {finding_count:<10} {execution:<10}"
         )
 
-    console.print("")
-
     if output and format == FormatChoice.json:
         combined: dict[str, object] = {
             "multi_skill": True,
             "skill_count": len(skills),
             "max_risk_score": max_score,
             "execution_successful": not execution_failed,
+            "transitive_finding_count": transitive_finding_count,
+            "transitive_sources": sorted(transitive_sources),
             "skills": [],
         }
         combined_skills = cast(list[dict[str, object]], combined["skills"])
@@ -542,6 +1155,8 @@ def _scan_multi_skill(
                     "risk_severity": result.get("risk_severity", "LOW"),
                     "finding_count": finding_count,
                     "execution_successful": result.get("execution_successful", True),
+                    "transitive_finding_count": result.get("transitive_finding_count", 0),
+                    "transitive_sources": result.get("transitive_sources", []),
                 }
                 entry.update(payload)
                 entry["name"] = skill.name
@@ -551,6 +1166,8 @@ def _scan_multi_skill(
                 entry["finding_count"] = finding_count
                 entry["execution_successful"] = result.get("execution_successful", True)
                 combined_skills.append(entry)
+                entry["transitive_finding_count"] = result.get("transitive_finding_count", 0)
+                entry["transitive_sources"] = result.get("transitive_sources", [])
         Path(output).write_text(json.dumps(combined, indent=2), encoding="utf-8")
         console.print(f"[green]Combined report saved to:[/green] {output}")
     elif output:

--- a/src/skillspector/input_handler.py
+++ b/src/skillspector/input_handler.py
@@ -47,7 +47,7 @@ from errno import ELOOP, ENOENT, ENOTDIR
 from pathlib import Path
 from stat import S_ISLNK, S_ISREG
 from typing import BinaryIO, cast
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
@@ -75,6 +75,11 @@ ALLOWED_DOWNLOAD_HOSTS = frozenset(
         "huggingface.co",
     }
 )
+_DIRECT_FILE_URL_SUFFIXES = (
+    ".md",
+    ".py",
+    ".sh",
+)
 
 # Hard ceiling on what any single ingest path can pull into the temp dir.
 # Sized above the per-file analysis cap (``MAX_FILE_BYTES`` = 1 MB) so a
@@ -87,11 +92,6 @@ INGEST_MAX_BYTES = 100 * 1024 * 1024  # 100 MiB
 # entry is small but the entry count itself exhausts the filesystem.
 INGEST_MAX_ZIP_MEMBERS = 10_000
 
-# Chunk size for streaming HTTP downloads.  Small enough that the
-# byte-count breach check fires promptly; large enough to keep syscall
-# overhead reasonable on legitimate inputs.
-_DOWNLOAD_CHUNK_BYTES = 64 * 1024
-
 
 class IngestLimitExceededError(ValueError):
     """Raised when an ingest path exceeds an ``INGEST_MAX_*`` budget.
@@ -99,6 +99,10 @@ class IngestLimitExceededError(ValueError):
     Subclass of ``ValueError`` so existing callers that catch
     ``ValueError`` from ``InputHandler.resolve()`` continue to work.
     """
+
+
+class _TraversalBudgetError(ValueError):
+    """Raised when transitive input work should truncate rather than fail."""
 
 
 def _is_private_ip(host: str) -> bool:
@@ -392,8 +396,9 @@ class InputHandler:
     Normalizes all inputs to a local directory path for scanning.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, transitive_budget: object | None = None) -> None:
         self._temp_dir: Path | None = None
+        self._transitive_budget = transitive_budget
 
     def resolve(self, input_path: str) -> tuple[Path, str]:
         """
@@ -448,6 +453,49 @@ class InputHandler:
             self._temp_dir = Path(tempfile.mkdtemp(prefix="skillspector_"))
         return self._temp_dir
 
+    def _remaining_seconds(self) -> float | None:
+        remaining = getattr(self._transitive_budget, "remaining_seconds", None)
+        if callable(remaining):
+            try:
+                return float(remaining())
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    def _remaining_bytes(self) -> int | None:
+        remaining = getattr(self._transitive_budget, "remaining_bytes", None)
+        if callable(remaining):
+            try:
+                return int(remaining())
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    def _note_truncation(self, reason: str) -> None:
+        note = getattr(self._transitive_budget, "note_truncation", None)
+        if callable(note):
+            note(reason)
+
+    def _empty_result_dir(self, reason: str, name: str) -> Path:
+        self._note_truncation(reason)
+        temp_dir = self._get_temp_dir()
+        target = temp_dir / name
+        if target.exists():
+            shutil.rmtree(target, ignore_errors=True)
+        target.mkdir(parents=True, exist_ok=True)
+        return target
+
+    def _measure_tree_bytes(self, root: Path) -> int:
+        total = 0
+        for path in root.rglob("*"):
+            if not path.is_file() or path.is_symlink() or ".git" in path.parts:
+                continue
+            try:
+                total += path.stat().st_size
+            except OSError:
+                logger.debug("Could not stat cloned file: %s", path)
+        return total
+
     def _is_git_url(self, path: str) -> bool:
         """Check if path is a Git repository URL."""
         if not path.startswith(("https://", "git@")):
@@ -455,7 +503,13 @@ class InputHandler:
         parsed = urlparse(path)
         host = parsed.hostname or ""
         if any(allowed in host for allowed in ALLOWED_GIT_HOSTS):
-            if "/raw/" in path or "/blob/" in path or path.endswith((".md", ".py", ".sh")):
+            lower_path = parsed.path.lower()
+            if (
+                "/raw/" in lower_path
+                or "/blob/" in lower_path
+                or "/archive/" in lower_path
+                or lower_path.endswith(_DIRECT_FILE_URL_SUFFIXES)
+            ):
                 return False
             return True
         if path.endswith(".git"):
@@ -502,21 +556,34 @@ class InputHandler:
         self._validate_url_host(url, ALLOWED_GIT_HOSTS)
         temp_dir = self._get_temp_dir()
         clone_dir = temp_dir / "repo"
+        remaining_seconds = self._remaining_seconds()
+        remaining_bytes = self._remaining_bytes()
+        if remaining_seconds is not None and remaining_seconds <= 0:
+            return self._empty_result_dir(
+                "Transitive time budget exhausted before git clone", "repo"
+            )
+        if remaining_bytes is not None and remaining_bytes <= 0:
+            return self._empty_result_dir(
+                "Transitive byte budget exhausted before git clone", "repo"
+            )
+        clone_command = [
+            "git",
+            "-c",
+            "core.symlinks=false",
+            "clone",
+            "--depth",
+            "1",
+            url,
+            str(clone_dir),
+        ]
+        if remaining_bytes is not None:
+            clone_command.insert(6, f"--filter=blob:limit={remaining_bytes}")
         try:
             subprocess.run(
-                [
-                    "git",
-                    "-c",
-                    "core.symlinks=false",
-                    "clone",
-                    "--depth",
-                    "1",
-                    url,
-                    str(clone_dir),
-                ],
+                clone_command,
                 check=True,
                 capture_output=True,
-                timeout=60,
+                timeout=remaining_seconds if remaining_seconds is not None else 60,
                 shell=False,
             )
         except subprocess.CalledProcessError as e:
@@ -524,12 +591,20 @@ class InputHandler:
             raise ValueError(f"Failed to clone repository: {e.stderr.decode()}") from e
         except subprocess.TimeoutExpired:
             logger.warning("Git clone timed out for %s", url)
-            raise ValueError("Git clone timed out after 60 seconds") from None
+            raise ValueError(
+                f"Git clone timed out after {remaining_seconds or 60:.0f} seconds"
+            ) from None
         except FileNotFoundError:
             logger.warning("Git not found when cloning %s", url)
             raise ValueError(
                 "Git is not installed. Please install git to scan repositories."
             ) from None
+
+        tree_bytes = self._measure_tree_bytes(clone_dir)
+        if remaining_bytes is not None and tree_bytes > remaining_bytes:
+            return self._empty_result_dir(
+                "Transitive byte budget exceeded by cloned repository", "repo"
+            )
 
         # Post-clone size check: a successful --depth 1 clone may still
         # land an arbitrarily large tree on disk before we can measure
@@ -564,6 +639,8 @@ class InputHandler:
         partial file produced by a mid-stream breach is removed before
         the exception propagates.
         """
+        if self._transitive_budget is not None:
+            return self._download_transitive_file(url)
         self._validate_url_host(url, ALLOWED_DOWNLOAD_HOSTS)
         temp_dir = self._get_temp_dir()
         parsed = urlparse(url)
@@ -575,38 +652,35 @@ class InputHandler:
         download_path = temp_dir / "_download.partial"
         content_type = ""
         try:
+            self._validate_url_host(url, ALLOWED_DOWNLOAD_HOSTS)
             with httpx.Client(follow_redirects=False, timeout=30) as client:
                 with client.stream("GET", url) as response:
                     response.raise_for_status()
                     content_type = response.headers.get("content-type", "")
                     # Cheap up-front check: trust Content-Length when the
                     # server provides it, so we abort before reading any
-                    # body bytes.  Streaming check below covers the case
+                    # body bytes. Streaming check below covers the case
                     # where the header is missing or wrong.
                     declared = response.headers.get("content-length")
                     if declared is not None:
                         try:
                             declared_bytes = int(declared)
                         except ValueError:
-                            # Malformed header — fall through to the
-                            # streamed byte counter, which is authoritative.
                             declared_bytes = None
                         if declared_bytes is not None and declared_bytes > INGEST_MAX_BYTES:
                             raise IngestLimitExceededError(
-                                f"Download exceeded ingest cap: "
-                                f"Content-Length {declared} bytes > "
+                                f"Download exceeded ingest cap: Content-Length {declared} bytes > "
                                 f"INGEST_MAX_BYTES ({INGEST_MAX_BYTES})"
                             )
 
                     received = 0
                     with download_path.open("wb") as out:
-                        for chunk in response.iter_bytes(_DOWNLOAD_CHUNK_BYTES):
+                        for chunk in response.iter_bytes():
                             received += len(chunk)
                             if received > INGEST_MAX_BYTES:
                                 raise IngestLimitExceededError(
-                                    f"Download exceeded ingest cap: streamed "
-                                    f"{received} bytes > INGEST_MAX_BYTES "
-                                    f"({INGEST_MAX_BYTES})"
+                                    f"Download exceeded ingest cap: streamed {received} bytes > "
+                                    f"INGEST_MAX_BYTES ({INGEST_MAX_BYTES})"
                                 )
                             out.write(chunk)
         except httpx.HTTPError as e:
@@ -628,6 +702,78 @@ class InputHandler:
         download_path.replace(file_path)
         return temp_dir
 
+    def _download_transitive_file(self, url: str) -> Path:
+        temp_dir = self._get_temp_dir()
+        try:
+            headers, final_url, content = self._download_with_redirect_validation(url)
+            filename = Path(urlparse(final_url).path).name or "SKILL.md"
+        except _TraversalBudgetError as exc:
+            return self._empty_result_dir(str(exc), "download")
+        except httpx.HTTPError as exc:
+            raise ValueError(f"Failed to download file: {exc}") from exc
+        if filename.endswith(".zip") or headers.get("content-type", "").startswith(
+            "application/zip"
+        ):
+            zip_path = temp_dir / "download.zip"
+            zip_path.write_bytes(content)
+            return self._extract_zip(zip_path)
+        (temp_dir / filename).write_bytes(content)
+        return temp_dir
+
+    def _download_with_redirect_validation(self, url: str) -> tuple[dict[str, str], str, bytes]:
+        current_url = url
+        for _ in range(5):
+            remaining_seconds = self._remaining_seconds()
+            if remaining_seconds is not None and remaining_seconds <= 0:
+                raise _TraversalBudgetError("Transitive time budget exhausted before download")
+            self._validate_url_host(current_url, ALLOWED_DOWNLOAD_HOSTS)
+            with httpx.Client(follow_redirects=False, timeout=remaining_seconds or 30) as client:
+                with client.stream("GET", current_url) as response:
+                    if response.status_code in {301, 302, 303, 307, 308}:
+                        location = response.headers.get("location")
+                        if not location:
+                            raise ValueError(f"Redirect response missing location: {current_url}")
+                        current_url = urljoin(current_url, location)
+                        continue
+                    response.raise_for_status()
+                    remaining_bytes = self._remaining_bytes()
+                    declared = response.headers.get("content-length")
+                    if declared is not None:
+                        try:
+                            declared_bytes = int(declared)
+                        except ValueError:
+                            declared_bytes = None
+                        if declared_bytes is not None and declared_bytes > INGEST_MAX_BYTES:
+                            raise IngestLimitExceededError(
+                                f"Download exceeded ingest cap: Content-Length {declared} bytes > "
+                                f"INGEST_MAX_BYTES ({INGEST_MAX_BYTES})"
+                            )
+                        if (
+                            declared_bytes is not None
+                            and remaining_bytes is not None
+                            and declared_bytes > remaining_bytes
+                        ):
+                            raise _TraversalBudgetError(
+                                "Transitive byte budget exceeded by downloaded file"
+                            )
+                    content = bytearray()
+                    for chunk in response.iter_bytes():
+                        if self._remaining_seconds() is not None and self._remaining_seconds() <= 0:
+                            raise _TraversalBudgetError(
+                                "Transitive time budget exhausted during download"
+                            )
+                        content.extend(chunk)
+                        if len(content) > INGEST_MAX_BYTES:
+                            raise IngestLimitExceededError(
+                                "Download exceeded ingest cap while following redirect"
+                            )
+                        if remaining_bytes is not None and len(content) > remaining_bytes:
+                            raise _TraversalBudgetError(
+                                "Transitive byte budget exceeded by downloaded file"
+                            )
+                    return dict(response.headers), current_url, bytes(content)
+        raise ValueError(f"Too many redirects while downloading: {url}")
+
     def _extract_zip(self, zip_path: Path) -> Path:
         """Extract a zip file, bounded by ``INGEST_MAX_BYTES`` and ``INGEST_MAX_ZIP_MEMBERS``.
 
@@ -639,6 +785,11 @@ class InputHandler:
         member name is applied before extraction to reject entries whose
         resolved path escapes the extraction directory.
         """
+        remaining_bytes = self._remaining_bytes()
+        if remaining_bytes is not None and remaining_bytes <= 0:
+            return self._empty_result_dir(
+                "Transitive byte budget exhausted before zip extraction", "extracted"
+            )
         with _open_regular_file_no_follow(zip_path) as archive_file:
             temp_dir = self._get_temp_dir()
             extract_dir = temp_dir / "extracted"
@@ -652,6 +803,10 @@ class InputHandler:
                             f"INGEST_MAX_ZIP_MEMBERS ({INGEST_MAX_ZIP_MEMBERS})"
                         )
                     total_uncompressed = sum(info.file_size for info in infos)
+                    if remaining_bytes is not None and total_uncompressed > remaining_bytes:
+                        return self._empty_result_dir(
+                            "Transitive byte budget exceeded by zip extraction", "extracted"
+                        )
                     if total_uncompressed > INGEST_MAX_BYTES:
                         raise IngestLimitExceededError(
                             f"Zip exceeded ingest cap: uncompressed "
@@ -677,6 +832,15 @@ class InputHandler:
 
     def _wrap_single_file(self, file_path: Path) -> Path:
         """Wrap a single file in a temporary directory for consistent handling."""
+        remaining_bytes = self._remaining_bytes()
+        if remaining_bytes is not None:
+            try:
+                if file_path.stat().st_size > remaining_bytes:
+                    return self._empty_result_dir(
+                        "Transitive byte budget exceeded by single-file input", "file"
+                    )
+            except OSError:
+                pass
         with _open_regular_file_no_follow(file_path) as source:
             temp_dir = self._get_temp_dir()
             dest = temp_dir / file_path.name

--- a/src/skillspector/llm_analyzer_base.py
+++ b/src/skillspector/llm_analyzer_base.py
@@ -31,6 +31,7 @@ import asyncio
 import os
 import time
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
@@ -464,11 +465,20 @@ class LLMAnalyzerBase:
 
     response_schema: type | None = LLMAnalysisResult
 
-    def __init__(self, base_prompt: str, model: str, *, node: str = "llm_analyzer"):
+    def __init__(
+        self,
+        base_prompt: str,
+        model: str,
+        *,
+        node: str = "llm_analyzer",
+        timeout: float | None | Callable[[], float | None] = None,
+    ):
         self.base_prompt = base_prompt
         self.model = model
+        self._timeout = timeout
+        self._dynamic_timeout = callable(timeout)
         self._input_budget = get_max_input_tokens(model)
-        self._llm = get_chat_model(model=model)
+        self._llm = get_chat_model(model=model, timeout=self._remaining_timeout())
         self._uses_native_connection_retries = _uses_native_connection_retries(self._llm)
         self._structured_llm = (
             self._llm.with_structured_output(self.response_schema) if self.response_schema else None
@@ -479,6 +489,20 @@ class LLMAnalyzerBase:
             model=model,
             chat_model=self._llm,
         )
+
+    def _remaining_timeout(self) -> float | None:
+        if callable(self._timeout):
+            return self._timeout()
+        return self._timeout
+
+    def _model_for_call(self) -> tuple[object, object | None]:
+        if not self._dynamic_timeout:
+            return self._llm, self._structured_llm
+        llm = get_chat_model(model=self.model, timeout=self._remaining_timeout())
+        structured = (
+            llm.with_structured_output(self.response_schema) if self.response_schema else None
+        )
+        return llm, structured
 
     @property
     def inference_usage(self) -> list[dict[str, object]]:
@@ -585,15 +609,14 @@ class LLMAnalyzerBase:
             estimate_tokens(prompt),
             len(batch.findings),
         )
-        if self._structured_llm:
+        llm, structured_llm = self._model_for_call()
+        if structured_llm:
             try:
-                response = _invoke_with_usage(self._structured_llm, prompt, self._usage_collector)
+                response = _invoke_with_usage(structured_llm, prompt, self._usage_collector)
             except (StructuredOutputParseError, ValidationError) as exc:
                 raise _StructuredResponseValidationError from exc
         else:
-            response = _raw_response_text(
-                _invoke_with_usage(self._llm, prompt, self._usage_collector)
-            )
+            response = _raw_response_text(_invoke_with_usage(llm, prompt, self._usage_collector))
         logger.debug("LLM response for %s", batch.file_label)
         return batch, self.parse_response(response, batch)
 
@@ -649,16 +672,15 @@ class LLMAnalyzerBase:
             estimate_tokens(prompt),
             len(batch.findings),
         )
-        if self._structured_llm:
+        llm, structured_llm = self._model_for_call()
+        if structured_llm:
             try:
-                response = await _ainvoke_with_usage(
-                    self._structured_llm, prompt, self._usage_collector
-                )
+                response = await _ainvoke_with_usage(structured_llm, prompt, self._usage_collector)
             except (StructuredOutputParseError, ValidationError) as exc:
                 raise _StructuredResponseValidationError from exc
         else:
             response = _raw_response_text(
-                await _ainvoke_with_usage(self._llm, prompt, self._usage_collector)
+                await _ainvoke_with_usage(llm, prompt, self._usage_collector)
             )
         logger.debug("LLM response for %s", batch.file_label)
         return batch, self.parse_response(response, batch)

--- a/src/skillspector/llm_utils.py
+++ b/src/skillspector/llm_utils.py
@@ -222,11 +222,19 @@ class _StructuredAgentCLIModel:
     ``complete()``, then parses and validates the response into *schema*.
     """
 
-    def __init__(self, provider: object, model: str, max_output_tokens: int, schema: type) -> None:
+    def __init__(
+        self,
+        provider: object,
+        model: str,
+        max_output_tokens: int,
+        schema: type,
+        timeout: float | None = None,
+    ) -> None:
         self._provider = provider
         self._model = model
         self._max_output_tokens = max_output_tokens
         self._schema = schema
+        self._timeout = timeout
 
     def _augment(self, prompt: str) -> str:
         schema_json = json.dumps(self._schema.model_json_schema(), indent=2)
@@ -243,6 +251,7 @@ class _StructuredAgentCLIModel:
             self._augment(prompt),
             model=self._model,
             max_output_tokens=self._max_output_tokens,
+            timeout=self._timeout,
         )
 
     def invoke(self, prompt: str) -> object:
@@ -282,10 +291,13 @@ class AgentCLIChatModel:
     message rather than a confusing ``AttributeError``.
     """
 
-    def __init__(self, provider: object, model: str, max_output_tokens: int) -> None:
+    def __init__(
+        self, provider: object, model: str, max_output_tokens: int, timeout: float | None = None
+    ) -> None:
         self._provider = provider
         self._model = model
         self._max_output_tokens = max_output_tokens
+        self._timeout = timeout
 
     def batch(self, *args: object, **kwargs: object) -> NoReturn:
         raise NotImplementedError(
@@ -304,6 +316,7 @@ class AgentCLIChatModel:
             prompt,
             model=self._model,
             max_output_tokens=self._max_output_tokens,
+            timeout=self._timeout,
         )
         return _AgentCLIMessage(text)
 
@@ -312,11 +325,13 @@ class AgentCLIChatModel:
 
     def with_structured_output(self, schema: type) -> _StructuredAgentCLIModel:
         return _StructuredAgentCLIModel(
-            self._provider, self._model, self._max_output_tokens, schema
+            self._provider, self._model, self._max_output_tokens, schema, self._timeout
         )
 
 
-def get_chat_model(model: str | None = None) -> BaseChatModel | AgentCLIChatModel:
+def get_chat_model(
+    model: str | None = None, *, timeout: float | None = None
+) -> BaseChatModel | AgentCLIChatModel:
     """Return a chat model for the active provider.
 
     For CLI providers (``claude_cli``, ``codex_cli``, ``gemini_cli``) this
@@ -339,6 +354,7 @@ def get_chat_model(model: str | None = None) -> BaseChatModel | AgentCLIChatMode
             provider,
             resolved_model,
             get_max_output_tokens(resolved_model),
+            timeout,
         )
         register_chat_model_provider(chat_model, provider)
         return chat_model
@@ -347,7 +363,7 @@ def get_chat_model(model: str | None = None) -> BaseChatModel | AgentCLIChatMode
     chat_model, effective_provider = create_chat_model_with_provider(
         model=model,
         max_tokens=get_max_output_tokens(model),
-        timeout=120,
+        timeout=timeout if timeout is not None else 120,
     )
     register_chat_model_provider(chat_model, effective_provider)
     return chat_model
@@ -409,6 +425,7 @@ def chat_completion(
     usage_collector: InferenceUsageCollector | None = None,
     node: str = "chat_completion",
     request_kind: str = "chat_completion",
+    timeout: float | None = None,
 ) -> str:
     """Request a single chat completion and return the assistant content.
 
@@ -419,7 +436,7 @@ def chat_completion(
     which normalise content blocks to a single string) and falls back to
     ``.content`` for the CLI adapter's ``_AgentCLIMessage``.
     """
-    chat_model = get_chat_model(model=model)
+    chat_model = get_chat_model(model=model, timeout=timeout)
     active_provider = get_active_provider()
     resolved_model = str(
         model

--- a/src/skillspector/models.py
+++ b/src/skillspector/models.py
@@ -89,10 +89,12 @@ class Finding:
     tags: list[str] = field(default_factory=list)
     context: str | None = None
     matched_text: str | None = None
+    transitive_depth: int = 0
+    source_url: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable dict representation (full finding shape)."""
-        return {
+        data: dict[str, object] = {
             "id": self.rule_id,
             "finding_id": self.finding_id,
             "category": self.category,
@@ -113,6 +115,11 @@ class Finding:
             # finding the LLM filter did not confirm but which is preserved anyway).
             "tags": list(self.tags),
         }
+        if self.transitive_depth:
+            data["transitive_depth"] = self.transitive_depth
+        if self.source_url:
+            data["source_url"] = self.source_url
+        return data
 
     def __str__(self) -> str:
         return f"{self.rule_id}: {self.message} ({self.file}:{self.start_line})"

--- a/src/skillspector/nodes/build_context.py
+++ b/src/skillspector/nodes/build_context.py
@@ -47,7 +47,13 @@ from skillspector.inspection_ledger import (
 )
 from skillspector.logging_config import get_logger
 from skillspector.python_ast import prewarm_python_ast_cache
-from skillspector.state import SkillspectorState
+from skillspector.state import (
+    SkillspectorState,
+    transitive_note_truncation,
+    transitive_remaining_bytes,
+    transitive_remaining_seconds,
+    transitive_traversal_state,
+)
 
 logger = get_logger(__name__)
 
@@ -360,13 +366,22 @@ def _build_component_metadata(
 
 
 def _read_file_cache(
-    skill_dir: Path, components: list[str]
+    skill_dir: Path,
+    components: list[str],
+    state: SkillspectorState | None = None,
 ) -> tuple[dict[str, str], list[InspectionLedgerEvent]]:
     """Build readable file content and terminal events for cache failures."""
     file_cache: dict[str, str] = {}
     ledger_events: list[InspectionLedgerEvent] = []
     skill_root = skill_dir.resolve(strict=False)
+    traversal = transitive_traversal_state(state) if state is not None else None
+    remaining_bytes = transitive_remaining_bytes(state) if state is not None else None
     for path in components:
+        remaining_seconds = transitive_remaining_seconds(state) if state is not None else None
+        if remaining_seconds is not None and remaining_seconds <= 0:
+            if state is not None:
+                transitive_note_truncation(state, f"time budget exhausted before reading {path}")
+            break
         full = skill_dir / path
         if _is_symlink(full) or _resolves_outside(full, skill_root):
             ledger_events.append(
@@ -405,6 +420,10 @@ def _read_file_cache(
                 )
             )
             continue
+        if remaining_bytes is not None and file_stat.st_size > remaining_bytes:
+            if state is not None:
+                transitive_note_truncation(state, f"byte budget exhausted before reading {path}")
+            break
         if not S_ISREG(file_stat.st_mode):
             ledger_events.append(
                 ledger_event(
@@ -418,7 +437,16 @@ def _read_file_cache(
             continue
         try:
             content = _read_text_no_follow(full)
+            content_bytes = len(content.encode("utf-8"))
+            if remaining_bytes is not None and content_bytes > remaining_bytes:
+                if state is not None:
+                    transitive_note_truncation(state, f"byte budget exhausted while reading {path}")
+                break
             file_cache[path] = content
+            record_bytes = getattr(traversal, "record_bytes", None)
+            if callable(record_bytes):
+                record_bytes(content_bytes)
+            remaining_bytes = transitive_remaining_bytes(state) if state is not None else None
         except FileNotFoundError as exc:
             ledger_events.append(
                 ledger_event(
@@ -570,7 +598,7 @@ def build_context(state: SkillspectorState) -> dict[str, object]:
         )
         for path in sorted(selected_baselines)
     ]
-    file_cache, cache_events = _read_file_cache(skill_dir, components)
+    file_cache, cache_events = _read_file_cache(skill_dir, components, state)
     python_ast_cache_key = prewarm_python_ast_cache(components, file_cache)
     manifest = _parse_manifest(skill_dir)
     metadata_components = [

--- a/src/skillspector/nodes/deduplicate.py
+++ b/src/skillspector/nodes/deduplicate.py
@@ -33,16 +33,16 @@ from skillspector.models import Finding
 logger = get_logger(__name__)
 
 
-def _same_file_key(finding: Finding) -> tuple[str, str, str]:
+def _same_file_key(finding: Finding) -> tuple[str, str, str, str]:
     """Build a deduplication key for same-file matches."""
     matched = (finding.matched_text or "").strip()[:100]
-    return (finding.rule_id, finding.file, matched)
+    return (finding.rule_id, finding.file, matched, finding.source_url or "")
 
 
-def _cross_file_key(finding: Finding) -> tuple[str, str]:
+def _cross_file_key(finding: Finding) -> tuple[str, str, str]:
     """Build a cross-file deduplication key from rule_id and normalized matched_text."""
     matched = (finding.matched_text or "").strip()[:100]
-    return (finding.rule_id, matched)
+    return (finding.rule_id, matched, finding.source_url or "")
 
 
 def deduplicate(findings: list[Finding]) -> list[Finding]:
@@ -62,7 +62,7 @@ def deduplicate(findings: list[Finding]) -> list[Finding]:
     original_count = len(findings)
 
     # Pass 1: Same-file deduplication
-    same_file_best: dict[tuple[str, str, str], Finding] = {}
+    same_file_best: dict[tuple[str, str, str, str], Finding] = {}
     for f in findings:
         key = _same_file_key(f)
         existing = same_file_best.get(key)
@@ -72,7 +72,7 @@ def deduplicate(findings: list[Finding]) -> list[Finding]:
     after_same_file = list(same_file_best.values())
 
     # Pass 2: Cross-file deduplication (only for findings WITH matched_text)
-    cross_file_best: dict[tuple[str, str], Finding] = {}
+    cross_file_best: dict[tuple[str, str, str], Finding] = {}
     no_text_findings: list[Finding] = []
 
     for f in after_same_file:

--- a/src/skillspector/nodes/report.py
+++ b/src/skillspector/nodes/report.py
@@ -132,6 +132,10 @@ def _build_sarif_properties(finding: Finding) -> dict[str, object] | None:
         "intent": finding_dict["intent"],
         "tags": finding_dict["tags"],
     }
+    if finding.source_url:
+        metadata["sourceUrl"] = finding.source_url
+    if finding.transitive_depth:
+        metadata["transitiveDepth"] = finding.transitive_depth
     cleaned = {key: value for key, value in metadata.items() if value is not None}
     return cleaned or None
 
@@ -555,6 +559,8 @@ def _format_terminal(
             console.print(f"  {icon}: {f.rule_id} - {f.message[:60]}...")
             end = f"–{f.end_line}" if f.end_line and f.end_line != f.start_line else ""
             console.print(f"    [dim]Location:[/dim] {f.file}:{f.start_line}{end}")
+            if f.source_url:
+                console.print(f"    [dim]Source:[/dim] {f.source_url} (depth {f.transitive_depth})")
             console.print(f"    [dim]Confidence:[/dim] {f.confidence:.0%}")
             if f.remediation:
                 console.print(f"    [dim]Remediation:[/dim] {(f.remediation or '')[:150]}...")
@@ -618,6 +624,9 @@ def _build_metadata(
     use_llm: bool,
     llm_call_log: Sequence[Mapping[str, object]] | None = None,
     inference_usage: Sequence[Mapping[str, object]] | None = None,
+    transitive_targets_scanned: int | None = None,
+    transitive_bytes_scanned: int | None = None,
+    transitive_truncation_reasons: Sequence[str] | None = None,
 ) -> dict[str, object]:
     """Build the metadata section shared by all output formats."""
     llm_call_log = llm_call_log or []
@@ -657,6 +666,13 @@ def _build_metadata(
         )
     elif use_llm and not llm_available:
         meta["llm_error"] = llm_error
+    if transitive_targets_scanned is not None:
+        meta["transitive_targets_scanned"] = transitive_targets_scanned
+    if transitive_bytes_scanned is not None:
+        meta["transitive_bytes_scanned"] = transitive_bytes_scanned
+    if transitive_truncation_reasons:
+        meta["transitive_truncated"] = True
+        meta["transitive_truncation_reasons"] = list(transitive_truncation_reasons)
     return meta
 
 
@@ -675,6 +691,9 @@ def _format_json(
     analysis_completeness: Mapping[str, object] | None = None,
     suppressed: list[SuppressedFinding] | None = None,
     execution_successful: bool = True,
+    transitive_targets_scanned: int | None = None,
+    transitive_bytes_scanned: int | None = None,
+    transitive_truncation_reasons: Sequence[str] | None = None,
 ) -> str:
     """Generate JSON report string."""
     suppressed = suppressed or []
@@ -697,6 +716,7 @@ def _format_json(
                 "lines": c.get("lines"),
                 "executable": c.get("executable"),
                 "size_bytes": c.get("size_bytes"),
+                "source_url": c.get("source_url"),
             }
             for c in component_metadata
         ],
@@ -708,6 +728,9 @@ def _format_json(
             use_llm,
             llm_call_log,
             inference_usage,
+            transitive_targets_scanned,
+            transitive_bytes_scanned,
+            transitive_truncation_reasons,
         ),
         "execution_successful": execution_successful,
     }
@@ -838,6 +861,9 @@ def _format_markdown(
             lines.append(f"### {emoji} {sev}: {f.rule_id}\n")
             end = f"–{f.end_line}" if f.end_line and f.end_line != f.start_line else ""
             lines.append(f"**Location:** `{f.file}:{f.start_line}{end}`  ")
+            if f.source_url:
+                lines.append(f"**Source:** `{f.source_url}`  ")
+                lines.append(f"**Transitive depth:** {f.transitive_depth}  ")
             lines.append(f"**Confidence:** {f.confidence:.0%}  ")
             lines.append("")
             lines.append(f"**Message:** {f.message}")
@@ -922,6 +948,21 @@ def report(state: SkillspectorState) -> dict[str, object]:
     use_llm = state.get("use_llm", True)
     llm_call_log = state.get("llm_call_log") or []
     inference_usage = state.get("inference_usage") or []
+    transitive_targets_scanned = state.get("transitive_targets_scanned")
+    transitive_bytes_scanned = state.get("transitive_bytes_scanned")
+    transitive_truncation_reasons = [
+        str(reason)
+        for reason in state.get("transitive_truncation_reasons", [])
+        if isinstance(reason, str)
+    ]
+    if transitive_truncation_reasons:
+        analysis_completeness = dict(analysis_completeness)
+        limitations = list(analysis_completeness.get("limitations") or [])
+        limitations.append(
+            "Transitive traversal truncated: " + "; ".join(transitive_truncation_reasons)
+        )
+        analysis_completeness["limitations"] = limitations
+        analysis_completeness["is_complete"] = False
 
     _attempted, _succeeded, degraded = _llm_runtime_status(use_llm, llm_call_log)
     degraded_notice = _llm_degradation_notice(use_llm, llm_call_log)
@@ -957,7 +998,9 @@ def report(state: SkillspectorState) -> dict[str, object]:
     entirely_uninspected = (
         entirely_uninspected_value if isinstance(entirely_uninspected_value, int) else 0
     )
-    if (degraded or fatal_exception or entirely_uninspected > 0) and risk_recommendation == "SAFE":
+    if (
+        degraded or fatal_exception or entirely_uninspected > 0 or transitive_truncation_reasons
+    ) and risk_recommendation == "SAFE":
         risk_recommendation = "CAUTION"
 
     sarif_report = _build_sarif(
@@ -1000,6 +1043,15 @@ def report(state: SkillspectorState) -> dict[str, object]:
             analysis_completeness=analysis_completeness,
             suppressed=suppressed,
             execution_successful=execution_successful,
+            transitive_targets_scanned=(
+                int(transitive_targets_scanned)
+                if isinstance(transitive_targets_scanned, int)
+                else None
+            ),
+            transitive_bytes_scanned=(
+                int(transitive_bytes_scanned) if isinstance(transitive_bytes_scanned, int) else None
+            ),
+            transitive_truncation_reasons=transitive_truncation_reasons,
         )
     elif output_format == "markdown":
         report_body = _format_markdown(
@@ -1034,6 +1086,11 @@ def report(state: SkillspectorState) -> dict[str, object]:
         "risk_recommendation": risk_recommendation,
         "report_body": report_body,
         "filtered_findings": selected_findings,
+        "active_findings": active_findings,
         "suppressed_findings": suppressed,
         "execution_successful": execution_successful,
+        "transitive_targets_scanned": transitive_targets_scanned,
+        "transitive_bytes_scanned": transitive_bytes_scanned,
+        "transitive_truncated": bool(transitive_truncation_reasons),
+        "transitive_truncation_reasons": transitive_truncation_reasons,
     }

--- a/src/skillspector/nodes/resolve_input.py
+++ b/src/skillspector/nodes/resolve_input.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 from skillspector.input_handler import InputHandler, validate_local_input_path
 from skillspector.logging_config import get_logger
-from skillspector.state import SkillspectorState
+from skillspector.state import SkillspectorState, transitive_traversal_state
 
 logger = get_logger(__name__)
 
@@ -42,9 +42,10 @@ def resolve_input(state: SkillspectorState) -> dict[str, object]:
     """
     input_path = state.get("input_path")
     skill_path = state.get("skill_path")
+    traversal = transitive_traversal_state(state)
 
     if input_path and isinstance(input_path, str) and input_path.strip():
-        handler = InputHandler()
+        handler = InputHandler(transitive_budget=traversal)
         try:
             resolved, source_type = handler.resolve(input_path.strip())
             update: dict[str, object] = {"skill_path": str(resolved)}

--- a/src/skillspector/providers/_agent_cli_base.py
+++ b/src/skillspector/providers/_agent_cli_base.py
@@ -56,7 +56,14 @@ class AgentCLIProviderBase:
 
     # -- Transport -----------------------------------------------------------
 
-    def complete(self, prompt: str, *, model: str, max_output_tokens: int = 8192) -> str:
+    def complete(
+        self,
+        prompt: str,
+        *,
+        model: str,
+        max_output_tokens: int = 8192,
+        timeout: float | None = None,
+    ) -> str:
         """Invoke the CLI via the hardened runner and return the assistant text.
 
         The prompt is passed through unchanged (parity with the HTTP path).
@@ -64,7 +71,11 @@ class AgentCLIProviderBase:
         :func:`skillspector.providers._agent_cli.run_agent_cli`.
         """
         return _agent_cli.run_agent_cli(
-            self.BINARY_NAME, prompt, model=model, max_output_tokens=max_output_tokens
+            self.BINARY_NAME,
+            prompt,
+            model=model,
+            max_output_tokens=max_output_tokens,
+            timeout=timeout if timeout is not None else _agent_cli.CLI_TIMEOUT_SECONDS,
         )
 
     # -- Metadata ------------------------------------------------------------

--- a/src/skillspector/providers/base.py
+++ b/src/skillspector/providers/base.py
@@ -94,7 +94,7 @@ class AgentCLICapable(Protocol):
         otherwise.  This replaces the credential-based availability check
         in :func:`skillspector.llm_utils.is_llm_available` for CLI providers.
 
-    ``complete(prompt, *, model, max_output_tokens)``
+    ``complete(prompt, *, model, max_output_tokens, timeout)``
         Execute the CLI, pass the prompt via stdin, and return the
         assistant's text response.  Raises on any failure (fail-closed).
     """
@@ -107,6 +107,7 @@ class AgentCLICapable(Protocol):
         *,
         model: str,
         max_output_tokens: int,
+        timeout: float | None = None,
     ) -> str: ...
 
 

--- a/src/skillspector/state.py
+++ b/src/skillspector/state.py
@@ -129,6 +129,15 @@ class SkillspectorState(TypedDict, total=False):
     sarif_report: dict[str, object]
     risk_score: int
 
+    # Transitive traversal metadata for report output and CLI summaries.
+    transitive_finding_count: int
+    transitive_sources: list[str]
+    transitive_targets_scanned: int
+    transitive_bytes_scanned: int
+    transitive_truncated: bool
+    transitive_truncation_reasons: list[str]
+    transitive_traversal_state: object
+
     # Additional YARA rules directory (user-specified via --yara-rules-dir)
     yara_rules_dir: str | None
 
@@ -150,6 +159,44 @@ def llm_call_record(node_id: str, *, ok: bool, error: str | None = None) -> LLMC
     not mistaken for "the LLM ran and found nothing").
     """
     return {"node": node_id, "ok": ok, "error": error}
+
+
+def transitive_traversal_state(state: SkillspectorState) -> object | None:
+    """Return the shared transitive traversal object, when one is present."""
+    traversal = state.get("transitive_traversal_state")
+    return traversal if traversal is not None else None
+
+
+def transitive_remaining_seconds(state: SkillspectorState) -> float | None:
+    """Return the remaining transitive deadline in seconds, when available."""
+    traversal = transitive_traversal_state(state)
+    remaining = getattr(traversal, "remaining_seconds", None)
+    if callable(remaining):
+        try:
+            return float(remaining())
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def transitive_remaining_bytes(state: SkillspectorState) -> int | None:
+    """Return the remaining transitive byte allowance, when available."""
+    traversal = transitive_traversal_state(state)
+    remaining = getattr(traversal, "remaining_bytes", None)
+    if callable(remaining):
+        try:
+            return int(remaining())
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def transitive_note_truncation(state: SkillspectorState, reason: str) -> None:
+    """Record a transitive truncation reason on the shared traversal object."""
+    traversal = transitive_traversal_state(state)
+    note = getattr(traversal, "note_truncation", None)
+    if callable(note):
+        note(reason)
 
 
 class AnalyzerNodeResponse(TypedDict):

--- a/src/skillspector/suppression.py
+++ b/src/skillspector/suppression.py
@@ -98,8 +98,14 @@ def _normalize_component_path(path: str) -> str:
     return posixpath.normpath(normalized)
 
 
-def _component_content(file_cache: Mapping[str, str], file_path: str) -> str | None:
+def _component_content(
+    file_cache: Mapping[str, str], file_path: str, *, source_url: str | None = None
+) -> str | None:
     """Look up *file_path* while tolerating slash-style differences."""
+    if source_url:
+        source_key = f"{source_url}::{file_path}"
+        if source_key in file_cache:
+            return file_cache[source_key]
     if file_path in file_cache:
         return file_cache[file_path]
     normalized = _normalize_component_path(file_path)
@@ -154,6 +160,11 @@ def finding_fingerprint(
             "code_snippet": finding.code_snippet or "",
         },
     }
+    if finding.source_url or finding.transitive_depth:
+        payload["source"] = {
+            "url": finding.source_url or "",
+            "depth": finding.transitive_depth,
+        }
     canonical = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
     digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
     return f"sha256:{digest}"
@@ -375,7 +386,9 @@ def partition_findings(
     for finding in findings:
         reason = baseline.reason_for(
             finding,
-            file_content=_component_content(cache, finding.file or ""),
+            file_content=_component_content(
+                cache, finding.file or "", source_url=finding.source_url
+            ),
             scanner_version=scanner_version,
         )
         if reason is None:
@@ -405,7 +418,7 @@ def build_baseline_dict(
     entries: list[dict[str, str]] = []
     seen_hashes: set[str] = set()
     for finding in findings:
-        content = _component_content(file_cache, finding.file or "")
+        content = _component_content(file_cache, finding.file or "", source_url=finding.source_url)
         if content is None:
             raise ValueError(
                 f"cannot create an exact fingerprint: source content missing for {finding.file!r}"

--- a/src/skillspector/transitive.py
+++ b/src/skillspector/transitive.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for opt-in transitive external-source traversal."""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from urllib.parse import ParseResult, unquote, urlparse, urlunparse
+
+from skillspector.input_handler import ALLOWED_DOWNLOAD_HOSTS, ALLOWED_GIT_HOSTS
+
+_LEADING_PUNCTUATION = "([{\"'<"
+_TRAILING_PUNCTUATION = "),.!?;:>\"'`]}"
+
+_SUPPORTED_FILE_EXTENSIONS = frozenset(
+    {
+        ".md",
+        ".py",
+        ".sh",
+        ".bash",
+        ".zsh",
+        ".js",
+        ".ts",
+        ".rb",
+        ".go",
+        ".rs",
+        ".pl",
+        ".json",
+        ".yaml",
+        ".yml",
+        ".toml",
+        ".txt",
+        ".zip",
+    }
+)
+
+_EXTERNAL_REF_PATTERN = re.compile(r"(?:https?://|git@)[^\s\"'<>`]+")
+
+_EXCLUDED_HOSTS = frozenset(
+    {
+        "img.shields.io",
+        "badge.fury.io",
+        "travis-ci.com",
+        "travis-ci.org",
+    }
+)
+
+_UNRESERVED_CHARACTERS = frozenset(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+)
+_PERCENT_ENCODED_RE = re.compile(r"%[0-9A-Fa-f]{2}")
+
+
+def canonicalize_source_identity(url: str) -> str:
+    """Return canonical URL identity used for dedupe and visited-state control."""
+    token = _clean_token(url).strip()
+    if not token:
+        raise ValueError(f"Unsupported URL: {url}")
+
+    parsed = _parse_url(token)
+    if parsed.scheme.lower() != "https":
+        raise ValueError(f"Unsupported URL scheme: {parsed.scheme}")
+    host = (parsed.hostname or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+
+    netloc = host
+    if parsed.port:
+        netloc = f"{host}:{parsed.port}"
+
+    path = _normalize_path(parsed.path or "/")
+    path = path.removesuffix(".git")
+    path = path.rstrip("/")
+    return urlunparse(("https", netloc, path if path else "/", "", "", ""))
+
+
+def extract_external_refs(file_cache: dict[str, str]) -> list[str]:
+    """Extract candidate external references from a file cache."""
+    refs: list[str] = []
+    seen: set[str] = set()
+    for raw_content in file_cache.values():
+        if not isinstance(raw_content, str):
+            continue
+        for match in _EXTERNAL_REF_PATTERN.finditer(raw_content):
+            token = match.group(0)
+            try:
+                identity = canonicalize_source_identity(token)
+            except ValueError:
+                continue
+            if identity in seen:
+                continue
+            if not _is_source_reference(identity):
+                continue
+            refs.append(identity)
+            seen.add(identity)
+    return refs
+
+
+def plan_transitive_targets(
+    refs: list[str],
+    visited: set[str],
+    current_depth: int,
+    max_depth: int,
+    allow_prefixes: tuple[str, ...],
+    deny_prefixes: tuple[str, ...],
+) -> list[str]:
+    """Plan the next transitive scan wave and mutate visited for approved targets."""
+    if current_depth > max_depth or max_depth <= 0:
+        return []
+    if current_depth < 1:
+        current_depth = 1
+
+    normalized_allow_prefixes, normalized_deny_prefixes = normalize_prefixes(
+        allow_prefixes, deny_prefixes
+    )
+
+    targets: list[str] = []
+    for ref in refs:
+        try:
+            identity = canonicalize_source_identity(ref)
+        except ValueError:
+            continue
+        if not _is_source_reference(identity):
+            continue
+        if identity in visited:
+            continue
+        if normalized_allow_prefixes and not _matches_any_prefix(
+            identity, normalized_allow_prefixes
+        ):
+            continue
+        if normalized_deny_prefixes and _matches_any_prefix(identity, normalized_deny_prefixes):
+            continue
+        visited.add(identity)
+        targets.append(identity)
+    return targets
+
+
+def normalize_prefixes(
+    allow_prefixes: tuple[str, ...] | list[str] | None,
+    deny_prefixes: tuple[str, ...] | list[str] | None,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Canonicalize CLI prefixes before any root scan starts."""
+    return (
+        tuple(_normalize_prefix(prefix) for prefix in (allow_prefixes or ())),
+        tuple(_normalize_prefix(prefix) for prefix in (deny_prefixes or ())),
+    )
+
+
+def _parse_url(url: str) -> ParseResult:
+    token = _clean_token(url)
+    if token.startswith("git@"):
+        return _parse_git_ssh_url(token)
+    parsed = urlparse(token)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f"Unsupported URL: {url}")
+    return parsed
+
+
+def _parse_git_ssh_url(url: str) -> ParseResult:
+    match = re.fullmatch(r"git@([^:]+):(.+)", url)
+    if not match:
+        raise ValueError(f"Unsupported git URL format: {url}")
+    host = match.group(1).strip()
+    path = match.group(2).strip().lstrip("/")
+    return urlparse(f"https://{host}/{path}")
+
+
+def _clean_token(token: str) -> str:
+    cleaned = token.strip()
+    while cleaned and cleaned[0] in _LEADING_PUNCTUATION:
+        cleaned = cleaned[1:]
+    while cleaned and cleaned[-1] in _TRAILING_PUNCTUATION:
+        cleaned = cleaned[:-1]
+    return cleaned.strip()
+
+
+def _decode_unreserved(text: str) -> str:
+    def replacer(match: re.Match[str]) -> str:
+        decoded = chr(int(match.group(0)[1:], 16))
+        if decoded in _UNRESERVED_CHARACTERS:
+            return decoded
+        return match.group(0).upper()
+
+    return _PERCENT_ENCODED_RE.sub(replacer, text)
+
+
+def _normalize_path(path: str) -> str:
+    normalized = posixpath.normpath(_decode_unreserved(path) or "/")
+    if normalized == ".":
+        return "/"
+    if not normalized.startswith("/"):
+        normalized = "/" + normalized
+    return normalized
+
+
+def _normalize_prefix(prefix: str) -> str:
+    if not prefix:
+        return ""
+    return canonicalize_source_identity(prefix)
+
+
+def _matches_any_prefix(url: str, prefixes: tuple[str, ...]) -> bool:
+    return any(_matches_prefix(url, prefix) for prefix in prefixes if prefix)
+
+
+def _matches_prefix(url: str, prefix: str) -> bool:
+    if url == prefix:
+        return True
+    if prefix.endswith("/"):
+        return url.startswith(prefix)
+    return url.startswith(prefix + "/")
+
+
+def _is_source_reference(identity: str) -> bool:
+    parsed = urlparse(identity)
+    host = (parsed.hostname or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+    if not host:
+        return False
+    if host in _EXCLUDED_HOSTS:
+        return False
+    if not _is_allowed_host(host):
+        return False
+
+    lower_path = unquote(parsed.path).lower()
+    if _has_excluded_path_marker(lower_path):
+        return False
+
+    if _looks_like_git_reference(host, lower_path):
+        return True
+    return _looks_like_file_reference(host, lower_path, parsed.path)
+
+
+def _has_excluded_path_marker(path: str) -> bool:
+    if path.endswith(".svg"):
+        return True
+    segments = [segment for segment in path.split("/") if segment]
+    if len(segments) < 3:
+        return False
+    ui_segment = segments[2]
+    return ui_segment in {
+        "actions",
+        "badge",
+        "badges",
+        "blob",
+        "checks",
+        "ci",
+        "issues",
+        "pull",
+        "pulls",
+        "tree",
+        "wiki",
+        "workflows",
+    }
+
+
+def _looks_like_git_reference(host: str, path: str) -> bool:
+    if not _host_in_allowed_git_hosts(host):
+        return False
+    if not path or path == "/":
+        return False
+    if path.startswith("/raw/"):
+        return False
+    if path.startswith("/blob/"):
+        return False
+    if "/tree/" in path:
+        return False
+    if "/archive/" in path:
+        return False
+
+    segments = [segment for segment in path.split("/") if segment]
+    if len(segments) < 2:
+        return False
+    if len(segments) >= 3 and segments[2] == "actions":
+        return False
+
+    return True
+
+
+def _looks_like_file_reference(host: str, lower_path: str, raw_path: str) -> bool:
+    if not _is_allowed_host(host):
+        return False
+    if raw_path.endswith("/"):
+        return False
+    extension = _split_extension(lower_path)
+    if not extension:
+        return False
+    return extension in _SUPPORTED_FILE_EXTENSIONS
+
+
+def _is_allowed_host(host: str) -> bool:
+    return (
+        host in ALLOWED_GIT_HOSTS
+        or host in {f"www.{entry}" for entry in ALLOWED_GIT_HOSTS}
+        or host in ALLOWED_DOWNLOAD_HOSTS
+        or host in {f"www.{entry}" for entry in ALLOWED_DOWNLOAD_HOSTS}
+    )
+
+
+def _host_in_allowed_git_hosts(host: str) -> bool:
+    return host in ALLOWED_GIT_HOSTS or host in {f"www.{entry}" for entry in ALLOWED_GIT_HOSTS}
+
+
+def _split_extension(path: str) -> str:
+    return (
+        "." + path.rsplit("/", 1)[-1].rsplit(".", 1)[-1] if "." in path.rsplit("/", 1)[-1] else ""
+    )

--- a/tests/nodes/test_deduplicate.py
+++ b/tests/nodes/test_deduplicate.py
@@ -108,6 +108,16 @@ class TestCrossFileDedup:
         assert result[0].confidence == 0.9
         assert result[0].file == "b.py"
 
+    def test_same_pattern_from_different_transitive_sources_is_preserved(self) -> None:
+        first = _finding(file="tool.py")
+        first.source_url = "https://github.com/org/first"
+        second = _finding(file="tool.py")
+        second.source_url = "https://github.com/org/second"
+
+        result = deduplicate([first, second])
+
+        assert len(result) == 2
+
     def test_different_patterns_across_files_not_deduped(self) -> None:
         """Different matched texts are independent even with same rule_id."""
         findings = [

--- a/tests/nodes/test_llm_analyzer_base.py
+++ b/tests/nodes/test_llm_analyzer_base.py
@@ -788,6 +788,41 @@ class TestRunBatches:
         analyzer._structured_llm.invoke.assert_not_called()
 
 
+class TestDynamicTimeout:
+    def test_run_batches_resolves_timeout_per_batch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Dynamic timeout providers are called again before every LLM call."""
+        captured_timeouts: list[float | None] = []
+        timeout_values = iter([30.0, 20.0, 10.0])
+
+        class _Structured:
+            def invoke(self, prompt: str) -> LLMAnalysisResult:
+                return LLMAnalysisResult(findings=[])
+
+        class _LLM:
+            def with_structured_output(self, schema: type) -> _Structured:
+                return _Structured()
+
+        def fake_get_chat_model(*, model: str, timeout: float | None = None) -> _LLM:
+            captured_timeouts.append(timeout)
+            return _LLM()
+
+        monkeypatch.setattr("skillspector.llm_analyzer_base.get_chat_model", fake_get_chat_model)
+
+        analyzer = LLMAnalyzerBase(
+            base_prompt="test",
+            model="nvidia/openai/gpt-oss-120b",
+            timeout=lambda: next(timeout_values),
+        )
+        analyzer.run_batches(
+            [
+                Batch(file_path="a.py", content="a"),
+                Batch(file_path="b.py", content="b"),
+            ]
+        )
+
+        assert captured_timeouts == [30.0, 20.0, 10.0]
+
+
 # ---------------------------------------------------------------------------
 # LLMAnalyzerBase.arun_batches (async parallel execution)
 # ---------------------------------------------------------------------------

--- a/tests/nodes/test_report.py
+++ b/tests/nodes/test_report.py
@@ -604,6 +604,32 @@ class TestReportNode:
         json.loads(body)
         assert "sarif_report" in result
 
+    def test_report_surfaces_transitive_provenance(self) -> None:
+        finding = _finding("T1", "HIGH", "child issue", file="dep.py")
+        finding.source_url = "https://github.com/org/dep"
+        finding.transitive_depth = 2
+        state: SkillspectorState = {
+            "filtered_findings": [finding],
+            "component_metadata": [],
+            "has_executable_scripts": False,
+            "manifest": {},
+            "output_format": "markdown",
+        }
+
+        markdown = report(state)["report_body"]
+        assert "https://github.com/org/dep" in markdown
+        assert "Transitive depth:** 2" in markdown
+
+        state["output_format"] = "sarif"
+        sarif = report(state)["sarif_report"]
+        properties = sarif["runs"][0]["results"][0]["properties"]
+        assert properties["sourceUrl"] == "https://github.com/org/dep"
+        assert properties["transitiveDepth"] == 2
+
+        state["output_format"] = "terminal"
+        terminal = report(state)["report_body"]
+        assert "https://github.com/org/dep" in terminal
+
     def test_report_dedup_affects_score_only_not_report_output(self) -> None:
         """Deduplication reduces score but all affected files appear in the report."""
         duplicated = [

--- a/tests/nodes/test_sarif_rules_and_empty_findings.py
+++ b/tests/nodes/test_sarif_rules_and_empty_findings.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from skillspector.models import Finding
 from skillspector.nodes.report import _build_sarif
+from skillspector.sarif_models import validate_sarif_report
 from skillspector.suppression import SuppressedFinding
 
 
@@ -215,3 +216,16 @@ class TestSarifResultProperties:
         assert result["properties"]["finding"] == "credential leak"
         assert result["properties"]["explanation"] == "Credential material is exposed in output"
         assert result["properties"]["intent"] == "exposed_secret"
+
+
+def test_sarif_transitive_properties_validate() -> None:
+    """Transitive provenance lands in SARIF properties and still validates."""
+    finding = _make_finding("TR1", "Transitive Dependency")
+    finding.transitive_depth = 2
+    finding.source_url = "https://github.com/org/dep"
+    sarif = _build_sarif([finding])
+    validate_sarif_report(sarif)
+    result = sarif["runs"][0]["results"][0]
+    properties = result["properties"]
+    assert properties["transitiveDepth"] == 2
+    assert properties["sourceUrl"] == "https://github.com/org/dep"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -26,11 +26,41 @@ import typer
 import yaml
 from typer.testing import CliRunner
 
-from skillspector import __version__
+from skillspector import __version__, cli, transitive
 from skillspector.cli import FormatChoice, _scan_multi_skill, app
+from skillspector.models import Finding
 from skillspector.multi_skill import MultiSkillDetectionResult, SkillDirectory
+from skillspector.suppression import Baseline, SuppressionRule
 
 runner = CliRunner()
+
+
+def _mock_graph_result(
+    findings: list[Finding] | None = None,
+    file_cache: dict[str, str] | None = None,
+    output_format: str = "json",
+) -> dict[str, object]:
+    return {
+        "findings": findings or [],
+        "filtered_findings": findings or [],
+        "components": ["SKILL.md"],
+        "component_metadata": [],
+        "file_cache": file_cache or {},
+        "has_executable_scripts": False,
+        "output_format": output_format,
+    }
+
+
+def _finding(rule_id: str, message: str, file: str = "SKILL.md", depth: int = 0) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        message=message,
+        severity="HIGH",
+        confidence=0.9,
+        file=file,
+        start_line=1,
+        transitive_depth=depth,
+    )
 
 
 def test_cli_version() -> None:
@@ -311,7 +341,8 @@ def test_cli_scan_missing_baseline_exits_2(tmp_path: Path) -> None:
     """scan with a --baseline pointing at a missing file exits with code 2."""
     (tmp_path / "SKILL.md").write_text("# Hi", encoding="utf-8")
     result = runner.invoke(
-        app, ["scan", str(tmp_path), "--no-llm", "--baseline", str(tmp_path / "missing.yaml")]
+        app,
+        ["scan", str(tmp_path), "--no-llm", "--baseline", str(tmp_path / "missing.yaml")],
     )
     assert result.exit_code == 2
     assert "baseline" in result.output.lower()
@@ -560,15 +591,25 @@ def test_scan_multi_skill_markdown_output_to_file(
 
     with patch("skillspector.cli.graph.invoke", side_effect=[result1, result2]):
         _scan_multi_skill(
-            detection, FormatChoice.markdown, out, no_llm=True, yara_rules_dir=None, verbose=False
+            detection,
+            FormatChoice.markdown,
+            out,
+            no_llm=True,
+            baseline=None,
+            show_suppressed=False,
+            transitive_enabled=False,
+            transitive_depth=1,
+            transitive_allow_prefix=(),
+            transitive_deny_prefix=(),
+            yara_dir=None,
+            verbose=False,
         )
 
     assert out.exists()
-    text = out.read_text(encoding="utf-8")
+    text = out.read_text()
     assert "ALPHA" in text
     assert "BETA" in text
-    assert "--- skill1 ---" in text
-    assert "--- skill2 ---" in text
+    assert "---" in text
 
     captured = capsys.readouterr()
     assert "ALPHA" not in captured.out
@@ -599,11 +640,22 @@ def test_scan_multi_skill_json_output_unchanged(tmp_path: Path) -> None:
 
     with patch("skillspector.cli.graph.invoke", side_effect=[result1, result2]):
         _scan_multi_skill(
-            detection, FormatChoice.json, out, no_llm=True, yara_rules_dir=None, verbose=False
+            detection,
+            FormatChoice.json,
+            out,
+            no_llm=True,
+            baseline=None,
+            show_suppressed=False,
+            transitive_enabled=False,
+            transitive_depth=1,
+            transitive_allow_prefix=(),
+            transitive_deny_prefix=(),
+            yara_dir=None,
+            verbose=False,
         )
 
     assert out.exists()
-    data = json.loads(out.read_text(encoding="utf-8"))
+    data = json.loads(out.read_text())
     assert data["multi_skill"] is True
     assert "skills" in data
 
@@ -1133,3 +1185,1172 @@ def test_cli_scan_json_preserves_single_skill_contract(
     assert payload["issues"] == [{"id": "X-1", "severity": "low"}]
     assert payload["suppressed_count"] == 0
     assert payload["suppressed"] == []
+
+
+def test_scan_without_transitive_invokes_graph_once(tmp_path: Path, monkeypatch) -> None:
+    """Direct scan without --transitive runs exactly one graph scan."""
+    (tmp_path / "SKILL.md").write_text("# Safe", encoding="utf-8")
+    calls: list[str] = []
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        calls.append(input_path)
+        return _mock_graph_result(output_format=format.value if format else "json")
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    result = runner.invoke(app, ["scan", str(tmp_path), "--format", "json"])
+    assert result.exit_code == 0
+    assert len(calls) == 1
+
+
+def test_scan_transitive_root_graph_keeps_budget_for_children(tmp_path: Path, monkeypatch) -> None:
+    """The root graph scan receives no child traversal budget state."""
+    (tmp_path / "SKILL.md").write_text("# Root", encoding="utf-8")
+    root_traversals: list[object] = []
+    child_traversals: list[object] = []
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        assert input_path == str(tmp_path)
+        assert transitive_traversal is None
+        root_traversals.append(transitive_traversal)
+        return _mock_graph_result(file_cache={"SKILL.md": "https://github.com/org/dep.git"})
+
+    def fake_scan_transitive(*args, traversal=None, **kwargs) -> dict[str, object]:
+        assert traversal is not None
+        child_traversals.append(traversal)
+        return {
+            "report_body": "{}",
+            "risk_score": 0,
+            "risk_severity": "LOW",
+            "transitive_finding_count": 0,
+            "transitive_sources": [],
+        }
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    monkeypatch.setattr(cli, "_scan_transitive", fake_scan_transitive)
+
+    result = runner.invoke(
+        app, ["scan", str(tmp_path), "--format", "json", "--transitive", "--no-llm"]
+    )
+
+    assert result.exit_code == 0
+    assert root_traversals == [None]
+    assert len(child_traversals) == 1
+
+
+def test_recursive_transitive_roots_keep_one_child_traversal(tmp_path: Path, monkeypatch) -> None:
+    """Recursive roots don't consume the shared child traversal state."""
+    s1 = SkillDirectory(path=tmp_path / "skill1", name="skill1", relative_path="skill1")
+    s2 = SkillDirectory(path=tmp_path / "skill2", name="skill2", relative_path="skill2")
+    detection = MultiSkillDetectionResult(
+        is_multi_skill=True, skills=[s1, s2], has_root_skill=False
+    )
+    root_traversals: list[object] = []
+    child_traversals: list[object] = []
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        assert transitive_traversal is None
+        root_traversals.append(transitive_traversal)
+        return _mock_graph_result(file_cache={"SKILL.md": "https://github.com/org/dep.git"})
+
+    def fake_scan_transitive(*args, traversal=None, **kwargs) -> dict[str, object]:
+        child_traversals.append(traversal)
+        return {
+            "report_body": "{}",
+            "risk_score": 0,
+            "risk_severity": "LOW",
+            "transitive_finding_count": 0,
+            "transitive_sources": [],
+        }
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    monkeypatch.setattr(cli, "_scan_transitive", fake_scan_transitive)
+
+    _scan_multi_skill(
+        detection,
+        FormatChoice.json,
+        None,
+        no_llm=True,
+        baseline=None,
+        show_suppressed=False,
+        transitive_enabled=True,
+        transitive_depth=1,
+        transitive_allow_prefix=(),
+        transitive_deny_prefix=(),
+        yara_dir=None,
+        verbose=False,
+    )
+
+    assert root_traversals == [None, None]
+    assert len(child_traversals) == 2
+    assert child_traversals[0] is child_traversals[1]
+
+
+def test_recursive_transitive_roots_do_not_burn_child_time_budget(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Shared child timing starts when the first child scan begins, not when roots start."""
+    s1 = SkillDirectory(path=tmp_path / "skill1", name="skill1", relative_path="skill1")
+    detection = MultiSkillDetectionResult(
+        is_multi_skill=True,
+        skills=[s1],
+        has_root_skill=False,
+    )
+    fake_time = {"value": 0.0}
+
+    def fake_monotonic() -> float:
+        return fake_time["value"]
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        fake_time["value"] += 61.0
+        return _mock_graph_result(file_cache={"SKILL.md": "https://github.com/org/dep.git"})
+
+    def fake_scan_transitive(*args, traversal=None, **kwargs) -> dict[str, object]:
+        assert traversal is not None
+        assert traversal.remaining_seconds() == 60.0
+        return {
+            "report_body": "{}",
+            "filtered_findings": [],
+            "findings": [],
+            "transitive_finding_count": 0,
+            "transitive_sources": [],
+        }
+
+    monkeypatch.setattr(cli, "monotonic", fake_monotonic)
+    monkeypatch.setattr(cli, "_scan_skill", cli._scan_skill)
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    monkeypatch.setattr(cli, "_scan_transitive", fake_scan_transitive)
+
+    cli._scan_multi_skill(
+        detection=detection,
+        format=cli.FormatChoice.json,
+        output=None,
+        no_llm=True,
+        baseline=None,
+        show_suppressed=False,
+        transitive_enabled=True,
+        transitive_depth=1,
+        transitive_allow_prefix=(),
+        transitive_deny_prefix=(),
+        yara_dir=None,
+        verbose=False,
+    )
+
+
+def test_scan_transitive_depth_one_merges_provenance(tmp_path: Path, monkeypatch) -> None:
+    """--transitive-depth 1 follows one approved external target and merges provenance."""
+    direct_output = "See dependency: https://github.com/org/transitive.git"
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        if input_path == str(tmp_path):
+            return _mock_graph_result(
+                findings=[_finding("D1", "direct finding")],
+                file_cache={"SKILL.md": direct_output},
+                output_format=format.value,
+            )
+        return _mock_graph_result(
+            findings=[_finding("T1", "transitive finding", file="dep.py", depth=1)],
+            file_cache={},
+            output_format=format.value,
+        )
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--transitive",
+            "--transitive-depth",
+            "1",
+            "--no-llm",
+        ],
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    issues = data["issues"]
+    assert len(issues) == 2
+    transitive_issue = next(issue for issue in issues if issue.get("source_url") is not None)
+    assert transitive_issue["transitive_depth"] == 1
+    assert transitive_issue["source_url"] == "https://github.com/org/transitive"
+
+
+def test_scan_transitive_ignores_non_scannable_urls(tmp_path: Path, monkeypatch) -> None:
+    """Non-scannable documentation or badge URLs are not followed transitively."""
+    calls: list[str] = []
+    file_cache = {
+        "SKILL.md": (
+            "badge: https://img.shields.io/github/stars/x/y "
+            "docs: https://github.com/org/repo/wiki/SkillSpector "
+            "issue: https://github.com/org/repo/issues/12"
+        )
+    }
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        calls.append(input_path)
+        return _mock_graph_result(
+            findings=[_finding("D1", "direct finding")],
+            file_cache=file_cache,
+            output_format=format.value,
+        )
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--transitive",
+            "--no-llm",
+        ],
+    )
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    data = json.loads(result.output)
+    assert len(data["issues"]) == 1
+
+
+def test_scan_transitive_allow_prefix_filters_targets(tmp_path: Path, monkeypatch) -> None:
+    """Allow prefix limits transitive traversal to matching canonical roots."""
+    file_cache = {
+        "SKILL.md": "refs: https://github.com/allowed/dep.git and https://github.com/blocked/dep.git"
+    }
+    calls: list[str] = []
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        calls.append(input_path)
+        if input_path == str(tmp_path):
+            return _mock_graph_result(
+                findings=[_finding("D1", "direct finding")],
+                file_cache=file_cache,
+                output_format=format.value,
+            )
+        return _mock_graph_result(
+            findings=[_finding("T1", "transitive finding")],
+            output_format=format.value,
+        )
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--transitive",
+            "--transitive-allow-prefix",
+            "https://github.com/allowed/",
+            "--no-llm",
+        ],
+    )
+    assert result.exit_code == 0
+    assert calls[0] == str(tmp_path)
+    assert len(calls) == 2
+    assert calls[1] == "https://github.com/allowed/dep"
+    data = json.loads(result.output)
+    assert any(
+        issue.get("source_url") == "https://github.com/allowed/dep" for issue in data["issues"]
+    )
+
+
+def test_scan_transitive_deny_prefix_skips_targets(tmp_path: Path, monkeypatch) -> None:
+    """Deny prefix blocks matching targets while still scanning siblings."""
+    file_cache = {
+        "SKILL.md": (
+            "refs: https://github.com/allowed/dep.git and https://github.com/blocked/dep.git"
+        )
+    }
+    calls: list[str] = []
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        calls.append(input_path)
+        if input_path == str(tmp_path):
+            return _mock_graph_result(
+                findings=[_finding("D1", "direct finding")],
+                file_cache=file_cache,
+                output_format=format.value,
+            )
+        return _mock_graph_result(
+            findings=[_finding("T1", "transitive finding")],
+            output_format=format.value,
+        )
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--transitive",
+            "--transitive-deny-prefix",
+            "https://github.com/blocked/",
+            "--no-llm",
+        ],
+    )
+    assert result.exit_code == 0
+    assert calls[0] == str(tmp_path)
+    assert len(calls) == 2
+    assert calls[1] == "https://github.com/allowed/dep"
+
+
+def test_cli_passes_result_file_cache_to_transitive_owner(tmp_path: Path, monkeypatch) -> None:
+    """CLI passes completed direct graph file_cache into the transitive owner."""
+    file_cache = {"SKILL.md": "deps https://github.com/org/dep.git"}
+    captured: list[dict[str, str]] = []
+
+    def fake_extract_external_refs(value: dict[str, str]) -> list[str]:
+        captured.append(value)
+        return []
+
+    def fake_run_graph_scan(
+        input_path: str, format, no_llm: bool, *args, **kwargs
+    ) -> dict[str, object]:
+        return _mock_graph_result(
+            findings=[_finding("D1", "direct finding")],
+            file_cache=file_cache if input_path == str(tmp_path) else {},
+            output_format=format.value,
+        )
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    monkeypatch.setattr(transitive, "extract_external_refs", fake_extract_external_refs)
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--transitive",
+            "--no-llm",
+        ],
+    )
+    assert result.exit_code == 0
+    assert captured == [file_cache]
+
+
+def test_single_and_recursive_transitive_route_through_shared_helper(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Both single and recursive scans call _scan_transitive for follow-up scanning."""
+    (tmp_path / "SKILL.md").write_text("# Root", encoding="utf-8")
+    parent = tmp_path / "collection"
+    parent.mkdir()
+    for name in ("skill-a", "skill-b"):
+        skill = parent / name
+        skill.mkdir()
+        (skill / "SKILL.md").write_text(f"---\nname: {name}\n---\n# {name}", encoding="utf-8")
+
+    single_calls: list[object] = []
+    recursive_calls: list[object] = []
+
+    def fake_scan_transitive(*args, **kwargs) -> dict[str, object]:
+        if not recursive_calls and not single_calls:
+            single_calls.append(args)
+        else:
+            recursive_calls.append(args)
+        return {
+            "report_body": "{}",
+            "risk_score": 0,
+            "risk_severity": "LOW",
+            "transitive_finding_count": 0,
+            "transitive_sources": [],
+        }
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        return _mock_graph_result(
+            findings=[_finding("D1", "direct finding")],
+            file_cache={"SKILL.md": "x"},
+            output_format=format.value,
+        )
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    monkeypatch.setattr(cli, "_scan_transitive", fake_scan_transitive)
+
+    single = runner.invoke(
+        app,
+        ["scan", str(tmp_path), "--format", "json", "--transitive", "--no-llm"],
+    )
+    assert single.exit_code == 0
+    assert len(single_calls) == 1
+
+    multi_output = tmp_path / "multi.json"
+    recursive = runner.invoke(
+        app,
+        [
+            "scan",
+            str(parent),
+            "--recursive",
+            "--format",
+            "json",
+            "--transitive",
+            "--output",
+            str(multi_output),
+            "--no-llm",
+        ],
+    )
+    assert recursive.exit_code == 0
+    assert len(recursive_calls) == 2
+
+
+def test_transitive_resolver_failure_preserves_direct_report(tmp_path: Path, monkeypatch) -> None:
+    """A transitive resolver failure should preserve the direct report result."""
+    target = "https://github.com/org/broken.git"
+    file_cache = {"SKILL.md": f"deps {target}"}
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        if input_path == str(tmp_path):
+            return _mock_graph_result(
+                findings=[_finding("D1", "direct finding")],
+                file_cache=file_cache,
+                output_format=format.value,
+            )
+        raise ValueError("resolver failure")
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--transitive",
+            "--no-llm",
+        ],
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data["issues"]) == 1
+    assert data["issues"][0]["id"] == "D1"
+
+
+def test_scan_transitive_does_not_rescan_root_source(monkeypatch) -> None:
+    """A root external source is seeded in visited so self-references are not rescanned."""
+    root_source = "https://github.com/org/root.git"
+    calls: list[str] = []
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        calls.append(input_path)
+        return _mock_graph_result(
+            findings=[_finding("D1", "direct finding")],
+            file_cache={"SKILL.md": root_source},
+            output_format=format.value,
+        )
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    result = runner.invoke(
+        app,
+        ["scan", root_source, "--format", "json", "--transitive", "--no-llm"],
+    )
+    assert result.exit_code == 0
+    assert calls == [root_source]
+
+
+def test_scan_transitive_preserves_root_cleanup_and_counts_findings(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Transitive merge keeps the root cleanup path and counts findings, not sources."""
+    cleanup_root = tmp_path / "cleanup-root"
+    initial_result = _mock_graph_result(
+        findings=[_finding("D1", "direct finding")],
+        file_cache={"SKILL.md": "https://github.com/org/transitive.git"},
+    )
+    initial_result["temp_dir_for_cleanup"] = str(cleanup_root)
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        assert input_path == "https://github.com/org/transitive"
+        return _mock_graph_result(
+            findings=[
+                _finding("T1", "transitive finding"),
+                _finding("T2", "second transitive finding"),
+            ],
+            output_format=format.value,
+        )
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    merged = cli._scan_transitive(
+        initial_result=initial_result,
+        format=cli.FormatChoice.json,
+        no_llm=True,
+        max_depth=1,
+        transitive_allow_prefix=(),
+        transitive_deny_prefix=(),
+        baseline=None,
+        show_suppressed=False,
+        visited=set(),
+    )
+
+    assert merged["temp_dir_for_cleanup"] == str(cleanup_root)
+    assert merged["transitive_finding_count"] == 2
+    assert merged["transitive_sources"] == ["https://github.com/org/transitive"]
+
+
+def test_scan_transitive_counts_only_active_post_baseline_findings(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Baseline-suppressed transitive findings are not counted in summaries."""
+    initial_result = _mock_graph_result(
+        findings=[_finding("D1", "direct finding")],
+        file_cache={"SKILL.md": "https://github.com/org/transitive.git"},
+    )
+    baseline = Baseline(rules=[SuppressionRule(rule_id="T1", reason="accepted")])
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        assert input_path == "https://github.com/org/transitive"
+        return _mock_graph_result(
+            findings=[
+                _finding("T1", "suppressed transitive finding"),
+                _finding("T2", "active transitive finding"),
+            ],
+            output_format=format.value,
+        )
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    merged = cli._scan_transitive(
+        initial_result=initial_result,
+        format=cli.FormatChoice.json,
+        no_llm=True,
+        max_depth=1,
+        transitive_allow_prefix=(),
+        transitive_deny_prefix=(),
+        baseline=baseline,
+        show_suppressed=False,
+        visited=set(),
+    )
+
+    assert merged["transitive_finding_count"] == 1
+    body = json.loads(merged["report_body"])
+    assert [issue["id"] for issue in body["issues"]] == ["D1", "T2"]
+
+
+def test_scan_transitive_preserves_cached_child_llm_telemetry(monkeypatch) -> None:
+    """Cached transitive child telemetry still drives degraded-report metadata."""
+    initial_result = _mock_graph_result(
+        findings=[_finding("D1", "direct finding")],
+        file_cache={"SKILL.md": "https://github.com/org/transitive.git"},
+    )
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        assert input_path == "https://github.com/org/transitive"
+        result = _mock_graph_result(
+            findings=[_finding("T1", "transitive finding")],
+            output_format=format.value,
+        )
+        result["llm_call_log"] = [{"node": "semantic_quality_policy", "ok": False, "error": "boom"}]
+        return result
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    merged = cli._scan_transitive(
+        initial_result=initial_result,
+        format=cli.FormatChoice.json,
+        no_llm=False,
+        max_depth=1,
+        transitive_allow_prefix=(),
+        transitive_deny_prefix=(),
+        baseline=None,
+        show_suppressed=False,
+        visited=set(),
+    )
+
+    body = json.loads(merged["report_body"])
+    assert body["metadata"]["llm_calls_attempted"] == 1
+    assert body["metadata"]["llm_calls_succeeded"] == 0
+    assert body["metadata"]["llm_degraded"] is True
+
+
+def test_scan_transitive_zero_depth_preserves_root_cleanup(tmp_path: Path, monkeypatch) -> None:
+    """Zero-depth transitive scans preserve root cleanup metadata and do not recurse."""
+    cleanup_root = tmp_path / "cleanup-root"
+    initial_result = _mock_graph_result(findings=[_finding("D1", "direct finding")])
+    initial_result["temp_dir_for_cleanup"] = str(cleanup_root)
+
+    def fail_run_graph_scan(*args, **kwargs) -> dict[str, object]:
+        raise AssertionError("zero-depth transitive scan should not recurse")
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fail_run_graph_scan)
+    merged = cli._scan_transitive(
+        initial_result=initial_result,
+        format=cli.FormatChoice.json,
+        no_llm=True,
+        max_depth=0,
+        transitive_allow_prefix=(),
+        transitive_deny_prefix=(),
+        baseline=None,
+        show_suppressed=False,
+        visited=set(),
+    )
+
+    assert merged["temp_dir_for_cleanup"] == str(cleanup_root)
+    assert merged["transitive_finding_count"] == 0
+    assert merged["transitive_sources"] == []
+
+
+def test_recursive_transitive_json_includes_sources(tmp_path: Path, monkeypatch) -> None:
+    """Recursive combined JSON output records transitive source summaries."""
+    root = tmp_path / "root"
+    root.mkdir()
+    for name in ("weather", "email"):
+        sub = root / name
+        sub.mkdir()
+        (sub / "SKILL.md").write_text(f"---\nname: {name}\n---\n", encoding="utf-8")
+
+    calls: list[int] = []
+    expected_sources = [
+        "https://github.com/org/weather-transitive",
+        "https://github.com/org/email-transitive",
+    ]
+    expected_counts = [2, 1]
+
+    def fake_scan_transitive(*args, **kwargs) -> dict[str, object]:
+        index = len(calls)
+        calls.append(index)
+        return {
+            "report_body": "{}",
+            "risk_score": 0,
+            "risk_severity": "LOW",
+            "transitive_finding_count": expected_counts[index],
+            "transitive_sources": [expected_sources[index]],
+        }
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        return _mock_graph_result(
+            findings=[_finding("D1", "direct finding")],
+            file_cache={"SKILL.md": "https://github.com/example/dummy.git"},
+            output_format=format.value,
+        )
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    monkeypatch.setattr(cli, "_scan_transitive", fake_scan_transitive)
+
+    out_file = root / "multi.json"
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            str(root),
+            "--recursive",
+            "--format",
+            "json",
+            "--transitive",
+            "--output",
+            str(out_file),
+            "--no-llm",
+        ],
+    )
+    assert result.exit_code == 0
+    assert out_file.exists()
+    data = json.loads(out_file.read_text(encoding="utf-8"))
+    assert data["transitive_finding_count"] == sum(expected_counts)
+    assert sorted(data["transitive_sources"]) == sorted(expected_sources)
+
+
+def test_recursive_transitive_reuses_cached_dependency_results(tmp_path: Path, monkeypatch) -> None:
+    """Sibling skills each merge shared dependency findings while scanning it only once."""
+    root = tmp_path / "root"
+    root.mkdir()
+    for name in ("weather", "email"):
+        sub = root / name
+        sub.mkdir()
+        (sub / "SKILL.md").write_text(f"---\nname: {name}\n---\n", encoding="utf-8")
+
+    shared_dep = "https://github.com/org/shared-dep"
+    calls: list[str] = []
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        calls.append(input_path)
+        if input_path == shared_dep:
+            transitive_finding = Finding(
+                rule_id="T1",
+                message="shared dependency finding",
+                severity="LOW",
+                confidence=0.9,
+                file="dep.py",
+                start_line=1,
+            )
+            return {
+                "findings": [transitive_finding],
+                "filtered_findings": [transitive_finding],
+                "components": ["SKILL.md", "dep.py"],
+                "component_metadata": [
+                    {
+                        "path": "SKILL.md",
+                        "type": "markdown",
+                        "lines": 5,
+                        "executable": False,
+                        "size_bytes": 50,
+                    },
+                    {
+                        "path": "dep.py",
+                        "type": "python",
+                        "lines": 8,
+                        "executable": True,
+                        "size_bytes": 80,
+                    },
+                ],
+                "file_cache": {"SKILL.md": "# dep", "dep.py": "print('dep')"},
+                "has_executable_scripts": True,
+                "output_format": format.value,
+            }
+        direct_finding = Finding(
+            rule_id="D1",
+            message="direct finding",
+            severity="LOW",
+            confidence=0.9,
+            file="SKILL.md",
+            start_line=1,
+        )
+        return {
+            "findings": [direct_finding],
+            "filtered_findings": [direct_finding],
+            "components": ["SKILL.md"],
+            "component_metadata": [
+                {
+                    "path": "SKILL.md",
+                    "type": "markdown",
+                    "lines": 4,
+                    "executable": False,
+                    "size_bytes": 40,
+                }
+            ],
+            "file_cache": {"SKILL.md": shared_dep},
+            "has_executable_scripts": False,
+            "output_format": format.value,
+        }
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+
+    out_file = root / "multi.json"
+    result = runner.invoke(
+        app,
+        [
+            "scan",
+            str(root),
+            "--recursive",
+            "--format",
+            "json",
+            "--transitive",
+            "--output",
+            str(out_file),
+            "--no-llm",
+        ],
+    )
+    assert result.exit_code == 0
+    data = json.loads(out_file.read_text(encoding="utf-8"))
+    assert calls.count(shared_dep) == 1
+    assert [skill["transitive_finding_count"] for skill in data["skills"]] == [1, 1]
+    assert data["transitive_sources"] == [shared_dep]
+
+
+def test_scan_transitive_marks_truncation_when_target_budget_hits(monkeypatch) -> None:
+    """Traversal stops after the target budget and reports the truncation."""
+    initial_result = {
+        "findings": [_finding("D1", "direct finding")],
+        "filtered_findings": [_finding("D1", "direct finding")],
+        "components": ["SKILL.md"],
+        "component_metadata": [
+            {
+                "path": "SKILL.md",
+                "type": "markdown",
+                "lines": 3,
+                "executable": False,
+                "size_bytes": 30,
+            }
+        ],
+        "file_cache": {
+            "SKILL.md": ("https://github.com/org/one.git https://github.com/org/two.git")
+        },
+        "has_executable_scripts": False,
+        "output_format": "json",
+    }
+    scanned_targets: list[str] = []
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        scanned_targets.append(input_path)
+        return {
+            "findings": [_finding("T1", "transitive finding", file="dep.py")],
+            "filtered_findings": [_finding("T1", "transitive finding", file="dep.py")],
+            "components": ["dep.py"],
+            "component_metadata": [
+                {
+                    "path": "dep.py",
+                    "type": "python",
+                    "lines": 10,
+                    "executable": True,
+                    "size_bytes": 64,
+                }
+            ],
+            "file_cache": {"dep.py": "print('dep')"},
+            "has_executable_scripts": True,
+            "output_format": format.value,
+        }
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    merged = cli._scan_transitive(
+        initial_result=initial_result,
+        format=cli.FormatChoice.json,
+        no_llm=True,
+        max_depth=1,
+        transitive_allow_prefix=(),
+        transitive_deny_prefix=(),
+        baseline=None,
+        show_suppressed=False,
+        visited=set(),
+        budget=cli._TransitiveBudget(max_targets=1, max_bytes=1_000_000, max_seconds=60.0),
+    )
+
+    body = json.loads(merged["report_body"])
+    assert scanned_targets == ["https://github.com/org/one"]
+    assert merged["transitive_targets_scanned"] == 1
+    assert merged["transitive_truncated"] is True
+    assert merged["transitive_truncation_reasons"] == ["target budget 1 reached"]
+    assert body["metadata"]["transitive_truncated"] is True
+
+
+def test_scan_transitive_merges_current_effective_finding_ids(monkeypatch) -> None:
+    """Child findings selected by the current ledger survive report rendering."""
+    target = "https://github.com/org/effective"
+    direct = _finding("D1", "direct finding")
+    child = _finding("T1", "transitive finding", file="dep.py")
+    initial_result = {
+        "findings": [direct],
+        "filtered_findings": [direct],
+        "effective_finding_ids": [direct.finding_id],
+        "components": ["SKILL.md"],
+        "component_metadata": [
+            {
+                "path": "SKILL.md",
+                "type": "markdown",
+                "lines": 3,
+                "executable": False,
+                "size_bytes": 30,
+            }
+        ],
+        "file_cache": {"SKILL.md": target},
+        "has_executable_scripts": False,
+        "output_format": "json",
+    }
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        assert input_path == target
+        return {
+            "findings": [child],
+            "filtered_findings": [child],
+            "effective_finding_ids": [child.finding_id],
+            "components": ["dep.py"],
+            "component_metadata": [
+                {
+                    "path": "dep.py",
+                    "type": "python",
+                    "lines": 4,
+                    "executable": True,
+                    "size_bytes": 20,
+                }
+            ],
+            "file_cache": {"dep.py": "print('dep')"},
+            "has_executable_scripts": True,
+            "output_format": format.value,
+        }
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    merged = cli._scan_transitive(
+        initial_result=initial_result,
+        format=cli.FormatChoice.json,
+        no_llm=True,
+        max_depth=1,
+        transitive_allow_prefix=(),
+        transitive_deny_prefix=(),
+        baseline=None,
+        show_suppressed=False,
+        visited=set(),
+    )
+
+    body = json.loads(merged["report_body"])
+    assert [issue["finding_id"] for issue in body["issues"]] == [
+        direct.finding_id,
+        child.finding_id,
+    ]
+    assert merged["transitive_finding_count"] == 1
+
+
+def test_scan_transitive_child_failure_stays_visible_and_fail_closed(monkeypatch) -> None:
+    """Child scan exceptions should degrade the report without leaking raw error text."""
+    failed_target = "https://github.com/org/broken"
+    initial_result = {
+        "findings": [_finding("D1", "direct finding")],
+        "filtered_findings": [_finding("D1", "direct finding")],
+        "components": ["SKILL.md"],
+        "component_metadata": [
+            {
+                "path": "SKILL.md",
+                "type": "markdown",
+                "lines": 3,
+                "executable": False,
+                "size_bytes": 30,
+            }
+        ],
+        "file_cache": {"SKILL.md": failed_target},
+        "has_executable_scripts": False,
+        "output_format": "json",
+        "temp_dir_for_cleanup": "root-temp",
+    }
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        assert input_path == failed_target
+        raise RuntimeError("secret token should stay private")
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    merged = cli._scan_transitive(
+        initial_result=initial_result,
+        format=cli.FormatChoice.json,
+        no_llm=True,
+        max_depth=1,
+        transitive_allow_prefix=(),
+        transitive_deny_prefix=(),
+        baseline=None,
+        show_suppressed=False,
+        visited=set(),
+    )
+
+    body = json.loads(merged["report_body"])
+    assert merged["temp_dir_for_cleanup"] == "root-temp"
+    assert merged["transitive_sources"] == [failed_target]
+    assert merged["transitive_targets_scanned"] == 0
+    assert merged["transitive_truncated"] is True
+    assert merged["transitive_truncation_reasons"] == [
+        f"transitive child scan failed for {failed_target}"
+    ]
+    assert merged["risk_recommendation"] == "CAUTION"
+    assert body["analysis_completeness"]["is_complete"] is False
+    assert body["metadata"]["transitive_truncated"] is True
+    assert any(
+        "transitive child scan failed for https://github.com/org/broken" in limitation
+        for limitation in body["analysis_completeness"]["limitations"]
+    )
+    assert "secret token should stay private" not in merged["transitive_truncation_reasons"][0]
+    assert "secret token should stay private" not in merged["report_body"]
+
+
+def test_scan_transitive_keeps_source_aware_component_coverage(monkeypatch) -> None:
+    """Coverage should stay complete when child sources reuse the same relative path names."""
+    shared_dep = "https://github.com/org/shared"
+    initial_result = {
+        "findings": [_finding("D1", "direct finding")],
+        "filtered_findings": [_finding("D1", "direct finding")],
+        "components": ["SKILL.md"],
+        "component_metadata": [
+            {
+                "path": "SKILL.md",
+                "type": "markdown",
+                "lines": 3,
+                "executable": False,
+                "size_bytes": 30,
+            }
+        ],
+        "file_cache": {"SKILL.md": shared_dep},
+        "has_executable_scripts": False,
+        "output_format": "json",
+    }
+
+    def fake_run_graph_scan(
+        input_path: str,
+        format,
+        no_llm: bool,
+        yara_dir: str | None = None,
+        baseline=None,
+        show_suppressed: bool = False,
+        transitive_traversal=None,
+    ) -> dict[str, object]:
+        assert input_path == shared_dep
+        return {
+            "findings": [_finding("T1", "transitive finding", file="SKILL.md")],
+            "filtered_findings": [_finding("T1", "transitive finding", file="SKILL.md")],
+            "components": ["SKILL.md"],
+            "component_metadata": [
+                {
+                    "path": "SKILL.md",
+                    "type": "markdown",
+                    "lines": 5,
+                    "executable": False,
+                    "size_bytes": 50,
+                }
+            ],
+            "file_cache": {"SKILL.md": "# dep"},
+            "has_executable_scripts": False,
+            "output_format": format.value,
+        }
+
+    monkeypatch.setattr(cli, "_run_graph_scan", fake_run_graph_scan)
+    merged = cli._scan_transitive(
+        initial_result=initial_result,
+        format=cli.FormatChoice.json,
+        no_llm=True,
+        max_depth=1,
+        transitive_allow_prefix=(),
+        transitive_deny_prefix=(),
+        baseline=None,
+        show_suppressed=False,
+        visited=set(),
+    )
+
+    body = json.loads(merged["report_body"])
+    assert body["analysis_completeness"]["coverage_percent"] == 100.0
+    assert len(body["components"]) == 2
+    assert {component["source_url"] for component in body["components"]} == {None, shared_dep}

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -234,7 +234,9 @@ class TestChatCompletion:
                 assert prompt == "ping"
                 return AIMessage(content="hello world")
 
-        monkeypatch.setattr(llm_utils, "get_chat_model", lambda model=None: _FakeLLM())
+        monkeypatch.setattr(
+            llm_utils, "get_chat_model", lambda model=None, timeout=None: _FakeLLM()
+        )
         assert chat_completion("ping") == "hello world"
 
     def test_returns_text_from_langchain_content_blocks(
@@ -246,7 +248,9 @@ class TestChatCompletion:
 
         captured: dict[str, str | None] = {}
 
-        def _fake_get_chat_model(model: str | None = None) -> _FakeLLM:
+        def _fake_get_chat_model(
+            model: str | None = None, timeout: float | None = None
+        ) -> _FakeLLM:
             captured["model"] = model
             return _FakeLLM()
 
@@ -260,7 +264,9 @@ class TestChatCompletion:
             def invoke(self, prompt: str) -> AIMessage:
                 return AIMessage(content="")
 
-        monkeypatch.setattr(llm_utils, "get_chat_model", lambda model=None: _FakeLLM())
+        monkeypatch.setattr(
+            llm_utils, "get_chat_model", lambda model=None, timeout=None: _FakeLLM()
+        )
         assert chat_completion("prompt") == ""
 
 
@@ -357,6 +363,21 @@ class TestChatCompletionCLIDispatch:
         call_kwargs = fake_complete.call_args[1]
         assert call_kwargs["model"] == "claude-haiku-3-5"
 
+    def test_dispatches_timeout_to_cli_provider_complete(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "claude_cli")
+
+        fake_complete = MagicMock(return_value="mocked CLI response")
+        with patch(
+            "skillspector.providers.claude_cli.provider.ClaudeCLIProvider.complete",
+            fake_complete,
+        ):
+            result = chat_completion("test prompt", model="claude-haiku-3-5", timeout=17.5)
+
+        assert result == "mocked CLI response"
+        assert fake_complete.call_args[1]["timeout"] == 17.5
+
     def test_does_not_call_complete_for_http_provider(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -395,9 +416,10 @@ class TestGetChatModelCLIAdapter:
         with patch(
             "skillspector.providers.claude_cli.provider.ClaudeCLIProvider.complete",
             MagicMock(return_value="hello"),
-        ):
+        ) as fake_complete:
             msg = get_chat_model(model="claude-sonnet-4-6").invoke("hi")
         assert msg.content == "hello"
+        assert fake_complete.call_args[1]["timeout"] is None
 
     def test_structured_output_parses_and_validates(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "claude_cli")
@@ -410,15 +432,16 @@ class TestGetChatModelCLIAdapter:
         with patch(
             "skillspector.providers.claude_cli.provider.ClaudeCLIProvider.complete",
             MagicMock(return_value=raw),
-        ):
+        ) as fake_complete:
             out = (
-                get_chat_model(model="claude-sonnet-4-6")
+                get_chat_model(model="claude-sonnet-4-6", timeout=12.0)
                 .with_structured_output(_Schema)
                 .invoke("x")
             )
         assert isinstance(out, _Schema)
         assert out.verdict == "unsafe"
         assert out.score == 7
+        assert fake_complete.call_args[1]["timeout"] == 12.0
 
     def test_structured_output_fail_closed_on_garbage(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_suppression.py
+++ b/tests/unit/test_suppression.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -105,6 +106,28 @@ def test_fingerprint_differs_on_field_change() -> None:
     assert _fingerprint(_finding(context="different context")) != base
     assert _fingerprint(_finding(), content=SKILL_CONTENT + "changed") != base
     assert _fingerprint(_finding(), scanner_version="2.3.12") != base
+
+
+def test_transitive_fingerprint_and_baseline_are_source_aware() -> None:
+    first = replace(_finding(), source_url="https://github.com/org/first", transitive_depth=1)
+    second = replace(_finding(), source_url="https://github.com/org/second", transitive_depth=1)
+    assert _fingerprint(first) != _fingerprint(second)
+
+    file_cache = {
+        "https://github.com/org/first::skill-a/SKILL.md": SKILL_CONTENT,
+        "https://github.com/org/second::skill-a/SKILL.md": SKILL_CONTENT,
+    }
+    baseline = baseline_from_dict(
+        build_baseline_dict([first], file_cache=file_cache, scanner_version=SCANNER_VERSION)
+    )
+    kept, suppressed = partition_findings(
+        [first, second],
+        baseline,
+        file_cache=file_cache,
+        scanner_version=SCANNER_VERSION,
+    )
+    assert kept == [second]
+    assert [item.finding for item in suppressed] == [first]
 
 
 def test_fingerprint_canonical_encoding_avoids_delimiter_collision() -> None:

--- a/tests/unit/test_transitive.py
+++ b/tests/unit/test_transitive.py
@@ -1,0 +1,496 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for transitive source extraction and traversal planning."""
+
+import subprocess
+from pathlib import Path
+
+import httpx
+
+from skillspector import input_handler as input_handler_module
+from skillspector import transitive
+from skillspector.input_handler import InputHandler
+
+
+def test_plan_blocks_circular_reference() -> None:
+    """Visited identities block repeated canonical targets before second resolution."""
+    refs = [
+        "https://github.com/org/dup.git",
+        "git@github.com:org/dup.git",
+        "https://github.com/org/dup",
+    ]
+    visited: set[str] = set()
+    first = transitive.plan_transitive_targets(
+        refs, visited=visited, current_depth=1, max_depth=3, allow_prefixes=(), deny_prefixes=()
+    )
+    second = transitive.plan_transitive_targets(
+        refs, visited=visited, current_depth=1, max_depth=3, allow_prefixes=(), deny_prefixes=()
+    )
+
+    assert first == ["https://github.com/org/dup"]
+    assert second == []
+    assert visited == {"https://github.com/org/dup"}
+
+
+def test_extract_excludes_badges_docs_and_issue_urls() -> None:
+    """Non-scan URLs should be filtered out, even when they look URL-like."""
+    file_cache = {
+        "SKILL.md": (
+            "badge https://img.shields.io/github/stars/user/repo?style=flat-square, "
+            "issue https://github.com/NVIDIA/SkillSpector/issues/12, "
+            "insecure http://github.com/NVIDIA/SkillSpector, "
+            "docs https://github.com/NVIDIA/SkillSpector/wiki, "
+            "ci https://github.com/NVIDIA/SkillSpector/actions, "
+            "src https://raw.githubusercontent.com/NVIDIA/SkillSpector/main/tool.py, "
+            "zip https://huggingface.co/abc/archive/main.zip"
+        ),
+    }
+
+    refs = transitive.extract_external_refs(file_cache)
+    assert refs == [
+        "https://raw.githubusercontent.com/NVIDIA/SkillSpector/main/tool.py",
+        "https://huggingface.co/abc/archive/main.zip",
+    ]
+
+
+def test_extract_keeps_repos_with_reserved_word_names() -> None:
+    """Reserved UI words in org or repo names should not block valid repository targets."""
+    file_cache = {
+        "SKILL.md": (
+            "https://github.com/wiki-tools/skill.git "
+            "https://github.com/org/actions.git "
+            "https://github.com/badger/skill.git "
+            "https://github.com/mrdoob/three.js"
+        ),
+    }
+
+    refs = transitive.extract_external_refs(file_cache)
+    assert refs == [
+        "https://github.com/wiki-tools/skill",
+        "https://github.com/org/actions",
+        "https://github.com/badger/skill",
+        "https://github.com/mrdoob/three.js",
+    ]
+
+
+def test_input_handler_treats_github_archive_zip_as_file_url() -> None:
+    """GitHub archive ZIP links should download as files, not route through git clone."""
+    handler = InputHandler()
+    url = "https://github.com/org/repo/archive/refs/heads/main.zip"
+
+    assert handler._is_git_url(url) is False
+    assert handler._is_file_url(url) is True
+
+
+def test_input_handler_keeps_extension_named_github_repositories_as_git() -> None:
+    handler = InputHandler()
+
+    assert handler._is_git_url("https://github.com/mrdoob/three.js") is True
+    assert handler._is_git_url("https://github.com/robfig/cron.go") is True
+    assert handler._is_git_url("https://github.com/org/skills.zip") is True
+
+
+def test_input_handler_resolves_github_archive_zip_via_validated_redirect(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """GitHub archive ZIP redirects should still resolve as downloadable archives."""
+
+    class FakeResponse:
+        def __init__(
+            self,
+            status_code: int,
+            *,
+            headers: dict[str, str] | None = None,
+            content: bytes = b"",
+        ) -> None:
+            self.status_code = status_code
+            self.headers = headers or {}
+            self.content = content
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                request = httpx.Request("GET", "https://example.invalid")
+                response = httpx.Response(
+                    self.status_code,
+                    headers=self.headers,
+                    content=self.content,
+                    request=request,
+                )
+                raise httpx.HTTPStatusError(
+                    f"HTTP error {self.status_code}", request=request, response=response
+                )
+
+        def iter_bytes(self):
+            yield self.content
+
+    class FakeClient:
+        def __init__(self, responses: list[FakeResponse], **kwargs) -> None:
+            self._responses = responses
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def stream(self, method: str, url: str):
+            response = self._responses.pop(0)
+
+            class _StreamContext:
+                def __enter__(self) -> FakeResponse:
+                    return response
+
+                def __exit__(self, exc_type, exc, tb) -> bool:
+                    return False
+
+            return _StreamContext()
+
+    class Budget:
+        def remaining_seconds(self) -> float:
+            return 60.0
+
+        def remaining_bytes(self) -> int:
+            return 1024 * 1024
+
+        def record_bytes(self, bytes_scanned: int) -> None:
+            return None
+
+        def note_truncation(self, reason: str) -> None:
+            return None
+
+    archive_url = "https://github.com/org/repo/archive/refs/heads/main.zip"
+    redirected_url = "https://codeload.github.com/org/repo/zip/refs/heads/main"
+    responses = [
+        FakeResponse(302, headers={"location": redirected_url}),
+        FakeResponse(200, headers={"content-type": "application/zip"}, content=b"zip-bytes"),
+    ]
+    handler = InputHandler(transitive_budget=Budget())
+
+    monkeypatch.setattr(input_handler_module, "_is_private_ip", lambda host: False)
+    monkeypatch.setattr(httpx, "Client", lambda **kwargs: FakeClient(responses, **kwargs))
+    monkeypatch.setattr(handler, "_extract_zip", lambda zip_path: tmp_path / Path(zip_path).stem)
+
+    resolved_path, source_type = handler.resolve(archive_url)
+
+    assert source_type == "url"
+    assert resolved_path == tmp_path / "download"
+    assert responses == []
+
+
+def test_input_handler_download_budget_exhaustion_returns_empty_dir(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A streamed transitive download over budget truncates instead of failing the child scan."""
+
+    class Budget:
+        def __init__(self) -> None:
+            self.reasons: list[str] = []
+
+        def remaining_seconds(self) -> float:
+            return 60.0
+
+        def remaining_bytes(self) -> int:
+            return 4
+
+        def note_truncation(self, reason: str) -> None:
+            self.reasons.append(reason)
+
+    class FakeResponse:
+        status_code = 200
+        headers = {"content-type": "text/plain"}
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_bytes(self):
+            yield b"12345"
+
+    class FakeClient:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def stream(self, method: str, url: str):
+            class _StreamContext:
+                def __enter__(self) -> FakeResponse:
+                    return FakeResponse()
+
+                def __exit__(self, exc_type, exc, tb) -> bool:
+                    return False
+
+            return _StreamContext()
+
+    budget = Budget()
+    handler = InputHandler(transitive_budget=budget)
+    monkeypatch.setattr(input_handler_module, "_is_private_ip", lambda host: False)
+    monkeypatch.setattr(httpx, "Client", lambda **kwargs: FakeClient(**kwargs))
+    monkeypatch.setattr(handler, "_get_temp_dir", lambda: tmp_path)
+
+    resolved = handler._download_file("https://raw.githubusercontent.com/org/repo/main/SKILL.md")
+
+    assert resolved == tmp_path / "download"
+    assert list(resolved.iterdir()) == []
+    assert budget.reasons == ["Transitive byte budget exceeded by downloaded file"]
+
+
+def test_input_handler_download_deadline_exhaustion_returns_empty_dir(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A streamed transitive download that runs out of time truncates instead of hard-failing."""
+
+    class Budget:
+        def __init__(self) -> None:
+            self.reasons: list[str] = []
+            self.calls = 0
+
+        def remaining_seconds(self) -> float:
+            self.calls += 1
+            return 60.0 if self.calls == 1 else 0.0
+
+        def remaining_bytes(self) -> int:
+            return 10
+
+        def note_truncation(self, reason: str) -> None:
+            self.reasons.append(reason)
+
+    class FakeResponse:
+        status_code = 200
+        headers = {"content-type": "text/plain"}
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_bytes(self):
+            yield b"1"
+
+    class FakeClient:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def stream(self, method: str, url: str):
+            class _StreamContext:
+                def __enter__(self) -> FakeResponse:
+                    return FakeResponse()
+
+                def __exit__(self, exc_type, exc, tb) -> bool:
+                    return False
+
+            return _StreamContext()
+
+    budget = Budget()
+    handler = InputHandler(transitive_budget=budget)
+    monkeypatch.setattr(input_handler_module, "_is_private_ip", lambda host: False)
+    monkeypatch.setattr(httpx, "Client", lambda **kwargs: FakeClient(**kwargs))
+    monkeypatch.setattr(handler, "_get_temp_dir", lambda: tmp_path)
+
+    resolved = handler._download_file("https://raw.githubusercontent.com/org/repo/main/SKILL.md")
+
+    assert resolved == tmp_path / "download"
+    assert list(resolved.iterdir()) == []
+    assert budget.reasons == ["Transitive time budget exhausted during download"]
+
+
+def test_input_handler_rejects_oversized_transitive_git_clone(tmp_path: Path, monkeypatch) -> None:
+    """A transitive git clone over the remaining byte budget returns an empty scan root."""
+
+    class Budget:
+        def __init__(self) -> None:
+            self.reasons: list[str] = []
+
+        def remaining_seconds(self) -> float:
+            return 60.0
+
+        def remaining_bytes(self) -> int:
+            return 5
+
+        def note_truncation(self, reason: str) -> None:
+            self.reasons.append(reason)
+
+    budget = Budget()
+    handler = InputHandler(transitive_budget=budget)
+    commands: list[list[str]] = []
+    monkeypatch.setattr(handler, "_get_temp_dir", lambda: tmp_path)
+    monkeypatch.setattr(handler, "_validate_url_host", lambda url, allowed: "github.com")
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        clone_dir = Path(cmd[-1])
+        clone_dir.mkdir(parents=True)
+        (clone_dir / "large.py").write_text("0123456789", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    resolved = handler._clone_git("https://github.com/org/large.git")
+
+    assert commands == [
+        [
+            "git",
+            "-c",
+            "core.symlinks=false",
+            "clone",
+            "--depth",
+            "1",
+            "--filter=blob:limit=5",
+            "https://github.com/org/large.git",
+            str(tmp_path / "repo"),
+        ]
+    ]
+    assert resolved == tmp_path / "repo"
+    assert list(resolved.iterdir()) == []
+    assert budget.reasons == ["Transitive byte budget exceeded by cloned repository"]
+
+
+def test_plan_depth_limit_prevents_next_wave() -> None:
+    """When current depth exceeds max depth, no targets are returned."""
+    refs = ["https://github.com/org/repo.git"]
+    visited: set[str] = set()
+    result = transitive.plan_transitive_targets(
+        refs=refs,
+        visited=visited,
+        current_depth=4,
+        max_depth=3,
+        allow_prefixes=(),
+        deny_prefixes=(),
+    )
+
+    assert result == []
+    assert visited == set()
+
+
+def test_plan_applies_allow_prefix() -> None:
+    """Only identities matching allow prefixes are returned."""
+    refs = [
+        "https://github.com/ok/repo.git",
+        "https://github.com/skip/repo.git",
+    ]
+    visited: set[str] = set()
+    allowed = ("https://github.com/ok/",)
+
+    result = transitive.plan_transitive_targets(
+        refs=refs,
+        visited=visited,
+        current_depth=1,
+        max_depth=2,
+        allow_prefixes=allowed,
+        deny_prefixes=(),
+    )
+
+    assert result == ["https://github.com/ok/repo"]
+
+
+def test_plan_allow_prefix_respects_path_boundaries() -> None:
+    """Allow prefixes should not match sibling org names sharing a string prefix."""
+    refs = [
+        "https://github.com/trusted/repo.git",
+        "https://github.com/trusted-malicious/repo.git",
+    ]
+    visited: set[str] = set()
+
+    result = transitive.plan_transitive_targets(
+        refs=refs,
+        visited=visited,
+        current_depth=1,
+        max_depth=2,
+        allow_prefixes=("https://github.com/trusted/",),
+        deny_prefixes=(),
+    )
+
+    assert result == ["https://github.com/trusted/repo"]
+
+
+def test_plan_allow_prefix_normalizes_dot_segment_escapes() -> None:
+    """Allow-prefix checks should run on normalized paths, not raw URL text."""
+    refs = ["https://github.com/trusted/%2e%2e/evil/repo.git"]
+
+    result = transitive.plan_transitive_targets(
+        refs=refs,
+        visited=set(),
+        current_depth=1,
+        max_depth=2,
+        allow_prefixes=("https://github.com/trusted/",),
+        deny_prefixes=(),
+    )
+
+    assert result == []
+
+
+def test_plan_applies_deny_prefix() -> None:
+    """Deny prefixes skip matching identities even if they are otherwise valid."""
+    refs = [
+        "https://github.com/ok/repo.git",
+        "https://github.com/skip/repo.git",
+    ]
+    visited: set[str] = set()
+    denied = ("https://github.com/skip/",)
+
+    result = transitive.plan_transitive_targets(
+        refs=refs,
+        visited=visited,
+        current_depth=1,
+        max_depth=2,
+        allow_prefixes=(),
+        deny_prefixes=denied,
+    )
+
+    assert result == ["https://github.com/ok/repo"]
+
+
+def test_plan_deny_prefix_respects_path_boundaries() -> None:
+    """Deny prefixes should not block sibling org names that only share a string prefix."""
+    refs = [
+        "https://github.com/trusted/repo.git",
+        "https://github.com/trusted-malicious/repo.git",
+    ]
+    visited: set[str] = set()
+
+    result = transitive.plan_transitive_targets(
+        refs=refs,
+        visited=visited,
+        current_depth=1,
+        max_depth=2,
+        allow_prefixes=(),
+        deny_prefixes=("https://github.com/trusted/",),
+    )
+
+    assert result == ["https://github.com/trusted-malicious/repo"]
+
+
+def test_plan_deny_prefix_blocks_normalized_dot_segment_escapes() -> None:
+    """Deny-prefix checks should block refs that normalize into the denied path."""
+    refs = ["https://github.com/trusted/%2e%2e/evil/repo.git"]
+
+    result = transitive.plan_transitive_targets(
+        refs=refs,
+        visited=set(),
+        current_depth=1,
+        max_depth=2,
+        allow_prefixes=(),
+        deny_prefixes=("https://github.com/evil/",),
+    )
+
+    assert result == []


### PR DESCRIPTION
## Summary

Rebuilds the opt-in transitive scanning feature onto current `main` while preserving the resolved review fixes and current state, input, analyzer, and report contracts.

Closes #97

## Root cause

The previous head was based on a pre-ledger state shape and stale provider call contracts. Rebasing it mechanically conflicted with current ownership of inspection completeness, effective finding selection, LLM telemetry, secure input handling, and report rendering. The branch also retained the current-head semantic analyzer failures from that integration drift.

## Diff Notes

- Port the transitive traversal through current `SkillspectorState`, `inspection_ledger`, `analyzer_status_events`, `effective_finding_ids`, `analysis_completeness`, `execution_successful`, and `llm_call_log` contracts.
- Namespace and merge child ledger/status/completeness facts so coverage and execution status describe root and dependency components together.
- Keep `--transitive` opt-in, with canonical source identities, normalized allow or deny prefixes, per-root visited sets, shared child-result caching, depth limits, target limits, byte limits, and time limits.
- Keep direct root scans outside the child traversal budget. Child input uses the existing `InputHandler` host, SSRF, redirect, clone, archive, and secure-file boundaries.
- Keep child failures, incomplete child reports, and traversal truncation visible through the current completeness path, and floor an otherwise `SAFE` result to `CAUTION` without changing the score or severity.
- Keep the shared deadline scoped to child work, continue after an individual child failure, and account for child file reads against the byte budget while retaining all inventoried components.
- Preserve effective child findings when merging graph results, including source-aware component coverage, finding provenance, cached LLM telemetry, and baseline suppression for repeated dependency paths.
- Surface dependency source and depth in JSON, Markdown, and SARIF output, while keeping default scans, MCP behavior, and existing direct baseline fingerprints unchanged.
- Add focused regressions for current analyzer/provider compatibility, child finding selection, input budgets and redirects, source-aware suppression, provenance, cache reuse, and fail-closed reports.

## Scope

The change remains limited to source types already supported by `InputHandler`, canonical trust-prefix handling, opt-in traversal, bounded child scanning, provenance, and fail-closed reporting. It does not add new hosts, a web crawler, MCP traversal, or default behavior changes when `--transitive` is absent.

## Verification

- [x] Focused CLI, transitive, input-budget/SSRF, LLM utility, report, completeness, and analyzer-base suites, `363 passed`
- [x] Focused suppression, deduplication, CLI, transitive, input-budget/SSRF, and report suites, `245 passed`
- [x] Focused semantic developer-intent, quality-policy, security-discovery, and MCP poisoning suites, `136 passed, 11 deselected`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] `git diff --check`
- [x] Invariant enumeration gate, `222 rows`, state domains checked
- [ ] GitHub CI, pending after push
