### PR TITLE
fix(provider): isolate Claude CLI settings hooks with --setting-sources=

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,7 @@ message) — see [`.skillspector-baseline.example.yaml`](.skillspector-baseline.
 ### LLM Analysis
 
 For the best results, configure an OpenAI-compatible LLM endpoint for
-semantic analysis. Pick a provider with `SKILLSPECTOR_PROVIDER`; each
-ships its own bundled default model. SkillSpector also works against
+semantic analysis. Pick a provider with `SKILLSPECTOR_PROVIDER`; hosted providers ship bundled default models, while CLI providers fall back to the local runtime's default model unless `SKILLSPECTOR_MODEL` is set. SkillSpector also works against
 local OpenAI-compatible servers (Ollama, vLLM, llama.cpp) and managed
 inference gateways.
 
@@ -215,8 +214,8 @@ inference gateways.
 | `anthropic_proxy` | `ANTHROPIC_PROXY_API_KEY` + `ANTHROPIC_PROXY_ENDPOINT_URL` | Any Vertex-style raw-predict proxy | `claude-sonnet-4-6` |
 | `bedrock` | `AWS_PROFILE` (optional) + `AWS_REGION` — SigV4 via boto3 | AWS Bedrock Runtime | `us.anthropic.claude-sonnet-4-6-20250915-v1:0` |
 | `nv_build` | `NVIDIA_INFERENCE_KEY` | build.nvidia.com | `deepseek-ai/deepseek-v4-flash` |
-| `claude_cli` | _(none — uses local CLI auth)_ | local `claude` binary | `claude-sonnet-4-6` |
-| `codex_cli` | _(none — uses local CLI auth)_ | local `codex` binary | `o4-mini` |
+| `claude_cli` | _(none — uses local CLI auth)_ | local `claude` binary | local Claude runtime fallback, or `SKILLSPECTOR_MODEL` |
+| `codex_cli` | _(none — uses local CLI auth)_ | local `codex` binary | local Codex runtime fallback, or `SKILLSPECTOR_MODEL` |
 
 ```bash
 # Stock OpenAI
@@ -256,6 +255,8 @@ skillspector scan ./my-skill/
 # Local Claude CLI — no API key; uses your existing `claude auth login` session
 # Requires: claude CLI installed and authenticated (claude auth login)
 export SKILLSPECTOR_PROVIDER=claude_cli
+# Uses the local Claude CLI runtime fallback unless SKILLSPECTOR_MODEL is set.
+# export SKILLSPECTOR_MODEL=claude-sonnet-4-6
 skillspector scan ./my-skill/
 
 # Local Codex CLI — no API key; uses your existing `codex login` session
@@ -553,7 +554,7 @@ Issues (2)
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `SKILLSPECTOR_PROVIDER` | Active LLM provider: `openai`, `anthropic`, `anthropic_proxy`, `bedrock`, `nv_build`, `claude_cli`, `codex_cli`, or `gemini_cli`. Each provider has its own bundled `model_registry.yaml` and default model (see the LLM Analysis table above). Defaults to `nv_build`. | Optional |
+| `SKILLSPECTOR_PROVIDER` | Active LLM provider: `openai`, `anthropic`, `anthropic_proxy`, `bedrock`, `nv_build`, `claude_cli`, `codex_cli`, or `gemini_cli`. Hosted providers use bundled `model_registry.yaml` defaults; `claude_cli` and `codex_cli` fall back to the local CLI runtime's default model unless `SKILLSPECTOR_MODEL` is set. Defaults to `nv_build`. | Optional |
 | `NVIDIA_INFERENCE_KEY` | Credential for the `nv_build` provider (build.nvidia.com). | Required for LLM analysis when `SKILLSPECTOR_PROVIDER=nv_build` |
 | `OPENAI_API_KEY` | Credential for the OpenAI provider (`SKILLSPECTOR_PROVIDER=openai`). Also serves as the tier-2 fallback in the credential waterfall when the active provider returns no credentials. | Required for LLM analysis when `SKILLSPECTOR_PROVIDER=openai` |
 | `OPENAI_BASE_URL` | Override the OpenAI endpoint (e.g. point at Ollama). | Optional |
@@ -564,7 +565,7 @@ Issues (2)
 | `ANTHROPIC_PROXY_API_VERSION` | `anthropic_version` value sent in the request body (default: `vertex-2023-10-16`). | Optional |
 | `AWS_PROFILE` | Named AWS profile for the Bedrock provider — authenticates via SigV4 through boto3. When unset, the standard boto3 credential chain (env vars, instance metadata, SSO, etc.) resolves. | Optional (used when `SKILLSPECTOR_PROVIDER=bedrock`) |
 | `AWS_REGION` | AWS region for the Bedrock Runtime endpoint. Defaults to `us-west-2`. | Optional (used when `SKILLSPECTOR_PROVIDER=bedrock`) |
-| `SKILLSPECTOR_MODEL` | Override the active provider's default model. See the LLM Analysis table for each provider's default. | Optional |
+| `SKILLSPECTOR_MODEL` | Override the active provider model. For hosted providers, this replaces the bundled default from the LLM Analysis table. For `claude_cli` and `codex_cli`, this is forwarded as `--model` instead of using the local CLI runtime fallback. | Optional |
 | `SKILLSPECTOR_MODEL_REGISTRY` | Override the bundled per-provider YAML registry (`src/skillspector/providers/<provider>/model_registry.yaml`) with a custom path. | Optional |
 | `SKILLSPECTOR_LOG_LEVEL` | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR` (default: `WARNING`). | Optional |
 

--- a/src/skillspector/providers/_agent_cli.py
+++ b/src/skillspector/providers/_agent_cli.py
@@ -212,7 +212,9 @@ def _build_claude_argv(binary: str, model: str, max_output_tokens: int) -> list[
 
     ``--setting-sources=``
         Load no user, project, or local settings, preventing their hooks from
-        running in the spawned Claude CLI process.
+        running in the spawned Claude CLI process. This also means filesystem
+        model settings do not flow into the child unless SkillSpector pins a
+        model explicitly.
 
     ``--disable-slash-commands``
         Prevents skill/plugin invocations from within the sandboxed call.
@@ -226,8 +228,8 @@ def _build_claude_argv(binary: str, model: str, max_output_tokens: int) -> list[
     - ``--add-dir`` — no extra directory access needed.
     """
     # Forward --model ONLY when SKILLSPECTOR_MODEL is explicitly set; otherwise
-    # omit it so claude uses the user's own configured default — no pinned model
-    # versions, and the user's model / thinking-level preference is respected.
+    # omit it and let Claude fall back without loading user/project/local
+    # settings from disk.
     model_arg = ["--model", _validate_model_label(model)] if model else []
     return [
         binary,

--- a/src/skillspector/providers/_agent_cli.py
+++ b/src/skillspector/providers/_agent_cli.py
@@ -210,6 +210,10 @@ def _build_claude_argv(binary: str, model: str, max_output_tokens: int) -> list[
         Use only MCP servers from ``--mcp-config`` — which we never pass — so
         zero MCP servers load. (Note: ``--no-mcp-config`` is NOT a real flag.)
 
+    ``--setting-sources=``
+        Load no user, project, or local settings, preventing their hooks from
+        running in the spawned Claude CLI process.
+
     ``--disable-slash-commands``
         Prevents skill/plugin invocations from within the sandboxed call.
 
@@ -236,6 +240,7 @@ def _build_claude_argv(binary: str, model: str, max_output_tokens: int) -> list[
         "--permission-mode",
         "dontAsk",
         "--strict-mcp-config",
+        "--setting-sources=",
         "--disable-slash-commands",
     ]
 

--- a/src/skillspector/providers/_agent_cli_base.py
+++ b/src/skillspector/providers/_agent_cli_base.py
@@ -35,8 +35,7 @@ class AgentCLIProviderBase:
 
     #: CLI name; must be a key in ``_agent_cli._REGISTRY``.
     BINARY_NAME: str = ""
-    #: Always "" for CLI providers — the user's own CLI-configured model is used
-    #: (we omit ``--model``). Present only so constants.py's
+    #: Always "" for CLI providers. Present only so constants.py's
     #: ``_provider.DEFAULT_MODEL`` lookup has an attribute; never pins a version.
     DEFAULT_MODEL: str = ""
     #: Optional path to a bundled ``model_registry.yaml`` for token budgets. CLI
@@ -83,10 +82,8 @@ class AgentCLIProviderBase:
     def resolve_model(self, slot: str = "default") -> str:
         """Return the model to forward to the CLI.
 
-        CLI providers default to the user's OWN CLI-configured model (we omit
-        ``--model`` entirely), so this returns ``""`` unless the user explicitly
-        sets ``SKILLSPECTOR_MODEL`` to override it. No model versions are pinned
-        here — that keeps the providers version-proof and respects the user's own
-        default model / thinking-level configuration.
+        CLI providers omit ``--model`` unless ``SKILLSPECTOR_MODEL`` is set, so
+        this returns ``""`` by default. Each CLI then applies whatever fallback
+        model behaviour its own settings and runtime contract define.
         """
         return os.environ.get("SKILLSPECTOR_MODEL", "").strip()

--- a/src/skillspector/providers/claude_cli/provider.py
+++ b/src/skillspector/providers/claude_cli/provider.py
@@ -36,8 +36,9 @@ BINARY_NAME = "claude"
 class ClaudeCLIProvider(AgentCLIProviderBase):
     """Claude CLI provider (no API key; uses the local ``claude`` login).
 
-    No model is pinned: ``claude`` runs with the user's own default model and
-    thinking-level config. Set ``SKILLSPECTOR_MODEL`` to override.
+    No model is pinned: ``claude`` falls back to its remaining runtime default
+    after SkillSpector strips user, project, and local settings. Set
+    ``SKILLSPECTOR_MODEL`` to override.
     """
 
     BINARY_NAME = "claude"

--- a/tests/integration/test_agent_cli_live.py
+++ b/tests/integration/test_agent_cli_live.py
@@ -36,7 +36,7 @@ cleanly — a missing tool never fails the suite.
 
 Each case verifies, against the real binary:
   1. A call returns non-empty text with NO model pinned — ``model=""`` means the
-     CLI uses the user's OWN default model (``--model`` is omitted).
+     CLI receives no explicit ``--model`` override.
   2. A prompt containing a prompt-injection is returned as analysis *text*, not
      executed (the capability-stripped, fail-closed invocation; the flags that
      guarantee this are unit-tested in ``tests/unit/test_agent_cli.py``).
@@ -73,12 +73,12 @@ class TestAgentCliLive:
     """Smoke tests that drive each real CLI through the hardened runner."""
 
     def test_returns_text_with_no_pinned_model(self, cli: str) -> None:
-        """``model=""`` -> the CLI runs with the user's own default model."""
+        """``model=""`` -> the CLI runs without an explicit ``--model`` flag."""
         _require(cli)
         out = _agent_cli.run_agent_cli(
             cli,
             "Reply with exactly one word: PONG",
-            model="",  # no --model: honour the user's own CLI-configured model
+            model="",  # no --model: let the CLI pick its own fallback model
             max_output_tokens=64,
         )
         assert isinstance(out, str)

--- a/tests/unit/test_agent_cli.py
+++ b/tests/unit/test_agent_cli.py
@@ -168,8 +168,7 @@ class TestBuildClaudeArgv:
         assert argv[idx + 1] == MODEL
 
     def test_model_flag_omitted_when_empty(self) -> None:
-        # No SKILLSPECTOR_MODEL -> resolve_model() is "" -> --model is omitted so
-        # claude runs with the user's OWN configured model (no pinned version).
+        # No SKILLSPECTOR_MODEL -> resolve_model() is "" -> --model is omitted.
         argv = _build_claude_argv(CLAUDE_BINARY, "", 4096)
         assert "--model" not in argv
 

--- a/tests/unit/test_agent_cli.py
+++ b/tests/unit/test_agent_cli.py
@@ -195,6 +195,12 @@ class TestBuildClaudeArgv:
         # --no-mcp-config is not a real claude flag and must not be used.
         assert "--no-mcp-config" not in argv
 
+    def test_setting_sources_is_empty_single_token_after_strict_mcp_config(self) -> None:
+        argv = _build_claude_argv(CLAUDE_BINARY, MODEL, 4096)
+        assert "--setting-sources=" in argv
+        assert argv[argv.index("--strict-mcp-config") + 1] == "--setting-sources="
+        assert argv.count("--setting-sources=") == 1
+
     def test_bare_flag_absent(self) -> None:
         argv = _build_claude_argv(CLAUDE_BINARY, MODEL, 4096)
         # --bare skips keychain reads, which breaks authentication; never use it.
@@ -253,6 +259,10 @@ class TestBuildCodexArgv:
         argv = _build_codex_argv(CODEX_BINARY, "o4-mini")
         full_cmd = " ".join(argv)
         assert "dangerously" not in full_cmd.lower()
+
+    def test_setting_sources_flag_absent(self) -> None:
+        argv = _build_codex_argv(CODEX_BINARY, "o4-mini")
+        assert "--setting-sources=" not in argv
 
 
 # ---------------------------------------------------------------------------
@@ -690,6 +700,10 @@ class TestGeminiArgv:
         # No SKILLSPECTOR_MODEL -> gemini runs with the user's own model.
         argv = _agent_cli._build_gemini_argv("gemini", "", 4096)
         assert "-m" not in argv
+
+    def test_setting_sources_flag_absent(self) -> None:
+        argv = _agent_cli._build_gemini_argv("gemini", "gemini-2.5-pro", 4096)
+        assert "--setting-sources=" not in argv
 
     def test_parse_handles_json_and_plaintext(self) -> None:
         assert _agent_cli._parse_gemini_output('{"response": "hi"}') == "hi"

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -737,7 +737,7 @@ class TestClaudeCLIProvider:
 
     def test_resolve_model_empty_when_no_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # No model is pinned: with SKILLSPECTOR_MODEL unset, resolve_model is ""
-        # so the CLI runs with the user's OWN configured model (we omit --model).
+        # so the Claude CLI receives no explicit --model override.
         monkeypatch.delenv("SKILLSPECTOR_MODEL", raising=False)
         assert ClaudeCLIProvider().resolve_model() == ""
         assert ClaudeCLIProvider.DEFAULT_MODEL == ""


### PR DESCRIPTION
## Summary

The `claude_cli` provider builds a capability-stripped `claude -p` subprocess, but it never constrains settings sources, so the spawned CLI loads the operator's `settings.json` and runs its hooks. When a hook re-enters Claude Code, each LLM call the scanner makes can turn into a full hook cycle and saturate the machine.

This change adds `--setting-sources=` beside the existing Claude isolation flags so the spawned CLI loads no user, project, or local settings and therefore runs none of those hooks. With `SKILLSPECTOR_MODEL` unset, that also means Claude no longer inherits filesystem default-model or thinking settings from those scopes.

Closes #295

Reported by @Mark2Mac in [issue #295](https://github.com/NVIDIA/SkillSpector/issues/295).

## Root cause

`_build_claude_argv` in `src/skillspector/providers/_agent_cli.py` already strips tools, MCP servers, and slash commands, but it omits the Claude CLI's settings-source boundary. The returned argv therefore still lets the child CLI load ambient settings before the model call, and settings-derived hooks execute inside what is otherwise intended to be an isolated subprocess.

## Before / After

| | argv tail | spawned `claude` loads settings hooks |
| --- | --- | --- |
| Before | `... --strict-mcp-config --disable-slash-commands` | yes |
| After | `... --strict-mcp-config --setting-sources= --disable-slash-commands` | no |

## Diff Notes

- `src/skillspector/providers/_agent_cli.py`: add the exact `--setting-sources=` token to `_build_claude_argv`, directly after `--strict-mcp-config`
- `src/skillspector/providers/_agent_cli.py`: document that the empty settings-source list blocks user, project, and local settings hooks, and that filesystem model settings no longer flow into the spawned Claude CLI unless SkillSpector pins `SKILLSPECTOR_MODEL`
- `src/skillspector/providers/_agent_cli_base.py` and `src/skillspector/providers/claude_cli/provider.py`: narrow the Claude contract text so `model=""` means "no explicit override" rather than "inherit filesystem model settings"
- `tests/unit/test_agent_cli.py`: add focused argv assertions for the new literal and its required single-token empty-value form
- `tests/unit/test_agent_cli.py`: add Codex and Gemini absence checks so the preservation coverage proves `--setting-sources=` stays Claude-only
- `tests/unit/test_providers.py` and `tests/integration/test_agent_cli_live.py`: align the Claude-facing test language with the new no-filesystem-settings boundary

## Scope

This is limited to the Claude CLI subprocess boundary. It does not change Codex or Gemini builders, env scrubbing, auth behavior, graph orchestration, analyzers, report metadata, MCP transport, or dependencies.

The hook-suppression effect is owned by the external Claude CLI flag contract. The committed unit tests prove the argv SkillSpector emits at that boundary, not the external CLI's full runtime behavior. The no-settings boundary also means Claude's filesystem model settings stop applying unless `SKILLSPECTOR_MODEL` pins a model explicitly.

## Verification

- [x] `.\.venv\Scripts\python.exe -m pytest tests\unit\test_agent_cli.py tests\unit\test_providers.py` returned `156 passed, 9 skipped in 2.47s`.
- [x] The base argv proxy omitted `--setting-sources=`; the head argv proxy emitted `--strict-mcp-config`, `--setting-sources=`, and `--disable-slash-commands` in that order.
- [x] `uv run ruff check src/ tests/` returned `All checks passed!`.
- [x] `uv run ruff format --check src/ tests/` returned `144 files already formatted`.
- [x] `claude --help` documented `--setting-sources <sources>` for `user, project, local`; `claude --setting-sources= --version` returned `2.1.217 (Claude Code)`.
- [x] Issue #295 owner-reaching measurement recorded `33` versus `0` log lines and `1` versus `0` created sessions for current argv versus `--setting-sources=`.
