### PR TITLE
fix(mp2): aligned tables and ASCII boxes are layout, not context stuffing

### DIFF
--- a/src/skillspector/nodes/analyzers/static_patterns_memory_poisoning.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_memory_poisoning.py
@@ -79,6 +79,15 @@ MP1_PATTERNS = [
     ),
 ]
 
+# Layout filler: characters that repeat because something is being *aligned*, not because
+# context is being displaced — aligned table cells, ASCII boxes, horizontal rules, padded
+# columns built by UI code. Box drawing is U+2500-U+257F.
+_MP2_LAYOUT_FILLER = re.compile(r"^[\s\-=_*.|:+~\u2500-\u257F]+$")
+
+# Above this width the run stops being plausible formatting: nobody reads a table row or an
+# ASCII box 400 characters wide, so a repetition that long is reported even if it is filler.
+_MP2_LAYOUT_MAX_RUN = 400
+
 # MP2: Context Window Stuffing — filling context to displace content
 MP2_PATTERNS = [
     (r"(.{2,20}?)\1{20,}", 0.8),
@@ -185,6 +194,14 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
             captured = match.group(1) if match.lastindex else match.group(0)
             non_ws_chars = set(captured) - {" ", "\t", "\n", "\r"}
             if len(non_ws_chars) <= 1 and not any(c in captured for c in (" ", "\t")):
+                continue
+            # Same reasoning as the guard above, extended to the case it misses: a unit made
+            # only of whitespace and alignment characters repeats because a table, a box or a
+            # column is being drawn. Runs wider than a readable line are still reported.
+            if (
+                _MP2_LAYOUT_FILLER.match(captured)
+                and len(match.group(0)) < _MP2_LAYOUT_MAX_RUN
+            ):
                 continue
             line_num = get_line_number(content, match.start())
             findings.append(

--- a/tests/unit/test_patterns_new.py
+++ b/tests/unit/test_patterns_new.py
@@ -551,6 +551,34 @@ class TestMemoryPoisoning:
     def test_mp2_separator_not_flagged(self) -> None:
         assert not any(f.rule_id == "MP2" for f in mp_mod.analyze("=" * 80, "test.md", "markdown"))
 
+    def test_mp2_aligned_markdown_table_is_layout(self) -> None:
+        # An aligned table repeats spaces and dashes because cells are being lined up, not
+        # because context is being displaced.
+        content = (
+            "| campo      | quando            | significato                        |\n"
+            "| ---------- | ----------------- | ---------------------------------- |\n"
+            "| id         | sempre            | identificatore stabile del record  |\n"
+            "| aggiornato | dopo ogni scrittura | timestamp dell'ultima modifica   |\n"
+        )
+        assert not any(f.rule_id == "MP2" for f in mp_mod.analyze(content, "docs/tabella.md", "markdown"))
+
+    def test_mp2_ascii_box_is_layout(self) -> None:
+        content = "│  └───────────────────────────────────────────────────────┘  │\n"
+        assert not any(f.rule_id == "MP2" for f in mp_mod.analyze(content, "README.md", "markdown"))
+
+    def test_mp2_padded_column_in_code_is_layout(self) -> None:
+        content = 'lines.append(f"{Colors.DIM}|{Colors.RESET}                                   ")\n'
+        assert not any(f.rule_id == "MP2" for f in mp_mod.analyze(content, "src/ui.py", "python"))
+
+    def test_mp2_whitespace_run_beyond_layout_width_is_still_stuffing(self) -> None:
+        # Layout stops being a plausible explanation well before this width.
+        content = "testo" + " " * 800 + "altro testo\n"
+        assert any(f.rule_id == "MP2" for f in mp_mod.analyze(content, "test.md", "markdown"))
+
+    def test_mp2_repeated_content_is_still_stuffing(self) -> None:
+        # The unit repeated here is content, not alignment: unchanged behaviour.
+        assert any(f.rule_id == "MP2" for f in mp_mod.analyze("lorem " * 60, "test.md", "markdown"))
+
     @pytest.mark.parametrize(
         "content",
         [


### PR DESCRIPTION
### The problem

`MP2` (context window stuffing) matches `(.{2,20}?)\1{20,}` — a short unit repeated twenty times or more. There is already a guard for the obvious false positive:

```python
non_ws_chars = set(captured) - {" ", "\t", "\n", "\r"}
if len(non_ws_chars) <= 1 and not any(c in captured for c in (" ", "\t")):
    continue
```

A run of one repeated character is skipped — but whitespace is explicitly exempted from that skip, so **any unit containing a space still matches**. In practice that is most formatting a real project contains:

```markdown
| campo      | quando              | significato                       |
| ---------- | ------------------- | --------------------------------- |
```

```
│  └───────────────────────────────────────────────────────┘  │
```

```python
lines.append(f"{Colors.DIM}│{Colors.RESET}                                   ")
```

An aligned table, an ASCII box, a padded column. None of them displaces anything.

### The change

The existing guard's reasoning, extended to the case it misses: a unit made only of whitespace and alignment characters — dashes, bars, colons, dots, box drawing `U+2500–U+257F` — repeats because something is being *lined up*.

It is deliberately **not** a blanket exemption. Above 400 characters layout stops being a plausible explanation, so a long run is still reported even when it is pure filler:

| input | before | after |
|---|---|---|
| aligned markdown table | MP2 | — |
| ASCII box / horizontal rule | MP2 | — |
| padded column built in code | MP2 | — |
| `"testo" + " " * 800` | MP2 | **MP2** |
| `"lorem " * 60` (repeated content) | MP2 | **MP2** |

### Measured effect

25 real files taken from a corpus of 65 skill/plugin units, every one of which had MP2 findings:

```
MP2 findings   95  ->  3
```

The three survivors come from MP2's *other* patterns — prose that talks about exceeding the context window — not from the repetition pattern. They are a different question and this PR does not touch them.

### Tests

Five new cases alongside the existing `test_mp2_separator_not_flagged`: aligned table, ASCII box and padded column produce nothing; a whitespace run past the layout width, and repeated content, still do.

Full suite: `1565 passed, 14 skipped, 6 xfailed`.
