### PR TITLE
fix(anthropic): honor ANTHROPIC_BASE_URL env override

### DIFF
--- a/src/skillspector/providers/anthropic/provider.py
+++ b/src/skillspector/providers/anthropic/provider.py
@@ -15,11 +15,12 @@
 
 """Anthropic provider — Claude models via api.anthropic.com.
 
-Reads ``ANTHROPIC_API_KEY`` for credentials and constructs
-``langchain_anthropic.ChatAnthropic`` directly. Defaults to Opus 4.6 for
-analyzers and Sonnet 4.6 for ``meta_analyzer`` (cheaper for the
-high-volume filter pass), mirroring the policy used by
-``NvInferenceProvider``.
+Reads ``ANTHROPIC_API_KEY`` for credentials and honors ``ANTHROPIC_BASE_URL``
+as an explicit endpoint override (e.g. a local proxy); when unset, requests
+go to api.anthropic.com. Constructs ``langchain_anthropic.ChatAnthropic``
+directly. Defaults to Opus 4.6 for analyzers and Sonnet 4.6 for
+``meta_analyzer`` (cheaper for the high-volume filter pass), mirroring the
+policy used by ``NvInferenceProvider``.
 """
 
 from __future__ import annotations
@@ -34,7 +35,7 @@ from pydantic import SecretStr
 from skillspector.providers import registry
 from skillspector.providers.chat_models import resolve_reasoning_effort
 
-# Documented for completeness — ChatAnthropic defaults here when base_url=None.
+# Default endpoint; overridden by ``ANTHROPIC_BASE_URL`` when set.
 ANTHROPIC_BASE_URL = "https://api.anthropic.com"
 
 REGISTRY_PATH = str(Path(__file__).with_name("model_registry.yaml"))
@@ -49,11 +50,12 @@ class AnthropicProvider:
     }
 
     def resolve_credentials(self) -> tuple[str, str | None] | None:
-        """Return ``(api_key, base_url)`` from ``ANTHROPIC_API_KEY``."""
+        """Return ``(api_key, base_url)`` from ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_BASE_URL``."""
         api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
         if not api_key:
             return None
-        return api_key, None
+        base_url = os.environ.get("ANTHROPIC_BASE_URL", "").strip() or None
+        return api_key, base_url
 
     def create_chat_model(
         self,
@@ -67,11 +69,11 @@ class AnthropicProvider:
         if creds is None:
             return None
 
-        api_key, _ = creds
+        api_key, base_url = creds
         kwargs = {
             "model_name": model,
             "api_key": SecretStr(api_key),
-            "base_url": ANTHROPIC_BASE_URL,
+            "base_url": base_url or ANTHROPIC_BASE_URL,
             "max_tokens_to_sample": max_tokens,
             "timeout": timeout,
             "stop": None,

--- a/src/skillspector/providers/anthropic/provider.py
+++ b/src/skillspector/providers/anthropic/provider.py
@@ -18,9 +18,8 @@
 Reads ``ANTHROPIC_API_KEY`` for credentials and honors ``ANTHROPIC_BASE_URL``
 as an explicit endpoint override (e.g. a local proxy); when unset, requests
 go to api.anthropic.com. Constructs ``langchain_anthropic.ChatAnthropic``
-directly. Defaults to Opus 4.6 for analyzers and Sonnet 4.6 for
-``meta_analyzer`` (cheaper for the high-volume filter pass), mirroring the
-policy used by ``NvInferenceProvider``.
+directly. It defaults to Opus 4.6 for analyzers and Sonnet 4.6 for
+``meta_analyzer`` (cheaper for the high-volume filter pass).
 """
 
 from __future__ import annotations

--- a/tests/provider/test_provider_endpoint.py
+++ b/tests/provider/test_provider_endpoint.py
@@ -71,11 +71,15 @@ def test_openai_provider_makes_live_structured_request(
     assert result == ProviderResult(ok=True)
 
 
-def test_anthropic_provider_makes_live_structured_request() -> None:
+def test_anthropic_provider_makes_live_structured_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Anthropic provider reaches its default endpoint and returns structured output."""
     from skillspector.providers.anthropic import ANTHROPIC_BASE_URL, AnthropicProvider
 
     _skip_without_env("ANTHROPIC_API_KEY")
+    # This live provider check must hit Anthropic's default base URL, not a proxy.
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
 
     model = _model_from_env("SKILLSPECTOR_ANTHROPIC_TEST_MODEL", AnthropicProvider.DEFAULT_MODEL)
     llm = AnthropicProvider().create_chat_model(model, max_tokens=32, timeout=60)

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -53,6 +53,7 @@ from skillspector.providers.openai import OpenAIProvider
 
 _LLM_ENV_VARS = (
     "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
     "OPENAI_API_KEY",
     "OPENAI_BASE_URL",
     "NVIDIA_INFERENCE_KEY",

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -45,7 +45,7 @@ from skillspector.providers import (
     resolve_provider_credentials,
     use_provider,
 )
-from skillspector.providers.anthropic import AnthropicProvider
+from skillspector.providers.anthropic import ANTHROPIC_BASE_URL, AnthropicProvider
 from skillspector.providers.antigravity_cli import AntigravityCLIProvider
 from skillspector.providers.chat_models import create_openai_compatible_chat_model
 from skillspector.providers.claude_cli import ClaudeCLIProvider
@@ -118,6 +118,7 @@ def _clean_provider_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("OPENAI_PROJECT_ID", raising=False)
     monkeypatch.delenv("SKILLSPECTOR_REASONING_EFFORT", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
     monkeypatch.delenv("SKILLSPECTOR_MODEL", raising=False)
     monkeypatch.delenv("SKILLSPECTOR_MODEL_REGISTRY", raising=False)
     monkeypatch.delenv("SKILLSPECTOR_PROVIDER", raising=False)
@@ -300,7 +301,13 @@ class TestAnthropicProvider:
     ) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-x")
         creds = AnthropicProvider().resolve_credentials()
-        assert creds == ("sk-ant-x", None)
+        assert creds == ("sk-ant-x", None)  # None → ChatAnthropic uses api.anthropic.com
+
+    def test_honors_anthropic_base_url_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-x")
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://localhost:8787")
+        creds = AnthropicProvider().resolve_credentials()
+        assert creds == ("sk-ant-x", "http://localhost:8787")
 
     def test_creates_native_chat_anthropic(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-x")
@@ -308,6 +315,17 @@ class TestAnthropicProvider:
         assert isinstance(llm, ChatAnthropic)
         assert llm.model == "claude-opus-4-6"
         assert llm.max_tokens == 123
+        # No override → ChatAnthropic points at the default Anthropic endpoint.
+        assert str(llm.anthropic_api_url).rstrip("/") == ANTHROPIC_BASE_URL.rstrip("/")
+
+    def test_create_chat_model_honors_base_url_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-x")
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://localhost:8787")
+        llm = AnthropicProvider().create_chat_model("claude-opus-4-6", max_tokens=123)
+        assert isinstance(llm, ChatAnthropic)
+        assert str(llm.anthropic_api_url).rstrip("/") == "http://localhost:8787"
 
     @pytest.mark.parametrize("effort", ["provider-specific-value"])
     def test_reasoning_effort_passthrough(


### PR DESCRIPTION
### What
`AnthropicProvider` now reads `ANTHROPIC_BASE_URL` and passes it to `ChatAnthropic`, falling back to `https://api.anthropic.com` when unset — mirroring how `OpenAIProvider` handles `OPENAI_BASE_URL`.

Fixes #281.

### Why
Previously `resolve_credentials()` returned `(api_key, None)` and `create_chat_model()` hardcoded `base_url=ANTHROPIC_BASE_URL`, so a proxy/gateway set via `ANTHROPIC_BASE_URL` was silently ignored and Anthropic requests went straight to the public API. This breaks egress-controlled/gateway deployments and is inconsistent with the OpenAI provider.

### Changes
- `providers/anthropic/provider.py`: read `ANTHROPIC_BASE_URL` in `resolve_credentials()`; use `base_url or ANTHROPIC_BASE_URL` in `create_chat_model()`.
- `tests/unit/test_providers.py`: add override + default-endpoint coverage; clear `ANTHROPIC_BASE_URL` in the env-isolation fixture.
- `tests/unit/test_llm_utils.py`: add `ANTHROPIC_BASE_URL` to the env-isolation list (keeps credential-resolution tests hermetic).
- `tests/provider/test_provider_endpoint.py`: clear `ANTHROPIC_BASE_URL` in the live anthropic test so it validates the default URL, mirroring the OpenAI live test.

### Testing
- `make lint` — clean
- `make format` — clean
- `pytest -m "not integration and not provider"` — 1314 passed, 12 skipped
