### PR TITLE
Sync OSS release snapshot (v2.3.12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,38 +30,84 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
-  lint-and-test:
-    name: Lint & Test (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
-    # Windows is excluded: the test suite has known path-separator failures
-    # in build_context that are out of scope for this workflow.
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+env:
+  UV_VERSION: "0.10.x"
+  PYTHON_VERSION: "3.12"
+  UV_CACHE_DIR: .uv-cache
+  UV_LINK_MODE: copy
 
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+            .dockerignore .github/workflows/ci.yml .gitlab-ci.yml Dockerfile \
+            Makefile pyproject.toml uv.lock src tests/docker tests/fixtures/safe_skill; then
+            echo "docker=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "docker=true" >> "$GITHUB_OUTPUT"
+          fi
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - name: Set up uv
         # Pinned to a full commit SHA (third-party action); comment tracks the tag.
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
+          version: ${{ env.UV_VERSION }}
           enable-cache: true
-          python-version: ${{ matrix.python-version }}
+          cache-dependency-glob: uv.lock
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: make install-dev
+      - run: uv run make lint
+      - run: uv run make format-check
 
-      - name: Install dependencies
-        run: uv sync --all-extras
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up uv
+        # Pinned to a full commit SHA (third-party action); comment tracks the tag.
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: make install-dev
+      - run: uv run skillspector --version
+      - run: uv run make test-ci
 
-      - name: Lint with ruff
-        run: uv run ruff check src/ tests/
-
-      - name: Check formatting with ruff
-        run: uv run ruff format --check src/ tests/
-
-      - name: Run unit tests with coverage
-        run: uv run pytest -m "not integration" --cov=src/skillspector --cov-report=term-missing
+  docker-smoke:
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker version
+      - run: docker info
+      - run: docker build -t skillspector .
+      - run: tests/docker/smoke.sh
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-smoke-reports
+          path: |
+            .skillspector-docker-smoke.json
+            .skillspector-docker-github-smoke.json
+          if-no-files-found: ignore
 
   dco:
     name: DCO Check

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Scan entire directories of skills in parallel from `contrib/batch_scan/`:
 
 ```bash
 python -m contrib.batch_scan.batch_scan ./my-skills/ --no-llm
-python -m contrib.batch_scan.batch_scan ./my-skills/ --workers 20 -f json -o report.json 
+python -m contrib.batch_scan.batch_scan ./my-skills/ --workers 20 -f json -o report.json
 python -m contrib.batch_scan.batch_scan ./tests/fixtures/ -f terminal --workers 20
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skillspector"
-version = "2.3.11"
+version = "2.3.12"
 description = "SkillSpector: Security scanner for AI agent skills (Claude Code, Cursor, and similar). Scans skills for vulnerabilities, malicious patterns, and security risks before installation. Supports Git repos, URLs, zips, and local directories; runs static pattern checks and optional LLM semantic analysis; outputs terminal, JSON, and Markdown reports with risk scoring."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2660,7 +2660,7 @@ wheels = [
 
 [[package]]
 name = "skillspector"
-version = "2.3.11"
+version = "2.3.12"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

- Refresh public SkillSpector from the internal OSS release snapshot.
- Source branch: `release/oss-2026-07-13`
- Source commit: `5c6e07548aef93705ae5c87924751d392cb0ce8e`
- Internal release: `2.3.12` at `d25c5894ea68b71ae679c9c4c088996edfcec17c`

## Diff Notes

- Align GitHub CI with deterministic lint, unit, and Docker smoke checks.
- Publish the `2.3.12` package metadata and `uv.lock` entry.
- Carry forward the batch-scan README command whitespace cleanup.
- No files are deleted from the public repository.

## Verification

- `make release USER=keshavp@nvidia.com VERSION=patch`
- `./scripts/create-oss-release.sh release/oss-2026-07-13` (includes `make test-unit`: 1269 passed, 34 deselected, 6 xfailed)
- `git diff --check origin/main`
