### PR TITLE
fix(mcp): prove stdio initialize compatibility (#199)

### DIFF
--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -15,6 +15,9 @@
 
 """Tests for the MCP server wrapper (run_scan core + scan_skill tool)."""
 
+import asyncio
+import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -90,3 +93,25 @@ async def test_build_server_registers_scan_skill() -> None:
     server = mcp_server.build_server()
     tools = await server.list_tools()
     assert "scan_skill" in {tool.name for tool in tools}
+
+
+async def test_mcp_stdio_initialize_registers_scan_skill() -> None:
+    """The real stdio CLI must initialize and expose the scan_skill tool."""
+    pytest.importorskip("mcp")
+
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    repo_root = Path(__file__).resolve().parents[2]
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "skillspector.cli", "mcp"],
+        env={**os.environ, "PYTHONPATH": str(repo_root / "src")},
+    )
+
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await asyncio.wait_for(session.initialize(), timeout=15)
+            tools = await asyncio.wait_for(session.list_tools(), timeout=15)
+
+    assert "scan_skill" in {tool.name for tool in tools.tools}


### PR DESCRIPTION
## Summary

Add focused coverage for the MCP stdio initialize path before changing runtime behavior. The local SDK handshake passes on the head branch, so the honest outcome is a scoped harness plus a documented external boundary rather than a runtime fix claim.

Refs #199

## Root cause

`skillspector mcp` delegates stdio startup directly to FastMCP, and the repository has no focused initialize proof around that path. The earlier docs PR covered installing the MCP extra, but it did not establish that the stdio server responds to initialize in the reported environment.

## Diff Notes

- Add a bounded MCP SDK stdio initialize test or harness for the SkillSpector server.
- Keep the runtime surface unchanged because the harness passes locally.
- Keep Codex-client success as a separate externally owned claim unless tested with Codex.

## Scope

No MCP HTTP transport expansion, analyzer changes, graph changes, credential changes, or broad process-manager rewrite.

## Verification

- [x] `.\.venv\Scripts\python.exe -m pytest tests/unit/test_mcp_server.py -k "initialize"`
- [x] `.\.venv\Scripts\python.exe -m pytest tests/unit/test_mcp_server.py`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
