### PR TITLE
(chore) pin dependencies for workflows and Docker base images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - id: filter
@@ -61,7 +61,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up uv
         # Pinned to a full commit SHA (third-party action); comment tracks the tag.
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -77,7 +77,7 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up uv
         # Pinned to a full commit SHA (third-party action); comment tracks the tag.
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -95,13 +95,13 @@ jobs:
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: docker version
       - run: docker info
       - run: docker build -t skillspector .
       - run: tests/docker/smoke.sh
       - if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docker-smoke-reports
           path: |
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm AS builder
+FROM python:3.12-slim-bookworm@sha256:8a7e7cc04fd3e2bd787f7f24e22d5d119aa590d429b50c95dfe12b3abe52f48b AS builder
 
 WORKDIR /app
 COPY pyproject.toml README.md ./
@@ -6,7 +6,7 @@ COPY src/ src/
 RUN python -m venv .venv
 RUN .venv/bin/pip install --no-cache-dir .
 
-FROM python:3.12-slim-bookworm
+FROM python:3.12-slim-bookworm@sha256:8a7e7cc04fd3e2bd787f7f24e22d5d119aa590d429b50c95dfe12b3abe52f48b
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y git ca-certificates \


### PR DESCRIPTION
Addressing two of the three issues from ossf/scorecard

Warn: GitHub-owned GitHubAction not pinned by hash: .github/workflows/ci.yml:45
Warn: GitHub-owned GitHubAction not pinned by hash: .github/workflows/ci.yml:71

Warn: containerImage not pinned by hash: Dockerfile:1
Warn: containerImage not pinned by hash: Dockerfile:9: pin your Docker image by updating python:3.12-slim-bookworm to python:3.12-slim-bookworm@sha256:8a7e7cc04fd3e2bd787f7f24e22d5d119aa590d429b50c95dfe12b3abe52f48b
Warn: pipCommand not pinned by hash: Dockerfile:7