### PR TITLE
fix(analyzers): rely on runner for example filtering in E5 and TM4 (close executable bypass)

### DIFF
--- a/src/skillspector/nodes/analyzers/static_patterns_data_exfiltration.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_data_exfiltration.py
@@ -32,7 +32,6 @@ from .common import (
     get_context,
     get_context_from_lines,
     get_line_number,
-    is_code_example,
     resolve_call_name,
     resolve_dotted_name,
 )
@@ -358,13 +357,9 @@ def analyze(
                     matched_text=match.group(0)[:200],
                 )
             )
-    # E5: cloud-storage exfiltration. Filtered through is_code_example() because
-    # upload calls commonly appear in SKILL.md docs and examples.
+    # E5: cloud-storage exfiltration. Example filtering is delegated to the runner.
     for pattern, confidence in E5_PATTERNS:
         for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
-            context = ctx(match.start())
-            if is_code_example(context):
-                continue
             line_num = get_line_number(content, match.start())
             findings.append(
                 AnalyzerFinding(
@@ -374,7 +369,7 @@ def analyze(
                     location=loc(line_num),
                     confidence=confidence,
                     tags=tag,
-                    context=context,
+                    context=ctx(match.start()),
                     matched_text=match.group(0)[:200],
                 )
             )

--- a/src/skillspector/nodes/analyzers/static_patterns_tool_misuse.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_tool_misuse.py
@@ -32,7 +32,7 @@ from skillspector.models import AnalyzerFinding, Location, Severity
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 from . import static_runner
-from .common import get_context, get_line_number, is_code_example
+from .common import get_context, get_line_number
 from .pattern_defaults import PatternCategory
 
 logger = get_logger(__name__)
@@ -322,13 +322,9 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
                     matched_text=match.group(0)[:200],
                 )
             )
-    # TM4: privileged K8s workload. Filtered through is_code_example() because
-    # privileged/hostPath fields commonly appear in SKILL.md docs and examples.
+    # TM4: privileged K8s workload. Example filtering is delegated to the runner.
     for pattern, confidence in TM4_PATTERNS:
         for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
-            context_text = ctx(match.start())
-            if is_code_example(context_text):
-                continue
             line_num = get_line_number(content, match.start())
             findings.append(
                 AnalyzerFinding(
@@ -338,7 +334,7 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
                     location=loc(line_num),
                     confidence=confidence,
                     tags=tag,
-                    context=context_text,
+                    context=ctx(match.start()),
                     matched_text=match.group(0)[:200],
                 )
             )

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -417,6 +417,21 @@ class TestRunStaticPatternsDataExfiltration:
         findings = static_runner.run_static_patterns(state, [data_exfiltration_module])
         assert not any(f.rule_id == "E5" for f in findings)
 
+    def test_e5_example_marker_in_executable_still_fires(self):
+        """An example marker near an upload in an executable .py must NOT suppress E5.
+
+        Example filtering belongs to the runner, which only downweights (does not
+        skip) executables — so a nearby '# for example' cannot be used to evade E5.
+        """
+        state = {
+            "components": ["up.py"],
+            "file_cache": {
+                "up.py": "# for example\ns3.put_object(Bucket='x', Key='k', Body=d)",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [data_exfiltration_module])
+        assert any(f.rule_id == "E5" for f in findings)
+
     def test_eval_dataset_prose_is_not_scanned_for_static_patterns(self):
         """Eval datasets are test-case data, not installed skill code."""
         for dataset_path in ("evals/evals.json", "eval/dataset.yaml"):

--- a/tests/unit/test_patterns_new.py
+++ b/tests/unit/test_patterns_new.py
@@ -1316,9 +1316,13 @@ guidance = "Set the flag to --no-verify to skip deterministic result verificatio
         )
         assert not any(f.rule_id == "TM4" for f in tm_mod.analyze(content, "ds.yaml", "yaml"))
 
-    def test_tm4_documentation_example_excluded(self) -> None:
-        content = "For example, never set privileged: true in your manifests."
-        assert not any(f.rule_id == "TM4" for f in tm_mod.analyze(content, "README.md", "markdown"))
+    def test_tm4_example_marker_not_self_filtered(self) -> None:
+        """analyze() no longer self-filters on example markers — the shared runner
+        handles that (suppressing non-executable docs, only downweighting
+        executables). So a nearby '# for example' marker cannot bypass TM4; the
+        finding is still produced at the analyzer level."""
+        content = "# for example\nprivileged: true"
+        assert any(f.rule_id == "TM4" for f in tm_mod.analyze(content, "ds.yaml", "yaml"))
 
     def test_safe_content_produces_no_findings(self) -> None:
         findings = tm_mod.analyze(


### PR DESCRIPTION
## Summary

The SC7 review (#224) established that calling `is_code_example()` inside an analyzer with an unconditional `continue` lets a nearby example marker suppress findings in **executable** files — the shared runner already filters examples in non-executable docs and only *downweights* executables, so the analyzer-level call is redundant and opens an attacker-controlled bypass. **E5 (#218) and TM4 (#220), both merged, use the same pattern.** This applies the same fix.

## Changes

- `static_patterns_data_exfiltration.py` (E5): drop the `is_code_example` call and import; rely on the runner's file-type-aware handling.
- `static_patterns_tool_misuse.py` (TM4): same.
- Tests: TM4's analyze-level doc-exclusion test is replaced with an executable-evasion test (`# for example` next to `privileged: true` still fires); an equivalent E5 regression is added.

## Why this is safe

Detection is unchanged — the runner still suppresses non-executable docs and downweights executables. Only the bypass is closed: a `# for example` near `s3.put_object(...)` or `privileged: true` in a `.sh`/`.py` no longer evades E5/TM4. `anti_refusal` already uses a confidence penalty (not a skip), so it is intentionally left as-is.

## Testing

`make format` and `make lint` pass; the full suite reports 1256 passed, 0 failed. A re-scan confirms detection is preserved (E5 ×2, TM4 ×6 still fire on the same fixtures).

Follows up on the review in #224.
