### PR TITLE
anthropic provider: honor ANTHROPIC_BASE_URL env var

### DIFF
--- a/src/skillspector/providers/anthropic/provider.py
+++ b/src/skillspector/providers/anthropic/provider.py
@@ -34,7 +34,7 @@ from pydantic import SecretStr
 from skillspector.providers import registry
 from skillspector.providers.chat_models import resolve_reasoning_effort
 
-# Documented for completeness — ChatAnthropic defaults here when base_url=None.
+# Default endpoint; overridden by the ANTHROPIC_BASE_URL env var when set.
 ANTHROPIC_BASE_URL = "https://api.anthropic.com"
 
 REGISTRY_PATH = str(Path(__file__).with_name("model_registry.yaml"))
@@ -68,10 +68,13 @@ class AnthropicProvider:
             return None
 
         api_key, _ = creds
+        # Honor ANTHROPIC_BASE_URL for self-hosted gateways / Anthropic-compatible
+        # endpoints, mirroring how the openai provider honors OPENAI_BASE_URL.
+        base_url = os.environ.get("ANTHROPIC_BASE_URL", "").strip() or ANTHROPIC_BASE_URL
         kwargs = {
             "model_name": model,
             "api_key": SecretStr(api_key),
-            "base_url": ANTHROPIC_BASE_URL,
+            "base_url": base_url,
             "max_tokens_to_sample": max_tokens,
             "timeout": timeout,
             "stop": None,


### PR DESCRIPTION
## Summary
The `anthropic` provider hardcodes `base_url` to `https://api.anthropic.com` in `create_chat_model`, so it can't be pointed at self-hosted gateways, corporate proxies, or Anthropic-compatible endpoints. The `openai` provider already honors `OPENAI_BASE_URL`; this brings the `anthropic` provider to parity by honoring `ANTHROPIC_BASE_URL` (the same env var the official Anthropic SDK reads).

## Change
- `create_chat_model` reads `ANTHROPIC_BASE_URL` from the environment, falling back to the existing `api.anthropic.com` default.
- Backward compatible: behavior is unchanged when the env var is unset.

## Testing
Pointed the `anthropic` provider at an Anthropic-compatible Messages endpoint via `ANTHROPIC_BASE_URL` and confirmed scans complete with tool-use structured output; the default path is unaffected when the var is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)