### PR TITLE
fix(analyzers): share Python AST parsing for environment-read detection

### DIFF
--- a/src/skillspector/cleanup.py
+++ b/src/skillspector/cleanup.py
@@ -5,9 +5,13 @@
 
 import shutil
 
+from skillspector.python_ast import clear_python_ast_cache
+
 
 def cleanup_result(result: dict[str, object]) -> None:
-    """Remove temp dir from graph result if set."""
+    """Release scan-local resources and remove a temp dir if set."""
+    python_ast_cache_key = result.get("python_ast_cache_key")
+    clear_python_ast_cache(python_ast_cache_key if isinstance(python_ast_cache_key, str) else None)
     temp_dir = result.get("temp_dir_for_cleanup")
     if temp_dir and isinstance(temp_dir, str):
         shutil.rmtree(temp_dir, ignore_errors=True)

--- a/src/skillspector/nodes/analyzers/behavioral_ast.py
+++ b/src/skillspector/nodes/analyzers/behavioral_ast.py
@@ -29,10 +29,10 @@ from skillspector.inspection_ledger import (
 )
 from skillspector.logging_config import get_logger
 from skillspector.models import AnalyzerFinding, Finding, Location, Severity
+from skillspector.python_ast import ParsedPythonFile, get_python_ast
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 from .common import (
-    build_import_aliases,
     get_context_from_lines,
     get_source_segment,
     resolve_call_name,
@@ -156,11 +156,13 @@ def _contains_dangerous_source(node: ast.AST, aliases: dict[str, str] | None = N
     return None
 
 
-def _analyze_python(content: str, file_path: str) -> list[AnalyzerFinding]:
-    tree = ast.parse(content, filename=file_path)
+def _analyze_python(python_ast: ParsedPythonFile, file_path: str) -> list[AnalyzerFinding]:
+    tree = python_ast.tree
+    if tree is None:
+        return []
 
-    aliases = build_import_aliases(tree)
-    lines = content.splitlines()
+    aliases = python_ast.import_aliases
+    lines = python_ast.lines
     findings: list[AnalyzerFinding] = []
 
     def _emit(
@@ -241,6 +243,7 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
     """Parse Python files via AST and detect dangerous execution patterns."""
     components: list[str] = state.get("components") or []
     file_cache: dict[str, str] = state.get("file_cache") or {}
+    python_ast_cache_key = state.get("python_ast_cache_key")
     all_findings: list[Finding] = []
     ledger_events: list[InspectionLedgerEvent] = []
 
@@ -268,9 +271,8 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
                 observed_bytes=len(content.encode("utf-8")),
             )
         else:
-            try:
-                raw = _analyze_python(content, path)
-            except SyntaxError:
+            python_ast = get_python_ast(python_ast_cache_key, content, path)
+            if not python_ast.is_parseable:
                 event = ledger_event(
                     outcome=LedgerOutcome.SKIPPED,
                     phase="behavioral",
@@ -279,6 +281,7 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
                     reason=LedgerReason.SYNTAX_ERROR,
                 )
             else:
+                raw = _analyze_python(python_ast, path)
                 path_findings = [analyzer_finding_to_finding(af) for af in raw]
                 all_findings.extend(path_findings)
                 event = ledger_event(

--- a/src/skillspector/nodes/analyzers/behavioral_taint_tracking.py
+++ b/src/skillspector/nodes/analyzers/behavioral_taint_tracking.py
@@ -35,11 +35,11 @@ from skillspector.inspection_ledger import (
 )
 from skillspector.logging_config import get_logger
 from skillspector.models import AnalyzerFinding, Finding, Location, Severity
+from skillspector.python_ast import ParsedPythonFile, get_python_ast
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 from .common import (
     apply_import_aliases,
-    build_import_aliases,
     build_type_map,
     get_context_from_lines,
     get_source_segment,
@@ -325,12 +325,14 @@ def _find_tainted_in_expr(node: ast.expr, tainted: dict[str, _TaintedVar]) -> _T
     return None
 
 
-def _analyze_python(content: str, file_path: str) -> list[AnalyzerFinding]:
-    tree = ast.parse(content, filename=file_path)
+def _analyze_python(python_ast: ParsedPythonFile, file_path: str) -> list[AnalyzerFinding]:
+    tree = python_ast.tree
+    if tree is None:
+        return []
 
-    type_map = build_type_map(tree)
-    aliases = build_import_aliases(tree)
-    lines = content.splitlines()
+    aliases = python_ast.import_aliases
+    type_map = build_type_map(tree, aliases)
+    lines = python_ast.lines
     findings: list[AnalyzerFinding] = []
     tainted: dict[str, _TaintedVar] = {}
     seen: set[tuple[str, int]] = set()
@@ -428,6 +430,7 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
     """Parse Python files and detect source\u2192sink data flows."""
     components: list[str] = state.get("components") or []
     file_cache: dict[str, str] = state.get("file_cache") or {}
+    python_ast_cache_key = state.get("python_ast_cache_key")
     all_findings: list[Finding] = []
     ledger_events: list[InspectionLedgerEvent] = []
 
@@ -455,9 +458,8 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
                 observed_bytes=len(content.encode("utf-8")),
             )
         else:
-            try:
-                raw = _analyze_python(content, path)
-            except SyntaxError:
+            python_ast = get_python_ast(python_ast_cache_key, content, path)
+            if not python_ast.is_parseable:
                 event = ledger_event(
                     outcome=LedgerOutcome.SKIPPED,
                     phase="behavioral",
@@ -466,6 +468,7 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
                     reason=LedgerReason.SYNTAX_ERROR,
                 )
             else:
+                raw = _analyze_python(python_ast, path)
                 path_findings = [analyzer_finding_to_finding(af) for af in raw]
                 all_findings.extend(path_findings)
                 event = ledger_event(

--- a/src/skillspector/nodes/analyzers/common.py
+++ b/src/skillspector/nodes/analyzers/common.py
@@ -21,6 +21,7 @@ import ast
 from typing import Any
 
 from skillspector.models import Finding
+from skillspector.python_ast import build_import_aliases
 
 
 def make_dummy_finding(analyzer_id: str) -> Finding:
@@ -205,38 +206,9 @@ def resolve_dynamic_import_call(
     return f"{module_name}.{func.attr}"
 
 
-def _build_import_aliases(tree: ast.Module) -> dict[str, str]:
-    """Map locally imported names to their fully-qualified module paths.
-
-    ``from pathlib import Path`` → ``{"Path": "pathlib.Path"}``
-    ``import socket``           → ``{"socket": "socket"}``
-    ``import pathlib``          → ``{"pathlib": "pathlib"}``
-    """
-    aliases: dict[str, str] = {}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                local = alias.asname or alias.name
-                aliases[local] = alias.name
-        elif isinstance(node, ast.ImportFrom):
-            module = node.module or ""
-            for alias in node.names:
-                local = alias.asname or alias.name
-                aliases[local] = f"{module}.{alias.name}" if module else alias.name
-    return aliases
-
-
-def build_import_aliases(tree: ast.Module) -> dict[str, str]:
-    """Map locally bound names to their fully-qualified import paths.
-
-    Public entry point around the import scan already used by :func:`build_type_map`.
-    Callers pass the result to :func:`resolve_call_name` /
-    :func:`resolve_call_name_typed` to defeat import-alias evasion.
-    """
-    return _build_import_aliases(tree)
-
-
-def build_type_map(tree: ast.Module) -> dict[str, str]:
+def build_type_map(
+    tree: ast.Module, import_aliases: dict[str, str] | None = None
+) -> dict[str, str]:
     """Infer variable types from constructor calls.
 
     Scans assignments (``var = Type(...)``) and ``with`` statements
@@ -244,7 +216,7 @@ def build_type_map(tree: ast.Module) -> dict[str, str]:
     Import aliases are resolved so ``from pathlib import Path; p = Path(x)``
     maps ``p`` → ``"pathlib.Path"``.
     """
-    import_aliases = _build_import_aliases(tree)
+    import_aliases = build_import_aliases(tree) if import_aliases is None else import_aliases
     type_map: dict[str, str] = {}
 
     def _resolve_ctor(call_node: ast.Call) -> str | None:

--- a/src/skillspector/nodes/analyzers/static_patterns_data_exfiltration.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_data_exfiltration.py
@@ -242,8 +242,16 @@ def _analyze_python_environment_reads(
     for ast_node in ast.walk(tree):
         if isinstance(ast_node, ast.Call):
             call_name = resolve_call_name(ast_node, aliases)
-            if call_name == "os.environ.get" and ast_node.args:
-                if _is_sensitive_environment_key(ast_node.args[0]):
+            if call_name == "os.environ.get":
+                key = (
+                    ast_node.args[0]
+                    if ast_node.args
+                    else next(
+                        (keyword.value for keyword in ast_node.keywords if keyword.arg == "key"),
+                        None,
+                    )
+                )
+                if key is not None and _is_sensitive_environment_key(key):
                     emit(ast_node, 0.7)
                 continue
 

--- a/src/skillspector/nodes/analyzers/static_patterns_data_exfiltration.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_data_exfiltration.py
@@ -23,12 +23,12 @@ import sys
 
 from skillspector.logging_config import get_logger
 from skillspector.models import AnalyzerFinding, Location, Severity
+from skillspector.python_ast import ParsedPythonFile, parse_python_source
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 from . import static_runner
 from .common import (
     apply_import_aliases,
-    build_import_aliases,
     get_context,
     get_context_from_lines,
     get_line_number,
@@ -41,6 +41,7 @@ from .pattern_defaults import PatternCategory
 logger = get_logger(__name__)
 
 ANALYZER_ID = "static_patterns_data_exfiltration"
+USES_PYTHON_AST = True
 
 E1_PATTERNS = [
     (r"requests\s*\.\s*(?:post|put)\s*\(\s*['\"]https?://", 0.6),
@@ -189,7 +190,11 @@ def _is_dynamic_copy_call(call: ast.Call, aliases: dict[str, str]) -> bool:
     )
 
 
-def _analyze_python_environment_reads(content: str, file_path: str) -> list[AnalyzerFinding] | None:
+def _analyze_python_environment_reads(
+    content: str,
+    file_path: str,
+    python_ast: ParsedPythonFile | None = None,
+) -> list[AnalyzerFinding] | None:
     """Detect materializing or enumerating the complete ``os.environ`` mapping.
 
     A full mapping copy or enumeration is an environment-harvesting signal, unlike a
@@ -198,15 +203,17 @@ def _analyze_python_environment_reads(content: str, file_path: str) -> list[Anal
     import aliases.
 
     ``None`` means the source could not be parsed, so callers can retain the regex
-    fallback for malformed Python files.
+    fallback for malformed Python files.  Standalone callers parse through the
+    shared utility; graph scans pass the prewarmed result.
     """
-    try:
-        tree = ast.parse(content, filename=file_path)
-    except (SyntaxError, ValueError):
+    if python_ast is None:
+        python_ast = parse_python_source(content, file_path)
+    tree = python_ast.tree
+    if tree is None:
         return None
 
-    aliases = build_import_aliases(tree)
-    lines = content.splitlines()
+    aliases = python_ast.import_aliases
+    lines = python_ast.lines
     findings: list[AnalyzerFinding] = []
     emitted: set[int] = set()
     tag = [PatternCategory.DATA_EXFILTRATION.value]
@@ -284,7 +291,13 @@ def _analyze_python_environment_reads(content: str, file_path: str) -> list[Anal
     return findings
 
 
-def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFinding]:
+def analyze(
+    content: str,
+    file_path: str,
+    file_type: str,
+    *,
+    python_ast: ParsedPythonFile | None = None,
+) -> list[AnalyzerFinding]:
     """Analyze content for data exfiltration patterns (E1–E5)."""
     findings: list[AnalyzerFinding] = []
 
@@ -318,7 +331,7 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
             )
     e2_patterns = E2_PATTERNS
     if file_type == "python":
-        python_e2_findings = _analyze_python_environment_reads(content, file_path)
+        python_e2_findings = _analyze_python_environment_reads(content, file_path, python_ast)
         if python_e2_findings is None:
             logger.debug("Using E2 regex fallback for unparsable Python file: %s", file_path)
         else:

--- a/src/skillspector/nodes/analyzers/static_patterns_data_exfiltration.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_data_exfiltration.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import ast
 import re
 import sys
 
@@ -25,7 +26,16 @@ from skillspector.models import AnalyzerFinding, Location, Severity
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 from . import static_runner
-from .common import get_context, get_line_number, is_code_example
+from .common import (
+    apply_import_aliases,
+    build_import_aliases,
+    get_context,
+    get_context_from_lines,
+    get_line_number,
+    is_code_example,
+    resolve_call_name,
+    resolve_dotted_name,
+)
 from .pattern_defaults import PatternCategory
 
 logger = get_logger(__name__)
@@ -46,14 +56,18 @@ E1_PATTERNS = [
         0.7,
     ),
 ]
-E2_PATTERNS = [
-    (r"for\s+\w+\s*,\s*\w+\s+in\s+os\.environ\.items\(\)", 0.7),
+E2_PYTHON_FALLBACK_PATTERNS = [
+    (r"for\s+\w+\s*,\s*\w+\s+in\s+os\s*\.\s*environ\s*\.\s*items\s*\(\s*\)", 0.7),
     (
-        r"os\.environ\s*\[\s*['\"][^'\"]*(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)[^'\"]*['\"]\s*\]",
+        r"os\s*\.\s*environ\s*\[\s*['\"][^'\"]*(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)[^'\"]*['\"]\s*\]",
         0.8,
     ),
-    (r"os\.environ\.get\s*\([^)]*(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)", 0.7),
-    (r"os\.environ\s*\.\s*copy\s*\(\)", 0.6),
+    (r"os\s*\.\s*environ\s*\.\s*get\s*\([^)]*(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)", 0.7),
+    (r"os\s*\.\s*environ\s*\.\s*copy\s*\(\s*\)", 0.6),
+    (r"dict\s*\(\s*os\s*\.\s*environ\s*\)", 0.6),
+    (r"\{\s*\*\*\s*os\s*\.\s*environ\s*\}", 0.6),
+]
+E2_OTHER_PATTERNS = [
     (r"(?:API_KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)\s+in\s+(?:key|name|var)", 0.8),
     (r"process\.env\s*\[\s*['\"][^'\"]*(?:KEY|SECRET|TOKEN|PASSWORD)[^'\"]*['\"]\s*\]", 0.7),
     (r"Object\.keys\s*\(\s*process\.env\s*\)", 0.6),
@@ -62,6 +76,17 @@ E2_PATTERNS = [
     (r"collect\s+(?:all\s+)?(?:environment\s+variables?|env\s+vars?)", 0.7),
     (r"(?:extract|harvest|gather)\s+(?:api\s+)?keys?\s+from\s+environment", 0.8),
 ]
+E2_PATTERNS = E2_PYTHON_FALLBACK_PATTERNS + E2_OTHER_PATTERNS
+
+_ENVIRONMENT_MAPPING_METHOD_CONFIDENCE = {
+    "copy": 0.6,
+    "items": 0.7,
+    "keys": 0.6,
+    "values": 0.6,
+}
+_ENVIRONMENT_COLLECTION_CALLS = frozenset({"dict", "list", "tuple", "set", "frozenset"})
+_ENVIRONMENT_COPY_CALLS = frozenset({"copy.copy", "copy.deepcopy"})
+_SENSITIVE_ENV_KEY_PATTERN = re.compile(r"(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)", re.IGNORECASE)
 E3_PATTERNS = [
     (r"glob\s*\.\s*glob\s*\([^)]*(?:\.env|\.ssh|\.aws|\.config|credentials)", 0.8),
     (r"os\s*\.\s*walk\s*\([^)]*(?:home|~|/Users|/home)", 0.6),
@@ -119,6 +144,146 @@ E5_PATTERNS = [
 ]
 
 
+def _resolve_expression_name(node: ast.expr, aliases: dict[str, str]) -> str | None:
+    """Resolve a Python expression to its import-normalized dotted name."""
+    name = resolve_dotted_name(node)
+    return apply_import_aliases(name, aliases) if name is not None else None
+
+
+def _is_os_environ_reference(node: ast.expr, aliases: dict[str, str]) -> bool:
+    """Return whether *node* is ``os.environ``, including imported aliases."""
+    return _resolve_expression_name(node, aliases) == "os.environ"
+
+
+def _is_sensitive_environment_key(node: ast.expr) -> bool:
+    """Return whether a literal environment key looks credential-like."""
+    return (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and _SENSITIVE_ENV_KEY_PATTERN.search(node.value) is not None
+    )
+
+
+def _has_direct_environ_argument(call: ast.Call, aliases: dict[str, str]) -> bool:
+    """Return whether a call receives ``os.environ`` directly, not via a lookup."""
+    return any(_is_os_environ_reference(arg, aliases) for arg in call.args) or any(
+        keyword.arg is None and _is_os_environ_reference(keyword.value, aliases)
+        for keyword in call.keywords
+    )
+
+
+def _is_dynamic_copy_call(call: ast.Call, aliases: dict[str, str]) -> bool:
+    """Recognize ``__import__('copy').copy(...)`` without broad call matching."""
+    func = call.func
+    if not isinstance(func, ast.Attribute) or func.attr not in {"copy", "deepcopy"}:
+        return False
+    if (
+        not isinstance(func.value, ast.Call)
+        or resolve_call_name(func.value, aliases) != "__import__"
+    ):
+        return False
+    return (
+        bool(func.value.args)
+        and isinstance(func.value.args[0], ast.Constant)
+        and func.value.args[0].value == "copy"
+    )
+
+
+def _analyze_python_environment_reads(content: str, file_path: str) -> list[AnalyzerFinding] | None:
+    """Detect materializing or enumerating the complete ``os.environ`` mapping.
+
+    A full mapping copy or enumeration is an environment-harvesting signal, unlike a
+    single-key lookup or passing ``os.environ`` through to a child process. AST parsing
+    makes the check insensitive to formatting and lets it resolve ``os`` / ``environ``
+    import aliases.
+
+    ``None`` means the source could not be parsed, so callers can retain the regex
+    fallback for malformed Python files.
+    """
+    try:
+        tree = ast.parse(content, filename=file_path)
+    except (SyntaxError, ValueError):
+        return None
+
+    aliases = build_import_aliases(tree)
+    lines = content.splitlines()
+    findings: list[AnalyzerFinding] = []
+    emitted: set[int] = set()
+    tag = [PatternCategory.DATA_EXFILTRATION.value]
+
+    def emit(node: ast.AST, confidence: float) -> None:
+        node_id = id(node)
+        if node_id in emitted:
+            return
+        emitted.add(node_id)
+        lineno = getattr(node, "lineno", 1)
+        end_lineno = getattr(node, "end_lineno", None)
+        matched_text = ast.get_source_segment(content, node)
+        findings.append(
+            AnalyzerFinding(
+                rule_id="E2",
+                message="Env Variable Harvesting",
+                severity=Severity.HIGH,
+                location=Location(file=file_path, start_line=lineno, end_line=end_lineno),
+                confidence=confidence,
+                tags=tag,
+                context=get_context_from_lines(lines, lineno),
+                matched_text=(matched_text or "os.environ")[:200],
+            )
+        )
+
+    for ast_node in ast.walk(tree):
+        if isinstance(ast_node, ast.Call):
+            call_name = resolve_call_name(ast_node, aliases)
+            if call_name == "os.environ.get" and ast_node.args:
+                if _is_sensitive_environment_key(ast_node.args[0]):
+                    emit(ast_node, 0.7)
+                continue
+
+            if call_name is not None:
+                method = call_name.rpartition(".")[2]
+                if (
+                    call_name.startswith("os.environ.")
+                    and method in _ENVIRONMENT_MAPPING_METHOD_CONFIDENCE
+                ):
+                    emit(ast_node, _ENVIRONMENT_MAPPING_METHOD_CONFIDENCE[method])
+                    continue
+                if call_name in _ENVIRONMENT_COLLECTION_CALLS and _has_direct_environ_argument(
+                    ast_node, aliases
+                ):
+                    emit(ast_node, 0.6)
+                    continue
+                if call_name in _ENVIRONMENT_COPY_CALLS and _has_direct_environ_argument(
+                    ast_node, aliases
+                ):
+                    emit(ast_node, 0.6)
+                    continue
+
+            if _is_dynamic_copy_call(ast_node, aliases) and _has_direct_environ_argument(
+                ast_node, aliases
+            ):
+                emit(ast_node, 0.6)
+
+        elif isinstance(ast_node, ast.Subscript):
+            if _is_os_environ_reference(ast_node.value, aliases) and _is_sensitive_environment_key(
+                ast_node.slice
+            ):
+                emit(ast_node, 0.8)
+
+        elif isinstance(ast_node, ast.Dict):
+            if any(
+                key is None and _is_os_environ_reference(value, aliases)
+                for key, value in zip(ast_node.keys, ast_node.values, strict=True)
+            ):
+                emit(ast_node, 0.6)
+
+        elif isinstance(ast_node, (ast.For, ast.AsyncFor, ast.comprehension)):
+            if _is_os_environ_reference(ast_node.iter, aliases):
+                emit(ast_node.iter, 0.7)
+
+    return findings
+
+
 def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFinding]:
     """Analyze content for data exfiltration patterns (E1–E5)."""
     findings: list[AnalyzerFinding] = []
@@ -151,7 +316,16 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
                     matched_text=match.group(0)[:200],
                 )
             )
-    for pattern, confidence in E2_PATTERNS:
+    e2_patterns = E2_PATTERNS
+    if file_type == "python":
+        python_e2_findings = _analyze_python_environment_reads(content, file_path)
+        if python_e2_findings is None:
+            logger.debug("Using E2 regex fallback for unparsable Python file: %s", file_path)
+        else:
+            findings.extend(python_e2_findings)
+            e2_patterns = E2_OTHER_PATTERNS
+
+    for pattern, confidence in e2_patterns:
         for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
             line_num = get_line_number(content, match.start())
             findings.append(

--- a/src/skillspector/nodes/analyzers/static_patterns_output_handling.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_output_handling.py
@@ -30,11 +30,11 @@ import sys
 
 from skillspector.logging_config import get_logger
 from skillspector.models import AnalyzerFinding, Location, Severity
+from skillspector.python_ast import ParsedPythonFile, parse_python_source
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 from . import static_runner
 from .common import (
-    build_import_aliases,
     get_context,
     get_context_from_lines,
     get_line_number,
@@ -47,6 +47,7 @@ from .pattern_defaults import PatternCategory
 logger = get_logger(__name__)
 
 ANALYZER_ID = "static_patterns_output_handling"
+USES_PYTHON_AST = True
 
 _SUBPROCESS_OUTPUT_NAMES = frozenset(
     {"response", "output", "result", "answer", "completion", "reply", "generated"}
@@ -210,18 +211,22 @@ def _analyze_subprocess_fallback(
 
 
 def _analyze_python_subprocess_calls(
-    content: str, file_path: str, tag: list[str]
+    content: str,
+    file_path: str,
+    tag: list[str],
+    python_ast: ParsedPythonFile | None = None,
 ) -> list[AnalyzerFinding]:
     """Detect output-like values used as Python subprocess command arguments."""
-    try:
-        tree = ast.parse(content, filename=file_path)
-    except SyntaxError:
+    if python_ast is None:
+        python_ast = parse_python_source(content, file_path)
+    tree = python_ast.tree
+    if tree is None:
         # Static pattern analysis also runs over partial/generated Python files.
         # Retain best-effort subprocess coverage without failing the analyzer.
         return _analyze_subprocess_fallback(content, file_path, tag)
 
-    aliases = build_import_aliases(tree)
-    lines = content.splitlines()
+    aliases = python_ast.import_aliases
+    lines = python_ast.lines
     findings: list[AnalyzerFinding] = []
 
     for node in ast.walk(tree):
@@ -261,7 +266,13 @@ def _analyze_python_subprocess_calls(
     return findings
 
 
-def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFinding]:
+def analyze(
+    content: str,
+    file_path: str,
+    file_type: str,
+    *,
+    python_ast: ParsedPythonFile | None = None,
+) -> list[AnalyzerFinding]:
     """Analyze content for output handling patterns (OH1–OH3)."""
     findings: list[AnalyzerFinding] = []
 
@@ -294,7 +305,7 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
                 )
             )
     if file_type == "python":
-        subprocess_findings = _analyze_python_subprocess_calls(content, file_path, tag)
+        subprocess_findings = _analyze_python_subprocess_calls(content, file_path, tag, python_ast)
     else:
         # Other file types can contain embedded Python snippets, so preserve the
         # analyzer's previous best-effort subprocess coverage for those files.

--- a/src/skillspector/nodes/analyzers/static_runner.py
+++ b/src/skillspector/nodes/analyzers/static_runner.py
@@ -30,6 +30,11 @@ from skillspector.inspection_ledger import (
 )
 from skillspector.logging_config import get_logger
 from skillspector.models import AnalyzerFinding, Finding
+from skillspector.python_ast import (
+    MAX_PYTHON_AST_SOURCE_CHARS,
+    ParsedPythonFile,
+    get_python_ast,
+)
 from skillspector.state import AnalyzerNodeResponse
 
 from .common import is_code_example
@@ -57,7 +62,7 @@ FILE_TYPES: dict[str, str] = {
     ".rs": "rust",
 }
 
-MAX_FILE_CHARS = 1_000_000
+MAX_FILE_CHARS = MAX_PYTHON_AST_SOURCE_CHARS
 _EVAL_DATASET_FILES = {
     "evals/evals.json",
     "evals/evals.jsonl",
@@ -308,14 +313,36 @@ def analyzer_finding_to_finding(
     )
 
 
-def _scan_path(path: str, content: str, pattern_modules: list) -> list[Finding]:
+def _uses_python_ast(module: object) -> bool:
+    """Return whether a pattern module explicitly opts into the shared AST hook."""
+    return getattr(module, "USES_PYTHON_AST", False) is True
+
+
+def _scan_path(
+    path: str,
+    content: str,
+    pattern_modules: list,
+    python_ast_cache_key: str | None = None,
+) -> list[Finding]:
     """Run pattern modules for one already-applicable file path."""
     findings: list[Finding] = []
     file_type = _infer_file_type(path)
     is_doc_markdown = _is_documentation_markdown(path)
     is_non_executable = file_type in _NON_EXECUTABLE_FILE_TYPES
+    python_ast: ParsedPythonFile | None = None
+    if file_type == "python" and any(_uses_python_ast(module) for module in pattern_modules):
+        python_ast = get_python_ast(python_ast_cache_key, content, path)
+
     for module in pattern_modules:
-        raw = module.analyze(content=content, file_path=path, file_type=file_type)
+        if file_type == "python" and _uses_python_ast(module):
+            raw = module.analyze(
+                content=content,
+                file_path=path,
+                file_type=file_type,
+                python_ast=python_ast,
+            )
+        else:
+            raw = module.analyze(content=content, file_path=path, file_type=file_type)
         for af in raw:
             if _is_env_file_reference_in_docs(af, file_type, path, content):
                 logger.debug(
@@ -372,6 +399,7 @@ def run_static_patterns(
     """
     components = cast(list[str], state.get("components") or [])
     file_cache = cast(dict[str, str], state.get("file_cache") or {})
+    python_ast_cache_key = cast(str | None, state.get("python_ast_cache_key"))
     findings: list[Finding] = []
 
     for path in components:
@@ -393,7 +421,7 @@ def run_static_patterns(
         if _is_binary_file(path, content):
             logger.debug("Skipping binary file: %s", path)
             continue
-        findings.extend(_scan_path(path, content, pattern_modules))
+        findings.extend(_scan_path(path, content, pattern_modules, python_ast_cache_key))
 
     return findings
 
@@ -406,6 +434,7 @@ def run_static_patterns_with_ledger(
     analyzer_id = str(getattr(pattern_modules[0], "ANALYZER_ID", "static_patterns"))
     components = cast(list[str], state.get("components") or [])
     file_cache = cast(dict[str, str], state.get("file_cache") or {})
+    python_ast_cache_key = cast(str | None, state.get("python_ast_cache_key"))
     findings: list[Finding] = []
     events: list[InspectionLedgerEvent] = []
 
@@ -449,7 +478,7 @@ def run_static_patterns_with_ledger(
                 )
             else:
                 try:
-                    path_findings = _scan_path(path, content, pattern_modules)
+                    path_findings = _scan_path(path, content, pattern_modules, python_ast_cache_key)
                 except Exception as exc:
                     logger.warning("%s: scan error on %s: %s", analyzer_id, path, exc)
                     event = ledger_event(

--- a/src/skillspector/nodes/build_context.py
+++ b/src/skillspector/nodes/build_context.py
@@ -40,6 +40,7 @@ from skillspector.inspection_ledger import (
     ledger_event,
 )
 from skillspector.logging_config import get_logger
+from skillspector.python_ast import prewarm_python_ast_cache
 from skillspector.state import SkillspectorState
 
 logger = get_logger(__name__)
@@ -428,6 +429,7 @@ def build_context(state: SkillspectorState) -> dict[str, object]:
         for path in sorted(recognized_oms_signatures)
     ]
     file_cache, cache_events = _read_file_cache(skill_dir, components)
+    python_ast_cache_key = prewarm_python_ast_cache(components, file_cache)
     manifest = _parse_manifest(skill_dir)
     component_metadata, has_executable_scripts = _build_component_metadata(
         skill_dir, inventoried_components, file_cache, recognized_oms_signatures
@@ -438,6 +440,7 @@ def build_context(state: SkillspectorState) -> dict[str, object]:
         "file_cache": file_cache,
         "inspection_ledger": [*discovery_events, *signature_events, *cache_events],
         "ast_cache": {},
+        "python_ast_cache_key": python_ast_cache_key,
         "manifest": manifest,
         "previous_manifest": None,
         "model_config": build_model_config(),

--- a/src/skillspector/nodes/report.py
+++ b/src/skillspector/nodes/report.py
@@ -40,6 +40,7 @@ from skillspector.llm_utils import is_llm_available
 from skillspector.logging_config import get_logger
 from skillspector.models import Finding
 from skillspector.nodes.deduplicate import deduplicate
+from skillspector.python_ast import clear_python_ast_cache
 from skillspector.sarif_models import (
     SARIF_SCHEMA_URI,
     SarifArtifactLocation,
@@ -850,6 +851,7 @@ def report(state: SkillspectorState) -> dict[str, object]:
     Finalization owns completeness derivation. The report node only selects the
     validated finding IDs, applies baseline suppression, and renders all surfaces.
     """
+    clear_python_ast_cache(state.get("python_ast_cache_key"))
     raw_findings = state.get("findings", [])
     findings_by_id = {finding.finding_id: finding for finding in raw_findings}
     effective_ids = state.get("effective_finding_ids")

--- a/src/skillspector/python_ast.py
+++ b/src/skillspector/python_ast.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared, per-scan Python AST parsing and import-alias metadata.
+
+The graph prewarms this module's cache before its analyzer branches fan out.
+Consumers must treat returned ASTs as read-only; keeping parsing, syntax-error
+handling, and import aliases together lets later scope-aware resolution extend
+one stable interface.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import OrderedDict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from threading import RLock
+from uuid import uuid4
+
+# Keep this in sync with the existing static-analyzer size gate.  It lives here
+# so prewarming does not parse files that AST consumers will skip anyway.
+MAX_PYTHON_AST_SOURCE_CHARS = 1_000_000
+# AST nodes can be substantially larger than their source.  Limit the total
+# source retained as parsed trees for any one scan; files beyond this budget
+# use the existing on-demand behavior rather than retaining unbounded memory.
+MAX_PYTHON_AST_CACHE_SOURCE_CHARS = 8_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedPythonFile:
+    """One Python source file's shared parse result and import aliases.
+
+    ``tree`` is ``None`` when parsing failed.  The failed result is cached just
+    like a successful one so every consumer can apply its own fallback policy
+    without reparsing the same malformed source.
+    """
+
+    tree: ast.Module | None
+    import_aliases: dict[str, str]
+    lines: list[str]
+    content: str
+    parse_error: str | None = None
+
+    @property
+    def is_parseable(self) -> bool:
+        """Return whether this result contains a usable Python AST."""
+        return self.tree is not None
+
+
+PythonAstCache = dict[str, ParsedPythonFile]
+
+
+@dataclass(slots=True)
+class _RuntimePythonAstCache:
+    """Per-scan LRU of parsed files with an aggregate source-size budget."""
+
+    entries: OrderedDict[str, ParsedPythonFile]
+    source_characters: int = 0
+
+
+# AST nodes are intentionally kept outside LangGraph state: ``ast.Module`` is
+# not checkpoint-serializable.  State carries a UUID cache key, while this
+# process-local registry keeps one scan's parsed trees available to all of its
+# parallel analyzer branches.  Completed scans release their entry in report.
+_MAX_RUNTIME_AST_CACHES = 32
+_runtime_ast_caches: OrderedDict[str, _RuntimePythonAstCache] = OrderedDict()
+_runtime_ast_cache_lock = RLock()
+
+
+def _remember_runtime_ast_cache(cache_key: str, cache: _RuntimePythonAstCache) -> None:
+    """Store a cache under the lock and bound abandoned scan entries."""
+    _runtime_ast_caches[cache_key] = cache
+    _runtime_ast_caches.move_to_end(cache_key)
+    while len(_runtime_ast_caches) > _MAX_RUNTIME_AST_CACHES:
+        _runtime_ast_caches.popitem(last=False)
+
+
+def _cache_runtime_entry(
+    cache: _RuntimePythonAstCache, filename: str, parsed: ParsedPythonFile
+) -> None:
+    """Store one parsed source, evicting least-recent entries to stay bounded."""
+    old = cache.entries.pop(filename, None)
+    if old is not None:
+        cache.source_characters -= len(old.content)
+
+    source_characters = len(parsed.content)
+    if source_characters > MAX_PYTHON_AST_CACHE_SOURCE_CHARS:
+        return
+    while (
+        cache.entries
+        and cache.source_characters + source_characters > MAX_PYTHON_AST_CACHE_SOURCE_CHARS
+    ):
+        _, evicted = cache.entries.popitem(last=False)
+        cache.source_characters -= len(evicted.content)
+    if cache.source_characters + source_characters <= MAX_PYTHON_AST_CACHE_SOURCE_CHARS:
+        cache.entries[filename] = parsed
+        cache.source_characters += source_characters
+
+
+def build_import_aliases(tree: ast.Module) -> dict[str, str]:
+    """Map locally bound names to their fully-qualified import paths.
+
+    ``from pathlib import Path`` becomes ``{"Path": "pathlib.Path"}``, while
+    ``import pathlib as pl`` becomes ``{"pl": "pathlib"}``.
+    """
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local = alias.asname or alias.name
+                aliases[local] = alias.name
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                local = alias.asname or alias.name
+                aliases[local] = f"{module}.{alias.name}" if module else alias.name
+    return aliases
+
+
+def parse_python_source(content: str, filename: str) -> ParsedPythonFile:
+    """Parse *content* once and retain its aliases or a structured parse failure."""
+    lines = content.splitlines()
+    try:
+        tree = ast.parse(content, filename=filename)
+    except (SyntaxError, ValueError, RecursionError) as exc:
+        return ParsedPythonFile(
+            tree=None,
+            import_aliases={},
+            lines=lines,
+            content=content,
+            parse_error=type(exc).__name__,
+        )
+    return ParsedPythonFile(
+        tree=tree,
+        import_aliases=build_import_aliases(tree),
+        lines=lines,
+        content=content,
+    )
+
+
+def build_python_ast_cache(
+    components: Iterable[str],
+    file_cache: Mapping[str, str],
+    *,
+    max_source_chars: int = MAX_PYTHON_AST_SOURCE_CHARS,
+    max_cache_source_chars: int = MAX_PYTHON_AST_CACHE_SOURCE_CHARS,
+) -> PythonAstCache:
+    """Preparse eligible Python files within one scan's aggregate cache budget."""
+    cache: PythonAstCache = {}
+    source_characters = 0
+    for path in components:
+        if not path.lower().endswith(".py"):
+            continue
+        content = file_cache.get(path)
+        if (
+            content is None
+            or len(content) > max_source_chars
+            or source_characters + len(content) > max_cache_source_chars
+        ):
+            continue
+        cache[path] = parse_python_source(content, path)
+        source_characters += len(content)
+    return cache
+
+
+def prewarm_python_ast_cache(
+    components: Iterable[str],
+    file_cache: Mapping[str, str],
+    *,
+    max_source_chars: int = MAX_PYTHON_AST_SOURCE_CHARS,
+    max_cache_source_chars: int = MAX_PYTHON_AST_CACHE_SOURCE_CHARS,
+) -> str | None:
+    """Preparse one scan's eligible Python files and return its runtime cache key."""
+    cache = build_python_ast_cache(
+        components,
+        file_cache,
+        max_source_chars=max_source_chars,
+        max_cache_source_chars=max_cache_source_chars,
+    )
+    if not cache:
+        return None
+
+    cache_key = uuid4().hex
+    with _runtime_ast_cache_lock:
+        _remember_runtime_ast_cache(
+            cache_key,
+            _RuntimePythonAstCache(
+                entries=OrderedDict(cache.items()),
+                source_characters=sum(len(parsed.content) for parsed in cache.values()),
+            ),
+        )
+    return cache_key
+
+
+def get_python_ast(cache_key: str | None, content: str, filename: str) -> ParsedPythonFile:
+    """Return a scan's prewarmed result, or parse for standalone analyzer use.
+
+    If a checkpoint resumes in a new process, the cache key has no registry
+    entry.  The lock recreates and fills it once per source before parallel
+    analyzer branches can observe it.
+    """
+    if cache_key is None:
+        return parse_python_source(content, filename)
+
+    with _runtime_ast_cache_lock:
+        cache = _runtime_ast_caches.get(cache_key)
+        if cache is None:
+            cache = _RuntimePythonAstCache(entries=OrderedDict())
+            _remember_runtime_ast_cache(cache_key, cache)
+        else:
+            _runtime_ast_caches.move_to_end(cache_key)
+        cached = cache.entries.get(filename)
+        if cached is not None and cached.content == content:
+            cache.entries.move_to_end(filename)
+            return cached
+        parsed = parse_python_source(content, filename)
+        _cache_runtime_entry(cache, filename, parsed)
+        return parsed
+
+
+def clear_python_ast_cache(cache_key: str | None) -> None:
+    """Release one scan's process-local parsed trees after its analyzer phase."""
+    if cache_key is None:
+        return
+    with _runtime_ast_cache_lock:
+        _runtime_ast_caches.pop(cache_key, None)

--- a/src/skillspector/state.py
+++ b/src/skillspector/state.py
@@ -58,7 +58,11 @@ class SkillspectorState(TypedDict, total=False):
     # build_context node populates these
     components: list[str]
     file_cache: dict[str, str]
+    # Retained for compatibility with the persisted workflow-state schema.
     ast_cache: dict[str, str]
+    # Key for the process-local parsed-AST cache.  The ASTs themselves stay
+    # outside state because they are not checkpoint-serializable.
+    python_ast_cache_key: str | None
     manifest: dict[str, object]
     previous_manifest: dict[str, object] | None
 

--- a/tests/nodes/analyzers/test_shared_python_ast.py
+++ b/tests/nodes/analyzers/test_shared_python_ast.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for the shared AST cache across analyzer consumers."""
+
+from __future__ import annotations
+
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+import skillspector.python_ast as python_ast
+from skillspector.graph import graph
+from skillspector.nodes.analyzers import (
+    behavioral_ast,
+    behavioral_taint_tracking,
+    static_patterns_data_exfiltration,
+    static_patterns_output_handling,
+)
+from skillspector.nodes.build_context import build_context
+from skillspector.python_ast import ParsedPythonFile, get_python_ast
+
+
+def test_preparsed_python_is_reused_by_all_ast_analyzers(tmp_path, monkeypatch) -> None:
+    """One scan parses each eligible Python file once before analyzer fan-out."""
+    (tmp_path / "script.py").write_text(
+        "import os\n"
+        "import subprocess\n"
+        "payload = input()\n"
+        "environment = os.environ.copy()\n"
+        "subprocess.run(output)\n"
+        "exec(payload)\n",
+        encoding="utf-8",
+    )
+    original_parse = python_ast.ast.parse
+    parse_calls = 0
+
+    def count_parse(*args, **kwargs):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse(*args, **kwargs)
+
+    monkeypatch.setattr(python_ast.ast, "parse", count_parse)
+    state = build_context({"skill_path": str(tmp_path)})
+
+    python_ast_cache_key = state["python_ast_cache_key"]
+    assert isinstance(python_ast_cache_key, str)
+    parsed = get_python_ast(
+        python_ast_cache_key,
+        state["file_cache"]["script.py"],
+        "script.py",
+    )
+    assert isinstance(parsed, ParsedPythonFile)
+    assert parsed.is_parseable
+    assert parse_calls == 1
+
+    data_findings = static_patterns_data_exfiltration.node(state)["findings"]
+    output_findings = static_patterns_output_handling.node(state)["findings"]
+    ast_findings = behavioral_ast.node(state)["findings"]
+    taint_findings = behavioral_taint_tracking.node(state)["findings"]
+
+    assert any(finding.rule_id == "E2" for finding in data_findings)
+    assert any(finding.rule_id == "OH1" for finding in output_findings)
+    assert any(finding.rule_id == "AST1" for finding in ast_findings)
+    assert any(finding.rule_id == "TT5" for finding in taint_findings)
+    assert parse_calls == 1
+
+
+def test_uppercase_python_path_reuses_preparsed_ast_for_static_analyzers(
+    tmp_path, monkeypatch
+) -> None:
+    """Static Python inference and cache eligibility use the same case handling."""
+    (tmp_path / "script.PY").write_text(
+        "import os\nimport subprocess\nos.environ.copy()\nsubprocess.run(output)\n",
+        encoding="utf-8",
+    )
+    original_parse = python_ast.ast.parse
+    parse_calls = 0
+
+    def count_parse(*args, **kwargs):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse(*args, **kwargs)
+
+    monkeypatch.setattr(python_ast.ast, "parse", count_parse)
+    state = build_context({"skill_path": str(tmp_path)})
+
+    data_findings = static_patterns_data_exfiltration.node(state)["findings"]
+    output_findings = static_patterns_output_handling.node(state)["findings"]
+
+    assert any(finding.rule_id == "E2" for finding in data_findings)
+    assert any(finding.rule_id == "OH1" for finding in output_findings)
+    assert parse_calls == 1
+
+
+def test_graph_scan_parses_python_once_before_parallel_analyzers(tmp_path, monkeypatch) -> None:
+    """The runtime cache shares one parse across the graph's analyzer fan-out."""
+    (tmp_path / "script.py").write_text(
+        "import os\n"
+        "import subprocess\n"
+        "payload = input()\n"
+        "environment = os.environ.copy()\n"
+        "subprocess.run(output)\n"
+        "exec(payload)\n",
+        encoding="utf-8",
+    )
+    original_parse = python_ast.ast.parse
+    parse_calls = 0
+
+    def count_parse(*args, **kwargs):
+        nonlocal parse_calls
+        parse_calls += 1
+        return original_parse(*args, **kwargs)
+
+    monkeypatch.setattr(python_ast.ast, "parse", count_parse)
+
+    result = graph.invoke({"skill_path": str(tmp_path), "use_llm": False})
+
+    assert {"E2", "OH1", "AST1", "TT5"} <= {finding.rule_id for finding in result["findings"]}
+    assert parse_calls == 1
+    assert JsonPlusSerializer().dumps_typed(result)

--- a/tests/nodes/test_build_context.py
+++ b/tests/nodes/test_build_context.py
@@ -26,10 +26,12 @@ import os
 from pathlib import Path
 
 import pytest
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 
 from skillspector.constants import MODEL_CONFIG
 from skillspector.nodes.build_context import build_context
 from skillspector.providers import reset_provider, use_provider
+from skillspector.python_ast import ParsedPythonFile, get_python_ast
 from skillspector.state import SkillspectorState
 
 _OMS_FIXTURE = Path(__file__).parents[1] / "fixtures" / "oms" / "mcore-split-pr.skill.oms.sig"
@@ -90,7 +92,16 @@ def test_build_context_real_directory_with_skill_md(tmp_path: Path) -> None:
         "allowed-tools": [],
         "parameters": [],
     }
-    assert result["ast_cache"] == {}
+    python_ast_cache_key = result["python_ast_cache_key"]
+    assert isinstance(python_ast_cache_key, str)
+    parsed_python = get_python_ast(
+        python_ast_cache_key,
+        result["file_cache"]["scripts/run.py"],
+        "scripts/run.py",
+    )
+    assert isinstance(parsed_python, ParsedPythonFile)
+    assert parsed_python.is_parseable
+    assert parsed_python.tree is not None
     assert result["previous_manifest"] is None
     assert "component_metadata" in result
     assert isinstance(result["component_metadata"], list)
@@ -104,6 +115,27 @@ def test_build_context_real_directory_with_skill_md(tmp_path: Path) -> None:
     assert run_py_meta.get("lines") == 1
     assert "has_executable_scripts" in result
     assert result["has_executable_scripts"] is True
+
+
+def test_build_context_ast_cache_skips_oversized_python(tmp_path: Path) -> None:
+    """Prewarming respects the same source-size limit as AST analyzers."""
+    from skillspector.python_ast import MAX_PYTHON_AST_SOURCE_CHARS
+
+    (tmp_path / "oversized.py").write_text("x = 1\n" + "#" * MAX_PYTHON_AST_SOURCE_CHARS)
+
+    result = build_context({"skill_path": str(tmp_path)})
+
+    assert result["python_ast_cache_key"] is None
+
+
+def test_build_context_ast_cache_handle_is_checkpoint_serializable(tmp_path: Path) -> None:
+    """Raw AST objects remain in runtime storage, not checkpointed graph state."""
+    (tmp_path / "script.py").write_text("import os\n", encoding="utf-8")
+
+    result = build_context({"skill_path": str(tmp_path)})
+
+    serializer = JsonPlusSerializer()
+    assert serializer.dumps_typed(result)
 
 
 def test_build_context_missing_skill_path() -> None:

--- a/tests/test_python_ast.py
+++ b/tests/test_python_ast.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared Python AST parsing utility."""
+
+from __future__ import annotations
+
+import skillspector.python_ast as python_ast
+from skillspector.python_ast import (
+    build_python_ast_cache,
+    clear_python_ast_cache,
+    get_python_ast,
+    parse_python_source,
+    prewarm_python_ast_cache,
+)
+
+
+def test_parse_python_source_exposes_import_aliases() -> None:
+    parsed = parse_python_source(
+        "import os as operating_system\nfrom subprocess import run\n", "script.py"
+    )
+
+    assert parsed.is_parseable
+    assert parsed.tree is not None
+    assert parsed.import_aliases == {
+        "operating_system": "os",
+        "run": "subprocess.run",
+    }
+    assert parsed.lines == ["import os as operating_system", "from subprocess import run"]
+    assert parsed.content == "import os as operating_system\nfrom subprocess import run\n"
+
+
+def test_parse_python_source_retains_syntax_error_result() -> None:
+    parsed = parse_python_source("def broken(\n", "broken.py")
+
+    assert not parsed.is_parseable
+    assert parsed.tree is None
+    assert parsed.import_aliases == {}
+    assert parsed.parse_error == "SyntaxError"
+
+
+def test_parse_python_source_retains_value_error_result(monkeypatch) -> None:
+    def raise_value_error(*args, **kwargs):
+        raise ValueError("invalid source")
+
+    monkeypatch.setattr(python_ast.ast, "parse", raise_value_error)
+
+    parsed = parse_python_source("x = 1\n", "broken.py")
+
+    assert not parsed.is_parseable
+    assert parsed.parse_error == "ValueError"
+
+
+def test_parse_python_source_retains_recursion_error_result(monkeypatch) -> None:
+    def raise_recursion_error(*args, **kwargs):
+        raise RecursionError("expression is too deep")
+
+    monkeypatch.setattr(python_ast.ast, "parse", raise_recursion_error)
+
+    parsed = parse_python_source("x = 1\n", "deep.py")
+
+    assert not parsed.is_parseable
+    assert parsed.parse_error == "RecursionError"
+
+
+def test_build_python_ast_cache_caches_failures_and_skips_oversized_files() -> None:
+    cache = build_python_ast_cache(
+        ["valid.py", "uppercase.PY", "broken.py", "oversized.py", "readme.md"],
+        {
+            "valid.py": "x = 1\n",
+            "uppercase.PY": "x = 2\n",
+            "broken.py": "def bad(\n",
+            "oversized.py": "x" * 11,
+            "readme.md": "not Python",
+        },
+        max_source_chars=10,
+    )
+
+    assert set(cache) == {"valid.py", "uppercase.PY", "broken.py"}
+    assert cache["valid.py"].is_parseable
+    assert cache["uppercase.PY"].is_parseable
+    assert not cache["broken.py"].is_parseable
+
+
+def test_build_python_ast_cache_respects_aggregate_source_budget() -> None:
+    cache = build_python_ast_cache(
+        ["first.py", "second.py"],
+        {
+            "first.py": "x = 1\n",
+            "second.py": "x = 2\n",
+        },
+        max_cache_source_chars=8,
+    )
+
+    assert set(cache) == {"first.py"}
+
+
+def test_get_python_ast_reparses_when_cached_source_changes() -> None:
+    cache_key = prewarm_python_ast_cache(["script.py"], {"script.py": "import os as old_name\n"})
+    assert cache_key is not None
+
+    parsed = get_python_ast(cache_key, "import os as new_name\n", "script.py")
+
+    assert parsed.import_aliases == {"new_name": "os"}
+    clear_python_ast_cache(cache_key)
+
+
+def test_runtime_ast_cache_registry_is_bounded_for_checkpoint_cache_misses() -> None:
+    cache_keys = [
+        f"resumed-scan-{index}" for index in range(python_ast._MAX_RUNTIME_AST_CACHES + 5)
+    ]
+
+    for cache_key in cache_keys:
+        get_python_ast(cache_key, "x = 1\n", "script.py")
+
+    assert len(python_ast._runtime_ast_caches) <= python_ast._MAX_RUNTIME_AST_CACHES
+
+    for cache_key in cache_keys:
+        clear_python_ast_cache(cache_key)

--- a/tests/unit/test_patterns.py
+++ b/tests/unit/test_patterns.py
@@ -150,12 +150,16 @@ for key, val in os.environ.items():
         assert len(findings) >= 1
         assert any(f.rule_id == "E2" for f in findings)
 
-    def test_e2_env_get_secret(self) -> None:
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            'os.environ.get("OPENAI_API_KEY")',
+            'os.environ.get(key="OPENAI_API_KEY")',
+        ],
+    )
+    def test_e2_env_get_secret(self, expression: str) -> None:
         """Detection of specific secret access."""
-        content = """
-import os
-api_key = os.environ.get("OPENAI_API_KEY")
-"""
+        content = f"import os\napi_key = {expression}\n"
         findings = data_exfiltration_module.analyze(content, "script.py", "python")
         assert len(findings) >= 1
         assert any(f.rule_id == "E2" for f in findings)
@@ -214,6 +218,7 @@ api_key = os.environ.get("OPENAI_API_KEY")
         [
             'os.environ["PATH"]',
             'os.environ.get("PATH")',
+            'os.environ.get(key="PATH", default="API_KEY")',
             "os.environ.copy",
             "2 ** os.environ",
             "subprocess.run(command, env=os.environ, check=False)",

--- a/tests/unit/test_patterns.py
+++ b/tests/unit/test_patterns.py
@@ -160,6 +160,14 @@ api_key = os.environ.get("OPENAI_API_KEY")
         assert len(findings) >= 1
         assert any(f.rule_id == "E2" for f in findings)
 
+    def test_e2_unparseable_python_uses_regex_fallback(self) -> None:
+        """Malformed Python preserves the pre-AST E2 regex coverage."""
+        content = "import os\nsecret = os.environ.get('API_KEY')\ndef broken(\n"
+
+        findings = data_exfiltration_module.analyze(content, "script.py", "python")
+
+        assert any(finding.rule_id == "E2" for finding in findings)
+
     @pytest.mark.parametrize(
         "expression",
         [

--- a/tests/unit/test_patterns.py
+++ b/tests/unit/test_patterns.py
@@ -160,6 +160,65 @@ api_key = os.environ.get("OPENAI_API_KEY")
         assert len(findings) >= 1
         assert any(f.rule_id == "E2" for f in findings)
 
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "os.environ.copy()",
+            "dict(os.environ)",
+            "{**os.environ}",
+            "dict(os.environ.items())",
+            '__import__("copy").copy(os.environ)',
+            "os . environ . copy ()",
+        ],
+    )
+    def test_e2_full_environment_read_forms(self, expression: str) -> None:
+        """Materializing the whole environment is detected independently of spelling."""
+        content = f"import os\nresult = {expression}\n"
+
+        findings = data_exfiltration_module.analyze(content, "script.py", "python")
+        e2 = [finding for finding in findings if finding.rule_id == "E2"]
+
+        assert len(e2) == 1
+        assert e2[0].location.start_line == 2
+
+    @pytest.mark.parametrize(
+        ("imports", "expression", "expected_line"),
+        [
+            ("import os as operating_system", "operating_system.environ.copy()", 2),
+            ("from os import environ as environment", "dict(environment)", 2),
+            ("import copy as copier\nimport os", "copier.copy(os.environ)", 3),
+        ],
+    )
+    def test_e2_full_environment_read_import_aliases(
+        self, imports: str, expression: str, expected_line: int
+    ) -> None:
+        """Import aliases cannot hide a full environment copy or enumeration."""
+        content = f"{imports}\nresult = {expression}\n"
+
+        findings = data_exfiltration_module.analyze(content, "script.py", "python")
+        e2 = [finding for finding in findings if finding.rule_id == "E2"]
+
+        assert len(e2) == 1
+        assert e2[0].location.start_line == expected_line
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            'os.environ["PATH"]',
+            'os.environ.get("PATH")',
+            "os.environ.copy",
+            "2 ** os.environ",
+            "subprocess.run(command, env=os.environ, check=False)",
+        ],
+    )
+    def test_e2_does_not_flag_non_harvesting_environment_use(self, expression: str) -> None:
+        """Single-key access and process environment plumbing are not harvesting."""
+        content = f"import os\nresult = {expression}\n"
+
+        findings = data_exfiltration_module.analyze(content, "script.py", "python")
+
+        assert not any(finding.rule_id == "E2" for finding in findings)
+
 
 class TestPrivilegeEscalation:
     """privilege_escalation.analyze() — PE3."""


### PR DESCRIPTION
## Summary

Replaces spelling-sensitive Python E2 checks with AST-based environment-read detection and introduces shared per-scan Python AST parsing for all AST-consuming analyzers.

- Detects complete environment materialization or enumeration through `copy()`, `dict(os.environ)`, dict unpacking, `.items()`, direct iteration, and `copy.copy()` variants.
- Resolves `os` and `environ` import aliases and is insensitive to formatting such as `os . environ . copy ()`.
- Shares one parsed AST per eligible Python file across E2, output-handling, behavioral-AST, and taint-tracking analyzers.
- Keeps AST objects outside checkpointed graph state, with bounded per-scan caching and cleanup after reporting.
- Preserves non-Python checks and regex fallback for syntactically invalid Python.
- Does not classify single-key reads or passing `os.environ` to a child process as full-environment harvesting.

## Motivation

E2 previously matched literal text such as `os.environ.copy()`, so aliases and equivalent Python syntax bypassed the rule. The shared AST layer fixes that detection gap while removing duplicate parsing across analyzer branches.

## Validation

- `uv run --no-sync python -m pytest tests/nodes/analyzers/test_static_patterns.py tests/unit/test_patterns.py -q`
- `uv run --with hatchling --no-sync python -m pytest -qq --disable-warnings -m "not integration and not provider" tests/`
- `uv run --no-sync make lint`
- `uv run --no-sync make format-check`

This supersedes the regex-only coverage in #331.

Fixes #329