### PR TITLE
fix(nv_build): cover reported model metadata

### DIFF
--- a/src/skillspector/providers/nv_build/model_registry.yaml
+++ b/src/skillspector/providers/nv_build/model_registry.yaml
@@ -15,6 +15,15 @@
 
 models:
   # NVIDIA-curated NIMs on build.nvidia.com.
+  "z-ai/glm-5.2":
+    context_length: 1000000
+
+  "z-ai/glm-5.1":
+    context_length: 205000
+
+  "moonshotai/kimi-k2.6":
+    context_length: 256000
+
   "deepseek-ai/deepseek-v4-pro":
     context_length: 1000000
     max_output_tokens: 128000

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -127,6 +127,25 @@ def _clean_provider_env(monkeypatch: pytest.MonkeyPatch):
 class TestNvBuildProvider:
     """build.nvidia.com provider — credentials + bundled YAML metadata."""
 
+    @pytest.mark.parametrize(
+        ("model", "context_length"),
+        [
+            ("z-ai/glm-5.2", 1_000_000),
+            ("z-ai/glm-5.1", 205_000),
+            ("moonshotai/kimi-k2.6", 256_000),
+        ],
+    )
+    def test_nv_build_reported_model_metadata(self, model: str, context_length: int) -> None:
+        provider = NvBuildProvider()
+        assert provider.get_context_length(model) == context_length
+        assert provider.get_max_output_tokens(model) is None
+
+    @pytest.mark.parametrize("model", ["glm-5.2", "z-ai/glm-5.2 "])
+    def test_nv_build_model_near_match_stays_unresolved(self, model: str) -> None:
+        provider = NvBuildProvider()
+        assert provider.get_context_length(model) is None
+        assert provider.get_max_output_tokens(model) is None
+
     def test_returns_none_without_env_var(self) -> None:
         assert NvBuildProvider().resolve_credentials() is None
 


### PR DESCRIPTION
## Summary

The nv_build provider now resolves bundled metadata for the current NVIDIA endpoint IDs that can be proved from owner docs. This prevents confirmed GLM entries from falling through to SkillSpector's generic 128,000-token budget while keeping short-form or unproved labels unresolved.

Refs #129

## Root cause

The nv_build provider uses exact keys from its bundled YAML registry. The reported models had no entries under their NVIDIA endpoint IDs, so metadata returned `None` and model budgeting used the generic fallback. `deepseek-ai/deepseek-v4-flash` is already present and remains unchanged, while the issue's short-form labels are not nv_build endpoint IDs and some reported models are not owner-proved as current NVIDIA endpoints.

## Diff Notes

- add only owner-confirmed current nv_build model IDs
- add parameterized exact-lookup coverage for every retained entry and every retained field
- preserve unknown-model fallback and reject short-form or unproved near-match aliases

## Scope

This change does not alter model defaults, provider creation, retry behavior, shared registry lookup, alias normalization, or other provider registries. The short labels as written in the issue (`glm-5.2`, `glm-5.1`, `kimi-k2.7-code`, `deepseek-v4-flash`) still resolve no metadata; nv_build keys entries by exact NVIDIA endpoint ID and this change adds no alias layer. It also does not invent a mapping for `kimi-k2.7-code` unless current owner docs prove that exact NVIDIA endpoint, and it leaves the issue's mimo-v2.5 and minimax-m3 CI deadlock reports unaddressed, so the issue stays open for those. It makes no claim that local metadata tests prove live inference success.

## Verification

- [x] `uv sync --all-extras` - completed successfully; installed the project and 151 packages
- [x] `uv run pytest tests/unit/test_providers.py -k "NvBuildProvider"` - `14 passed, 62 deselected in 1.17s`
- [x] `uv run pytest tests/unit/test_providers.py -k "nv_build and reported_model"` - `3 passed, 73 deselected in 0.98s`
- [x] `uv run pytest tests/unit/test_providers.py -k "nv_build and model_near_match"` - `2 passed, 74 deselected in 0.99s`
- [x] `uv run pytest tests/unit/test_providers.py -k "NvBuildProvider and metadata_known_model"` - `1 passed, 75 deselected in 1.02s`
- [x] `uv run ruff check src/ tests/` - `All checks passed!`
- [x] `uv run ruff format --check src/ tests/` - `144 files already formatted`
