### PR TITLE
fix(agent-cli): Windows temp-cwd cleanup must not fail a successful batch

### DIFF
--- a/src/skillspector/providers/_agent_cli.py
+++ b/src/skillspector/providers/_agent_cli.py
@@ -53,6 +53,7 @@ import shutil
 import subprocess
 import tempfile
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -632,6 +633,37 @@ def _drain_stream(stream: Any, buf: bytearray, cap: int, on_overflow: Any) -> No
             pass
 
 
+_CLEANUP_RETRIES = 10
+_CLEANUP_RETRY_DELAY_S = 0.2
+
+
+def _cleanup_temp_dir(path: str) -> None:
+    """Best-effort removal of the per-invocation temp cwd.
+
+    On Windows a directory cannot be deleted while any process has it as its
+    working directory or holds a handle inside it. The agent CLI's process
+    tree can outlive the direct child by a beat (a ``.cmd`` shim's node child,
+    or a killed-but-not-reaped child on the timeout path), so the first
+    attempts may fail transiently with ``WinError 32``. Retry briefly, then
+    leak the directory with a warning rather than raise: by the time cleanup
+    runs the model's response is already in hand, and a temp-dir leak must
+    never fail the batch (#315).
+    """
+    for _ in range(_CLEANUP_RETRIES):
+        try:
+            shutil.rmtree(path)
+            return
+        except OSError:
+            time.sleep(_CLEANUP_RETRY_DELAY_S)
+    shutil.rmtree(path, ignore_errors=True)
+    if os.path.isdir(path):
+        logger.warning(
+            "Could not remove temp dir %s (handle still held by the CLI "
+            "process tree?); leaking it rather than failing the batch",
+            path,
+        )
+
+
 def _run_bounded(
     proc: subprocess.Popen, prompt_bytes: bytes, timeout: float
 ) -> tuple[int | None, bytes, bytes, bool]:
@@ -767,7 +799,12 @@ def run_agent_cli(
     child_env = _scrub_env()
 
     # -- Run in a temporary directory (no CWD access) -------------------------
-    with tempfile.TemporaryDirectory(prefix="skillspector_cli_") as tmp_cwd:
+    # mkdtemp + explicit best-effort cleanup instead of TemporaryDirectory:
+    # the context manager's rmtree-at-__exit__ raises on Windows while the
+    # CLI's process tree still holds the directory as its cwd, turning an
+    # already-successful call into a batch failure (#315).
+    tmp_cwd = tempfile.mkdtemp(prefix="skillspector_cli_")
+    try:
         logger.debug(
             "Running %s argv=%r cwd=%s timeout=%ss",
             binary_name,
@@ -792,6 +829,8 @@ def run_agent_cli(
         # CLI cannot exhaust memory before the cap is enforced (a chatty child
         # could otherwise buffer unbounded output until the timeout).
         returncode, stdout_raw, stderr_raw, overflow = _run_bounded(proc, prompt_bytes, timeout)
+    finally:
+        _cleanup_temp_dir(tmp_cwd)
 
     # -- Fail-closed checks ---------------------------------------------------
     if overflow:

--- a/tests/unit/test_agent_cli.py
+++ b/tests/unit/test_agent_cli.py
@@ -733,3 +733,95 @@ class TestAntigravityDisabled:
         ok, reason = _agent_cli.is_available("agy")
         assert ok is False
         assert "disabled" in (reason or "")
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_temp_dir — Windows-safe temp cwd removal (#315)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupTempDir:
+    """Cleanup failure must never outrank a successful CLI response (#315).
+
+    On Windows the CLI's process tree can hold the temp cwd (a ``.cmd``
+    shim's node child, or a killed child on the timeout path), so rmtree can
+    fail transiently — or persistently — after the model already answered.
+    """
+
+    def test_removes_directory(self, tmp_path) -> None:
+        target = tmp_path / "cli_cwd"
+        target.mkdir()
+        (target / "scratch.txt").write_text("x")
+        _agent_cli._cleanup_temp_dir(str(target))
+        assert not target.exists()
+
+    def test_retries_transient_failure_then_succeeds(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "cli_cwd"
+        target.mkdir()
+        real_rmtree = _agent_cli.shutil.rmtree
+        calls = {"n": 0}
+
+        def flaky_rmtree(path, ignore_errors=False):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise OSError(32, "held by another process")
+            return real_rmtree(path, ignore_errors=ignore_errors)
+
+        monkeypatch.setattr(_agent_cli.shutil, "rmtree", flaky_rmtree)
+        monkeypatch.setattr(_agent_cli.time, "sleep", lambda _s: None)
+        _agent_cli._cleanup_temp_dir(str(target))
+        assert not target.exists()
+        assert calls["n"] == 3
+
+    def test_never_raises_when_removal_keeps_failing(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "cli_cwd"
+        target.mkdir()
+
+        def stuck_rmtree(path, ignore_errors=False):
+            if not ignore_errors:
+                raise OSError(32, "held by another process")
+
+        monkeypatch.setattr(_agent_cli.shutil, "rmtree", stuck_rmtree)
+        monkeypatch.setattr(_agent_cli.time, "sleep", lambda _s: None)
+        # Must not raise; the directory is leaked deliberately.
+        _agent_cli._cleanup_temp_dir(str(target))
+        assert target.exists()
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows handle semantics")
+    def test_open_handle_does_not_raise_on_windows(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A real open handle inside the dir — the exact WinError 32 case."""
+        target = tmp_path / "cli_cwd"
+        target.mkdir()
+        monkeypatch.setattr(_agent_cli.time, "sleep", lambda _s: None)
+        held = open(target / "held.txt", "w")  # noqa: SIM115 — handle held on purpose
+        try:
+            _agent_cli._cleanup_temp_dir(str(target))  # must not raise
+        finally:
+            held.close()
+        _agent_cli._cleanup_temp_dir(str(target))
+        assert not target.exists()
+
+
+@patch("skillspector.providers._agent_cli.find_binary", return_value=CLAUDE_BINARY)
+@patch("skillspector.providers._agent_cli.subprocess.Popen")
+class TestRunAgentCLISurvivesCleanupFailure:
+    def test_response_returned_when_temp_dir_cannot_be_removed(
+        self, mock_popen: MagicMock, _mock_binary: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression for #315: rmtree failure must not fail the batch."""
+        mock_popen.return_value = _make_ok_process(_GOOD_CLAUDE_OUTPUT.encode())
+
+        def stuck_rmtree(path, ignore_errors=False):
+            if not ignore_errors:
+                raise OSError(32, "held by another process")
+
+        monkeypatch.setattr(_agent_cli.shutil, "rmtree", stuck_rmtree)
+        monkeypatch.setattr(_agent_cli.time, "sleep", lambda _s: None)
+        result = run_agent_cli("claude", PROMPT, model=MODEL)
+        assert result  # the model's answer survives the cleanup failure


### PR DESCRIPTION
Closes #315.

## Root cause — one correction to the issue's hypothesis

It isn't a cross-worker collision on a shared temp file: every invocation already gets a unique directory (`tempfile.TemporaryDirectory(prefix="skillspector_cli_")` → `mkdtemp` under the hood). The race is **delete-at-`__exit__` vs the CLI's process-tree teardown**. On Windows, a directory cannot be removed while any live process has it as its working directory or holds any handle inside it — I verified both hold modes raise exactly `WinError 32` in controlled experiments. The `claude` binary on Windows is a `.cmd` shim that spawns node children; when any of that tree outlives the direct child (or a killed-but-unreaped child lingers on the timeout path), `rmtree` at `__exit__` throws **after the model has already answered**, and `llm_analyzer_base` records the batch as `llm_batch_failed`. Concurrency widens the teardown window, which is why the issue's batch runs fail while one-file-at-a-time runs pass, and why the failing set varies between runs.

## Fix

`mkdtemp` + explicit best-effort cleanup in a `finally`: `_cleanup_temp_dir` retries briefly (10 × 0.2 s — enough for the common case where the holder exits within a beat), then falls back to `ignore_errors` and leaks the directory with a warning. A cleanup failure never outranks a successful response. Detection/scan behavior is untouched; concurrency is preserved (no serialization).

## Verification on Windows 10

Mechanism-faithful repro: a fake `claude.cmd` that answers normally on stdout but detaches a grandchild whose CWD is the temp dir (via `Start-Process`, so no pipe-handle inheritance — matching how the real CLI's children behave), 8 concurrent batches through `run_agent_cli`:

| build | result |
|---|---|
| `main` | **8/8 batches fail**, `PermissionError: [WinError 32] ... 'C:\...\skillspector_cli_<rand>'` — the exact signature from #315 |
| this branch | **8/8 batches succeed**; dirs reclaimed by retry when the holder exits quickly, else leaked with one warning |

Controlled experiments (independent of the shim) confirm each mechanism: another process's CWD blocks `rmtree` (WinError 32 naming the directory — matching the issue's error, which names the directory rather than a file); an open file handle inside blocks it too (naming the file).

## Tests

5 new cases in `tests/unit/test_agent_cli.py`: happy-path removal, transient-failure retry, never-raises-when-stuck (deliberate leak), a Windows-only real open-handle hold, and a regression test asserting `run_agent_cli` returns the model's response even when `rmtree` keeps failing. **87/87 pass on Windows** — which also exercises the suite on the platform this provider was breaking on (4 pre-existing, unrelated Windows failures elsewhere in the full suite reproduce identically on a clean `main`; detailed in #316).

🤖 Generated with [Claude Code](https://claude.com/claude-code)