### PR TITLE
Sync OSS release snapshot (v2.3.11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skillspector"
-version = "2.3.9"
+version = "2.3.11"
 description = "SkillSpector: Security scanner for AI agent skills (Claude Code, Cursor, and similar). Scans skills for vulnerabilities, malicious patterns, and security risks before installation. Supports Git repos, URLs, zips, and local directories; runs static pattern checks and optional LLM semantic analysis; outputs terminal, JSON, and Markdown reports with risk scoring."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2660,7 +2660,7 @@ wheels = [
 
 [[package]]
 name = "skillspector"
-version = "2.3.9"
+version = "2.3.11"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

- Refresh the public SkillSpector snapshot from internal OSS branch `release/oss-2026-07-06`.
- Advance the package version from `2.3.9` to `2.3.11` in `pyproject.toml` and `uv.lock`.
- Preserve all current public workflows and repository policy files; the merged feature content already matches the internal OSS snapshot.

## Source

- Internal OSS branch: `release/oss-2026-07-06`
- Internal OSS commit: `b86ae09dac661abef3a0c87258e7ec7f669f5f52`
- Snapshot method: `scripts/create-oss-release.sh` followed by `git archive`

## Diff Notes

- `pyproject.toml`: package version `2.3.9` → `2.3.11`
- `uv.lock`: editable package version `2.3.9` → `2.3.11`
- No public-only files or `.github/` automation are removed.

## Verification

- `uv run --all-extras ./scripts/create-oss-release.sh release/oss-2026-07-06` — 1,256 passed, 12 skipped, 34 deselected, 6 xfailed.
- `uv lock --check` — passed.
- `git diff --check origin/main` — passed for the public two-file diff.
