### PR TITLE
docs: correct MCP fixture expectations

### DIFF
--- a/docs/B.3.1-mcp-least-privilege.md
+++ b/docs/B.3.1-mcp-least-privilege.md
@@ -223,7 +223,7 @@ The rules are designed to avoid redundant or contradictory findings:
 | Fixture directory                 | Expected findings | Purpose                          |
 |-----------------------------------|-------------------|----------------------------------|
 | `mcp_clean_skill/`               | None              | Negative test -- all caps declared |
-| `mcp_underdeclared_skill/`        | LP1, LP3          | Missing permissions + undeclared caps |
+| `mcp_underdeclared_skill/`        | LP3               | Missing permissions + detected caps |
 | `mcp_overprivileged_skill/`      | LP2, LP4          | Wildcard + overdeclared permissions |
 
 ---


### PR DESCRIPTION
## Problem

The B.3.1 MCP least-privilege docs list `mcp_underdeclared_skill/` as expecting both `LP1` and `LP3`, but the rule interaction table, implementation, and regression test all treat a missing permissions declaration as `LP3` only.

## Fix

Update the fixture expectations table so `mcp_underdeclared_skill/` expects `LP3` and describes the case as missing permissions plus detected capabilities.

## Test

- `git diff --check`
- `./.venv/bin/pytest tests/test_mcp_least_privilege.py::TestLP1UnderdeclaredCapability::test_underdeclared_detected -q`

## Risk

Low. This is a docs-only correction and does not change analyzer behavior.