### PR TITLE
feat(provider): allow scoped LLM provider injection (#243)

### DIFF
--- a/src/skillspector/constants.py
+++ b/src/skillspector/constants.py
@@ -50,21 +50,28 @@ _MODEL_SLOTS: tuple[str, ...] = (
 )
 
 
-def _resolve_slot_model(slot: str) -> str:
+def _resolve_slot_model(slot: str, provider=None) -> str:
     """Resolve the model for *slot* with per-slot env var override support.
 
     Precedence: ``SKILLSPECTOR_MODEL_{SLOT}`` env var > provider
     ``resolve_model(slot)`` (which itself runs ``SKILLSPECTOR_MODEL`` env >
     provider slot default > provider ``DEFAULT_MODEL``).
     """
+    provider = provider or get_metadata_provider()
     env_key = f"SKILLSPECTOR_MODEL_{slot.upper()}"
     env_val = os.environ.get(env_key, "").strip()
     if env_val:
         return env_val
-    return _provider.resolve_model(slot)
+    return provider.resolve_model(slot)
 
 
-MODEL_CONFIG: dict[str, str] = {slot: _resolve_slot_model(slot) for slot in _MODEL_SLOTS}
+def build_model_config() -> dict[str, str]:
+    """Resolve the model map for the currently active provider."""
+    provider = get_metadata_provider()
+    return {slot: _resolve_slot_model(slot, provider) for slot in _MODEL_SLOTS}
+
+
+MODEL_CONFIG: dict[str, str] = {slot: _resolve_slot_model(slot, _provider) for slot in _MODEL_SLOTS}
 
 
 def _validate_model_config() -> None:

--- a/src/skillspector/llm_utils.py
+++ b/src/skillspector/llm_utils.py
@@ -46,6 +46,7 @@ from skillspector.providers import (
     get_active_provider,
     get_metadata_provider,
     has_cli_capability,
+    has_provider_binding,
     raise_no_llm_api_key_configured,
     resolve_chat_model_credentials,
     resolve_provider_credentials,
@@ -71,6 +72,9 @@ def _resolve_llm_credentials() -> tuple[str, str | None]:
 
 def _resolve_default_chat_model() -> str:
     """Return the default chat model for the endpoint that will be used."""
+    if has_provider_binding():
+        return get_metadata_provider().resolve_model()
+
     if resolve_provider_credentials() is not None:
         return get_metadata_provider().resolve_model()
 
@@ -84,13 +88,26 @@ def _resolve_default_chat_model() -> str:
 def is_llm_available() -> tuple[bool, str | None]:
     """Return ``(available, error_message)`` describing LLM availability.
 
-    For CLI providers (``claude_cli``, ``codex_cli``, ``gemini_cli``) the check
-    delegates to the provider's ``is_available()`` method (binary on PATH +
-    auth).  For HTTP providers, it falls back to credential resolution.
+    CLI providers (``claude_cli``, ``codex_cli``, ``gemini_cli``) are checked
+    through their ``is_available()`` method first.  Other providers probe the
+    same native chat-model path used by :func:`get_chat_model`; unbound HTTP
+    providers keep the credential-resolution and OpenAI fallback path.
     """
     provider = get_active_provider()
     if has_cli_capability(provider):
         return provider.is_available()  # type: ignore[attr-defined]
+
+    if has_provider_binding():
+        try:
+            model = provider.resolve_model()
+            create_chat_model(
+                model=model,
+                max_tokens=get_max_output_tokens(model),
+                timeout=120,
+            )
+        except ValueError as exc:
+            return False, str(exc)
+        return True, None
     try:
         _resolve_llm_credentials()
     except ValueError as exc:

--- a/src/skillspector/mcp_server.py
+++ b/src/skillspector/mcp_server.py
@@ -32,8 +32,8 @@ from typing import TYPE_CHECKING, Any
 
 from skillspector import __version__
 from skillspector.graph import graph
+from skillspector.llm_utils import is_llm_available
 from skillspector.logging_config import get_logger
-from skillspector.providers import resolve_provider_credentials
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -58,8 +58,9 @@ async def run_scan(
     Args:
         target: Git URL, file URL, ``.zip``, ``.md`` file, or local directory.
         use_llm: Whether to request the optional LLM semantic pass on top of
-            static analysis. Honoured only when provider credentials resolve;
-            the returned payload reports what actually happened.
+            static analysis. Honoured only when the active provider can
+            actually build or run the LLM pass; the returned payload reports
+            what actually happened.
         output_format: Format of the embedded ``report`` string. One of
             :data:`VALID_FORMATS`.
         yara_rules_dir: Optional directory of additional YARA rules.
@@ -74,7 +75,7 @@ async def run_scan(
     if output_format not in VALID_FORMATS:
         raise ValueError(f"output_format must be one of {VALID_FORMATS}, got {output_format!r}")
 
-    llm_available = resolve_provider_credentials() is not None
+    llm_available, _ = is_llm_available()
     llm_used = use_llm and llm_available
 
     state: dict[str, Any] = {

--- a/src/skillspector/model_info.py
+++ b/src/skillspector/model_info.py
@@ -22,8 +22,6 @@ import from.  Test fixtures patch :func:`_resolve_context_length` here.
 
 from __future__ import annotations
 
-import functools
-
 from skillspector.constants import DEFAULT_CONTEXT_LENGTH, MAX_INPUT_TOKENS_PCT
 from skillspector.logging_config import get_logger
 from skillspector.providers import get_metadata_provider
@@ -31,13 +29,12 @@ from skillspector.providers import get_metadata_provider
 logger = get_logger(__name__)
 
 
-@functools.cache
 def _resolve_context_length(model_label: str) -> int:
     """Return the context window size for *model_label*.
 
     Delegates to the configured provider chain; falls back to
     :data:`DEFAULT_CONTEXT_LENGTH` with a warning when no provider knows
-    about the model.  Cached per model label for the lifetime of the process.
+    about the model.
     """
     ctx = get_metadata_provider().get_context_length(model_label)
     if ctx is not None:

--- a/src/skillspector/nodes/build_context.py
+++ b/src/skillspector/nodes/build_context.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 import yaml
 
-from skillspector.constants import MODEL_CONFIG
+from skillspector.constants import build_model_config
 from skillspector.logging_config import get_logger
 from skillspector.state import SkillspectorState
 
@@ -246,7 +246,7 @@ def build_context(state: SkillspectorState) -> dict[str, object]:
         "ast_cache": {},
         "manifest": manifest,
         "previous_manifest": None,
-        "model_config": MODEL_CONFIG,
+        "model_config": build_model_config(),
         "component_metadata": component_metadata,
         "has_executable_scripts": has_executable_scripts,
     }

--- a/src/skillspector/providers/__init__.py
+++ b/src/skillspector/providers/__init__.py
@@ -46,6 +46,7 @@ instead of the ``ChatOpenAI`` HTTP transport.
 from __future__ import annotations
 
 import os
+from contextvars import ContextVar, Token
 from typing import NoReturn
 
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -67,14 +68,38 @@ NO_LLM_API_KEY_MESSAGE = (
     "Use --no-llm to skip LLM analysis and run static checks only."
 )
 
+_INJECTED_PROVIDER: ContextVar[LLMProvider | None] = ContextVar(
+    "skillspector_injected_provider",
+    default=None,
+)
+
 
 def raise_no_llm_api_key_configured() -> NoReturn:
     """Raise the shared no-LLM-credentials error."""
     raise ValueError(NO_LLM_API_KEY_MESSAGE)
 
 
+def use_provider(provider: LLMProvider) -> Token[LLMProvider | None]:
+    """Bind *provider* for the current context."""
+    return _INJECTED_PROVIDER.set(provider)
+
+
+def reset_provider(token: Token[LLMProvider | None]) -> None:
+    """Restore the provider binding represented by *token*."""
+    _INJECTED_PROVIDER.reset(token)
+
+
+def has_provider_binding() -> bool:
+    """Return whether the current context has an injected provider."""
+    return _INJECTED_PROVIDER.get() is not None
+
+
 def _select_active_provider() -> LLMProvider:
     """Construct the active provider based on ``SKILLSPECTOR_PROVIDER``."""
+    injected_provider = _INJECTED_PROVIDER.get()
+    if injected_provider is not None:
+        return injected_provider
+
     name = os.environ.get("SKILLSPECTOR_PROVIDER", "").strip().lower()
 
     if name == "openai":
@@ -166,6 +191,9 @@ def resolve_chat_model_credentials() -> tuple[str, str | None] | None:
     if creds is not None:
         return creds
 
+    if has_provider_binding():
+        return None
+
     return _openai_fallback_provider().resolve_credentials()
 
 
@@ -194,6 +222,9 @@ def create_chat_model(
         if llm is not None:
             return llm
 
+        if has_provider_binding():
+            raise_no_llm_api_key_configured()
+
         from .openai import OpenAIProvider
 
         if not isinstance(provider, OpenAIProvider):
@@ -219,7 +250,10 @@ __all__ = [
     "get_active_provider",
     "get_metadata_provider",
     "has_cli_capability",
+    "has_provider_binding",
+    "reset_provider",
     "raise_no_llm_api_key_configured",
     "resolve_chat_model_credentials",
     "resolve_provider_credentials",
+    "use_provider",
 ]

--- a/tests/nodes/test_build_context.py
+++ b/tests/nodes/test_build_context.py
@@ -26,6 +26,7 @@ import pytest
 
 from skillspector.constants import MODEL_CONFIG
 from skillspector.nodes.build_context import build_context
+from skillspector.providers import reset_provider, use_provider
 from skillspector.state import SkillspectorState
 
 
@@ -129,6 +130,36 @@ def test_build_context_empty_directory_is_valid_empty_scan(tmp_path: Path) -> No
     assert result["file_cache"] == {}
     assert result["manifest"] == {}
     assert result["model_config"] == MODEL_CONFIG
+
+
+def test_build_context_model_config_uses_bound_provider(tmp_path: Path) -> None:
+    class _BoundProvider:
+        DEFAULT_MODEL = "bound-default"
+        SLOT_DEFAULTS = {"meta_analyzer": "bound-meta"}
+
+        def get_context_length(self, model: str) -> int | None:
+            return 4096
+
+        def get_max_output_tokens(self, model: str) -> int | None:
+            return 128
+
+        def resolve_model(self, slot: str = "default") -> str:
+            return self.SLOT_DEFAULTS.get(slot, self.DEFAULT_MODEL)
+
+        def resolve_credentials(self) -> tuple[str, str | None] | None:
+            return None
+
+        def create_chat_model(self, model: str, *, max_tokens: int, timeout: float | None = 120):
+            return object()
+
+    token = use_provider(_BoundProvider())
+    try:
+        result = build_context({"skill_path": str(tmp_path)})
+    finally:
+        reset_provider(token)
+
+    assert result["model_config"]["default"] == "bound-default"
+    assert result["model_config"]["meta_analyzer"] == "bound-meta"
 
 
 def test_build_context_skips_skip_dirs(tmp_path: Path) -> None:

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -39,7 +39,13 @@ from skillspector.llm_utils import (
     get_chat_model,
     is_llm_available,
 )
-from skillspector.providers import NO_LLM_API_KEY_MESSAGE, resolve_provider_credentials
+from skillspector.providers import (
+    NO_LLM_API_KEY_MESSAGE,
+    reset_provider,
+    resolve_chat_model_credentials,
+    resolve_provider_credentials,
+    use_provider,
+)
 from skillspector.providers.nv_build import NvBuildProvider
 from skillspector.providers.openai import OpenAIProvider
 
@@ -120,6 +126,84 @@ class TestCredentialResolution:
         assert isinstance(llm, ChatAnthropic)
         assert llm.model == "claude-opus-4-6"
 
+    def test_injected_provider_without_credentials_builds_native_chat_model(self) -> None:
+        chat_model = object()
+
+        class _InjectedProvider:
+            DEFAULT_MODEL = "injected-default"
+            SLOT_DEFAULTS = {"meta_analyzer": "injected-default"}
+
+            def get_context_length(self, model: str) -> int | None:
+                return 4096 if model == "injected-default" else None
+
+            def get_max_output_tokens(self, model: str) -> int | None:
+                return 128 if model == "injected-default" else None
+
+            def resolve_model(self, slot: str = "default") -> str:
+                return "injected-default"
+
+            def resolve_credentials(self) -> tuple[str, str | None] | None:
+                return None
+
+            def create_chat_model(
+                self,
+                model: str,
+                *,
+                max_tokens: int,
+                timeout: float | None = 120,
+            ) -> object:
+                assert model == "injected-default"
+                assert max_tokens == 128
+                assert timeout == 120
+                return chat_model
+
+        token = use_provider(_InjectedProvider())
+        try:
+            assert is_llm_available() == (True, None)
+            assert get_chat_model() is chat_model
+        finally:
+            reset_provider(token)
+
+    def test_injected_provider_without_native_model_does_not_fall_back_to_openai(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fallback")
+
+        class _InjectedProvider:
+            DEFAULT_MODEL = "injected-default"
+            SLOT_DEFAULTS = {}
+
+            def get_context_length(self, model: str) -> int | None:
+                return 4096
+
+            def get_max_output_tokens(self, model: str) -> int | None:
+                return 128
+
+            def resolve_model(self, slot: str = "default") -> str:
+                return "injected-default"
+
+            def resolve_credentials(self) -> tuple[str, str | None] | None:
+                return None
+
+            def create_chat_model(
+                self,
+                model: str,
+                *,
+                max_tokens: int,
+                timeout: float | None = 120,
+            ) -> object | None:
+                return None
+
+        token = use_provider(_InjectedProvider())
+        try:
+            assert resolve_chat_model_credentials() is None
+            assert is_llm_available() == (False, NO_LLM_API_KEY_MESSAGE)
+            with pytest.raises(ValueError) as exc_info:
+                get_chat_model()
+            assert str(exc_info.value) == NO_LLM_API_KEY_MESSAGE
+        finally:
+            reset_provider(token)
+
 
 class TestFetchModelTokenLimits:
     def test_returns_input_and_output_token_pair(self) -> None:
@@ -198,6 +282,50 @@ class TestIsLlmAvailable:
             ok, err = is_llm_available()
         assert ok is False
         assert "not found" in (err or "").lower()
+
+    def test_bound_cli_provider_uses_cli_availability(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Bound CLI providers should use is_available, not the HTTP probe path."""
+
+        class _InjectedCLIProvider:
+            DEFAULT_MODEL = "cli-default"
+            SLOT_DEFAULTS = {"meta_analyzer": "cli-default"}
+
+            def get_context_length(self, model: str) -> int | None:
+                return 4096
+
+            def get_max_output_tokens(self, model: str) -> int | None:
+                return 128
+
+            def resolve_model(self, slot: str = "default") -> str:
+                return "cli-default"
+
+            def resolve_credentials(self) -> tuple[str, str | None] | None:
+                return None
+
+            def complete(
+                self,
+                prompt: str,
+                *,
+                model: str,
+                max_output_tokens: int,
+            ) -> str:
+                return "ok"
+
+        provider = _InjectedCLIProvider()
+        provider.is_available = MagicMock(return_value=(False, "binary not found on PATH"))
+        token = use_provider(provider)
+        try:
+            with patch("skillspector.llm_utils.create_chat_model") as mock_create_chat_model:
+                ok, err = is_llm_available()
+        finally:
+            reset_provider(token)
+
+        assert ok is False
+        assert err == "binary not found on PATH"
+        provider.is_available.assert_called_once_with()
+        mock_create_chat_model.assert_not_called()
 
 
 class TestChatCompletionCLIDispatch:

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -21,6 +21,7 @@ import pytest
 
 from skillspector import mcp_server
 from skillspector.mcp_server import run_scan
+from skillspector.providers import reset_provider, use_provider
 
 
 def _write_skill(tmp_path: Path, body: str = "# Safe skill") -> Path:
@@ -32,8 +33,7 @@ async def test_run_scan_returns_structured_verdict(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """run_scan returns a JSON-serialisable verdict with the expected shape."""
-    # No credentials: the LLM pass cannot run regardless of what is requested.
-    monkeypatch.setattr(mcp_server, "resolve_provider_credentials", lambda: None)
+    monkeypatch.setattr(mcp_server, "is_llm_available", lambda: (False, "no llm"))
     _write_skill(tmp_path)
 
     result = await run_scan(str(tmp_path), use_llm=True, output_format="json")
@@ -51,7 +51,7 @@ async def test_run_scan_llm_accounting_is_honest_without_credentials(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Requesting the LLM with no credentials must report it as not used."""
-    monkeypatch.setattr(mcp_server, "resolve_provider_credentials", lambda: None)
+    monkeypatch.setattr(mcp_server, "is_llm_available", lambda: (False, "no llm"))
     _write_skill(tmp_path)
 
     result = await run_scan(str(tmp_path), use_llm=True, output_format="json")
@@ -66,13 +66,125 @@ async def test_run_scan_reports_llm_available_with_credentials(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Credentials present but use_llm=False: available, but honestly not used."""
-    monkeypatch.setattr(mcp_server, "resolve_provider_credentials", lambda: ("key", None))
+    monkeypatch.setattr(mcp_server, "is_llm_available", lambda: (True, None))
     _write_skill(tmp_path)
 
     result = await run_scan(str(tmp_path), use_llm=False, output_format="json")
 
     assert result["llm_available"] is True
     assert result["llm_requested"] is False
+    assert result["llm_used"] is False
+    assert result["scan_mode"] == "static-only"
+
+
+async def test_run_scan_uses_bound_provider_without_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An injected provider can own the LLM client without exposing raw credentials."""
+
+    class _InjectedProvider:
+        DEFAULT_MODEL = "injected-default"
+        SLOT_DEFAULTS = {"meta_analyzer": "injected-default"}
+
+        def get_context_length(self, model: str) -> int | None:
+            return 4096 if model == "injected-default" else None
+
+        def get_max_output_tokens(self, model: str) -> int | None:
+            return 128 if model == "injected-default" else None
+
+        def resolve_model(self, slot: str = "default") -> str:
+            return "injected-default"
+
+        def resolve_credentials(self) -> tuple[str, str | None] | None:
+            return None
+
+        def create_chat_model(
+            self,
+            model: str,
+            *,
+            max_tokens: int,
+            timeout: float | None = 120,
+        ) -> object:
+            return object()
+
+    class _Graph:
+        async def ainvoke(self, state, config):
+            assert state["use_llm"] is True
+            return {
+                "filtered_findings": [],
+                "risk_score": 0,
+                "risk_severity": "LOW",
+                "risk_recommendation": "OK",
+                "report_body": "report",
+            }
+
+    token = use_provider(_InjectedProvider())
+    monkeypatch.setattr(mcp_server, "graph", _Graph())
+    _write_skill(tmp_path)
+
+    try:
+        result = await run_scan(str(tmp_path), use_llm=True, output_format="json")
+    finally:
+        reset_provider(token)
+
+    assert result["llm_available"] is True
+    assert result["llm_requested"] is True
+    assert result["llm_used"] is True
+    assert result["scan_mode"] == "static+llm"
+
+
+async def test_run_scan_disables_llm_for_unavailable_bound_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bound provider that cannot build a chat model must stay static-only."""
+
+    class _UnavailableInjectedProvider:
+        DEFAULT_MODEL = "injected-default"
+        SLOT_DEFAULTS = {"meta_analyzer": "injected-default"}
+
+        def get_context_length(self, model: str) -> int | None:
+            return 4096 if model == "injected-default" else None
+
+        def get_max_output_tokens(self, model: str) -> int | None:
+            return 128 if model == "injected-default" else None
+
+        def resolve_model(self, slot: str = "default") -> str:
+            return "injected-default"
+
+        def resolve_credentials(self) -> tuple[str, str | None] | None:
+            return None
+
+        def create_chat_model(
+            self,
+            model: str,
+            *,
+            max_tokens: int,
+            timeout: float | None = 120,
+        ) -> object | None:
+            return None
+
+    class _Graph:
+        async def ainvoke(self, state, config):
+            assert state["use_llm"] is False
+            return {
+                "filtered_findings": [],
+                "risk_score": 0,
+                "risk_severity": "LOW",
+                "risk_recommendation": "OK",
+                "report_body": "report",
+            }
+
+    token = use_provider(_UnavailableInjectedProvider())
+    monkeypatch.setattr(mcp_server, "graph", _Graph())
+    _write_skill(tmp_path)
+
+    try:
+        result = await run_scan(str(tmp_path), use_llm=True, output_format="json")
+    finally:
+        reset_provider(token)
+
+    assert result["llm_available"] is False
+    assert result["llm_requested"] is True
     assert result["llm_used"] is False
     assert result["scan_mode"] == "static-only"
 

--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -24,6 +24,7 @@ import pytest
 import yaml
 
 from skillspector.constants import DEFAULT_CONTEXT_LENGTH, MAX_INPUT_TOKENS_PCT
+from skillspector.providers import reset_provider, use_provider
 
 MODULE = "skillspector.model_info"
 NV_PROVIDER_MODULE = "skillspector.providers.nv_inference.provider"
@@ -42,11 +43,9 @@ nv_provider_required = pytest.mark.skipif(
 
 
 def _clear_caches() -> None:
-    """Clear all functools.cache caches across model_info and the providers."""
-    from skillspector import model_info
+    """Clear the provider registry cache used by model-info lookups."""
     from skillspector.providers import registry
 
-    model_info._resolve_context_length.cache_clear()
     registry._load_registry.cache_clear()
 
 
@@ -80,7 +79,6 @@ def _get_real_functions():
     from skillspector.providers import registry
 
     importlib.reload(mod)
-    mod._resolve_context_length.cache_clear()
     registry._load_registry.cache_clear()
     return mod
 
@@ -355,3 +353,44 @@ class TestPublicApi:
             result = mod.get_max_output_tokens("bare/model")
             expected = int(200_000 * (1 - MAX_INPUT_TOKENS_PCT))
             assert result == expected
+
+    def test_token_limits_follow_current_bound_provider_for_same_model_label(self) -> None:
+        """Same labels must resolve against the provider bound in this context."""
+
+        class _BoundProvider:
+            DEFAULT_MODEL = "shared/model"
+            SLOT_DEFAULTS = {"meta_analyzer": "shared/model"}
+
+            def __init__(self, context_length: int, max_output_tokens: int) -> None:
+                self._context_length = context_length
+                self._max_output_tokens = max_output_tokens
+
+            def get_context_length(self, model: str) -> int | None:
+                return self._context_length if model == "shared/model" else None
+
+            def get_max_output_tokens(self, model: str) -> int | None:
+                return self._max_output_tokens if model == "shared/model" else None
+
+            def resolve_model(self, slot: str = "default") -> str:
+                return "shared/model"
+
+            def resolve_credentials(self) -> tuple[str, str | None] | None:
+                return None
+
+        mod = _get_real_functions()
+        first = _BoundProvider(context_length=100, max_output_tokens=10)
+        second = _BoundProvider(context_length=200, max_output_tokens=20)
+
+        first_token = use_provider(first)
+        try:
+            assert mod.get_max_input_tokens("shared/model") == 75
+            assert mod.get_max_output_tokens("shared/model") == 10
+        finally:
+            reset_provider(first_token)
+
+        second_token = use_provider(second)
+        try:
+            assert mod.get_max_input_tokens("shared/model") == 150
+            assert mod.get_max_output_tokens("shared/model") == 20
+        finally:
+            reset_provider(second_token)

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -28,14 +28,19 @@ import pytest
 from langchain_anthropic import ChatAnthropic
 from langchain_openai import ChatOpenAI
 
+import skillspector.providers as providers_module
 from skillspector.providers import (
     NO_LLM_API_KEY_MESSAGE,
     create_chat_model,
+    get_active_provider,
     get_metadata_provider,
     has_cli_capability,
+    has_provider_binding,
     registry,
+    reset_provider,
     resolve_chat_model_credentials,
     resolve_provider_credentials,
+    use_provider,
 )
 from skillspector.providers.anthropic import AnthropicProvider
 from skillspector.providers.antigravity_cli import AntigravityCLIProvider
@@ -62,6 +67,44 @@ nv_inference_required = pytest.mark.skipif(
 )
 
 
+class FakeProvider:
+    DEFAULT_MODEL = "fake-default"
+    SLOT_DEFAULTS = {"meta_analyzer": "fake-meta"}
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        credentials: tuple[str, str | None] | None = None,
+        chat_model: object | None = None,
+    ) -> None:
+        self.name = name
+        self._credentials = credentials
+        self.chat_model = chat_model if chat_model is not None else object()
+
+    def get_context_length(self, model: str) -> int | None:
+        return 111 if model == self.name else None
+
+    def get_max_output_tokens(self, model: str) -> int | None:
+        return 222 if model == self.name else None
+
+    def resolve_model(self, slot: str = "default") -> str:
+        return f"{self.name}:{slot}"
+
+    def resolve_credentials(self) -> tuple[str, str | None] | None:
+        return self._credentials
+
+    def create_chat_model(
+        self,
+        model: str,
+        *,
+        max_tokens: int,
+        timeout: float | None = 120,
+    ) -> object:
+        self.last_chat_model_request = (model, max_tokens, timeout)
+        return self.chat_model
+
+
 @pytest.fixture(autouse=True)
 def _clean_provider_env(monkeypatch: pytest.MonkeyPatch):
     """Isolate provider-related env vars and the YAML cache for each test."""
@@ -74,8 +117,10 @@ def _clean_provider_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("SKILLSPECTOR_MODEL", raising=False)
     monkeypatch.delenv("SKILLSPECTOR_MODEL_REGISTRY", raising=False)
     monkeypatch.delenv("SKILLSPECTOR_PROVIDER", raising=False)
+    providers_module._INJECTED_PROVIDER.set(None)
     registry._load.cache_clear()
     yield
+    providers_module._INJECTED_PROVIDER.set(None)
     registry._load.cache_clear()
 
 
@@ -427,6 +472,74 @@ class TestProviderSelection:
         provider = get_metadata_provider()
         assert isinstance(provider, AntigravityCLIProvider)
         assert resolve_provider_credentials() is None
+
+    def test_injected_provider_routes_metadata_and_active_helpers(self) -> None:
+        provider = FakeProvider("injected")
+        token = use_provider(provider)
+        try:
+            assert has_provider_binding() is True
+            assert get_metadata_provider() is provider
+            assert get_active_provider() is provider
+        finally:
+            reset_provider(token)
+        assert has_provider_binding() is False
+
+    def test_injected_provider_routes_credentials_and_chat_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+        chat_model = object()
+        provider = FakeProvider(
+            "injected",
+            credentials=("injected-key", "injected-base-url"),
+            chat_model=chat_model,
+        )
+        token = use_provider(provider)
+        try:
+            assert resolve_provider_credentials() == ("injected-key", "injected-base-url")
+            assert create_chat_model("model-x", max_tokens=42) is chat_model
+        finally:
+            reset_provider(token)
+
+    def test_provider_token_reset_restores_env_dispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+        provider = FakeProvider("injected", credentials=("injected-key", None))
+        token = use_provider(provider)
+        reset_provider(token)
+        assert isinstance(get_metadata_provider(), OpenAIProvider)
+        assert resolve_provider_credentials() == ("sk-x", None)
+
+    def test_provider_token_nested_restores_previous_binding(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+        outer_provider = FakeProvider(
+            "outer",
+            credentials=("outer-key", "outer-base-url"),
+        )
+        inner_provider = FakeProvider(
+            "inner",
+            credentials=("inner-key", "inner-base-url"),
+        )
+        outer_token = use_provider(outer_provider)
+        try:
+            inner_token = use_provider(inner_provider)
+            try:
+                assert get_metadata_provider() is inner_provider
+                assert resolve_provider_credentials() == ("inner-key", "inner-base-url")
+            finally:
+                reset_provider(inner_token)
+            assert get_metadata_provider() is outer_provider
+            assert resolve_provider_credentials() == ("outer-key", "outer-base-url")
+        finally:
+            reset_provider(outer_token)
+        assert isinstance(get_metadata_provider(), OpenAIProvider)
+        assert resolve_provider_credentials() == ("sk-x", None)
 
 
 class TestAntigravityCLIProvider:


### PR DESCRIPTION
## Summary

Embedding applications can now bind a governed in-process LLM provider for the current scan context. That lets hosts reuse their existing completion API without exporting raw keys, invoking an agent CLI, or monkeypatching SkillSpector internals.

Closes #243

## Root cause

Provider selection lived entirely behind `SKILLSPECTOR_PROVIDER` and the built-in fallback chain. Every public helper routed through `_select_active_provider()`, but that selector had no scoped override for a provider object that the embedding application already owns.

The first implementation also left three provider-context edges open: bound HTTP providers could be treated as available even when their native chat-model construction failed, bound CLI providers could be sent through the HTTP provider path, and model context length was cached only by label even though the same label can resolve differently under different providers.

## Diff Notes

- Add a `ContextVar`-backed provider binding API in `skillspector.providers`.
- Keep the existing env/default provider dispatch when no provider is bound.
- Route LLM availability through the active provider path, including CLI-capable providers, bound HTTP providers with native chat-model probes, and the existing unbound fallback.
- Keep MCP scan accounting honest by using the same availability result that the graph will use for provider selection.
- Resolve model context length from the current provider context at call time rather than caching only by model label.
- Cover metadata, active-provider, credential, chat-model, reset, nested-token, availability, MCP accounting, CLI binding, unavailable bound providers, and provider-specific context length behavior in focused tests.

## Scope

This does not add a new provider family, credential store, CLI transport, or graph-level policy. The hook stays in the provider adapter layer, and MCP scan accounting only observes whether a provider is bound for the current context.

## Attribution

The upstream issue proposed the `ContextVar` binding shape; this PR implements that design in the existing provider selector.

## Verification

- [x] `pytest tests/unit/test_llm_utils.py tests/unit/test_mcp_server.py tests/unit/test_model_info.py tests/unit/test_providers.py` - pass
- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`
- [x] Invariant enumeration gate - pass, `24 rows`, state domains checked
- [x] Local adversarial review - no findings
- [ ] CI `Lint & Test (Python 3.12)`, `Lint & Test (Python 3.13)`, and `DCO Check` - pending maintainer approval and rerun after push
