### PR TITLE
fix: suppress Sigstore certificate payload false positives

### DIFF
--- a/src/skillspector/nodes/analyzers/static_runner.py
+++ b/src/skillspector/nodes/analyzers/static_runner.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Callable, Mapping
 from typing import cast
@@ -121,6 +122,43 @@ _BINARY_EXTENSIONS = frozenset(
 )
 
 _NULL_BYTE_SAMPLE_SIZE = 512
+
+_SIGSTORE_BUNDLE_MEDIA_TYPE = "application/vnd.dev.sigstore.bundle.v0.3+json"
+_SIGSTORE_CERTIFICATE_VALUE_RE = re.compile(r'("rawBytes"\s*:\s*")(?P<value>[^"\\]*)(")')
+
+
+def _mask_sigstore_certificate_bytes(path: str, content: str) -> str:
+    """Mask certificate payloads in a valid ``skill.oms.sig`` bundle.
+
+    Sigstore v0.3 stores DER certificates as base64 in ``rawBytes``. Those
+    payloads are cryptographic metadata, not executable skill content, and
+    otherwise trigger the generic long-base64 and repetition rules. Keep the
+    original offsets intact so findings in every other bundle field retain
+    correct locations.
+    """
+    if path.replace("\\", "/").rsplit("/", 1)[-1].lower() != "skill.oms.sig":
+        return content
+    try:
+        bundle = json.loads(content)
+        if bundle.get("mediaType") != _SIGSTORE_BUNDLE_MEDIA_TYPE:
+            return content
+        certificates = bundle["verificationMaterial"]["x509CertificateChain"]["certificates"]
+        certificate_values = {
+            certificate["rawBytes"]
+            for certificate in certificates
+            if isinstance(certificate, dict) and isinstance(certificate.get("rawBytes"), str)
+        }
+    except (json.JSONDecodeError, KeyError, TypeError, AttributeError):
+        return content
+
+    def mask(match: re.Match[str]) -> str:
+        value = match.group("value")
+        if value not in certificate_values:
+            return match.group(0)
+        masked = "".join(chr(0xE000 + (index % 4096)) for index in range(len(value)))
+        return f"{match.group(1)}{masked}{match.group(3)}"
+
+    return _SIGSTORE_CERTIFICATE_VALUE_RE.sub(mask, content)
 
 
 def _is_binary_file(path: str, content: str) -> bool:
@@ -283,6 +321,7 @@ def analyzer_finding_to_finding(
 def _scan_path(path: str, content: str, pattern_modules: list) -> list[Finding]:
     """Run pattern modules for one already-applicable file path."""
     findings: list[Finding] = []
+    content = _mask_sigstore_certificate_bytes(path, content)
     file_type = _infer_file_type(path)
     is_doc_markdown = _is_documentation_markdown(path)
     is_non_executable = file_type in _NON_EXECUTABLE_FILE_TYPES

--- a/tests/nodes/analyzers/test_static_runner_filtering.py
+++ b/tests/nodes/analyzers/test_static_runner_filtering.py
@@ -17,11 +17,16 @@
 
 from __future__ import annotations
 
+import base64
+import json
+
 import pytest
 
 from skillspector.nodes.analyzers import static_patterns_anti_refusal as ar_module
+from skillspector.nodes.analyzers import static_patterns_memory_poisoning as mp_module
 from skillspector.nodes.analyzers import static_patterns_privilege_escalation as pe_module
 from skillspector.nodes.analyzers import static_patterns_rogue_agent as ra_module
+from skillspector.nodes.analyzers import static_patterns_supply_chain as sc_module
 from skillspector.nodes.analyzers import static_patterns_tool_misuse as tm_module
 from skillspector.nodes.analyzers import static_runner
 
@@ -38,6 +43,57 @@ class _RecordingModule:
     def analyze(self, *, content: str, file_path: str, file_type: str) -> list:
         self.calls.append(content)
         return []
+
+
+def _sigstore_bundle(*, extra: dict[str, str] | None = None) -> str:
+    certificates = [
+        {"rawBytes": base64.b64encode(bytes([index]) * 14_000).decode()} for index in range(1, 6)
+    ]
+    bundle = {
+        "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+        "verificationMaterial": {"x509CertificateChain": {"certificates": certificates}},
+        **(extra or {}),
+    }
+    return json.dumps(bundle)
+
+
+class TestSigstoreCertificateFiltering:
+    def test_valid_bundle_certificate_bytes_do_not_trigger_sc3_or_mp2(self) -> None:
+        content = _sigstore_bundle()
+        state = {"components": ["skill.oms.sig"], "file_cache": {"skill.oms.sig": content}}
+
+        findings = static_runner.run_static_patterns(state, [sc_module, mp_module])
+
+        assert not {finding.rule_id for finding in findings} & {"SC3", "MP2"}
+
+    def test_other_bundle_fields_remain_visible(self) -> None:
+        payload = base64.b64encode(b"payload" * 200).decode()
+        content = _sigstore_bundle(extra={"untrustedPayload": payload})
+        state = {"components": ["skill.oms.sig"], "file_cache": {"skill.oms.sig": content}}
+
+        findings = static_runner.run_static_patterns(state, [sc_module])
+
+        assert any(finding.rule_id == "SC3" for finding in findings)
+
+    @pytest.mark.parametrize("path", ["other.sig", "nested/signature.sig"])
+    def test_non_skill_signature_paths_are_not_exempt(self, path: str) -> None:
+        content = _sigstore_bundle()
+        state = {"components": [path], "file_cache": {path: content}}
+
+        findings = static_runner.run_static_patterns(state, [sc_module])
+
+        assert any(finding.rule_id == "SC3" for finding in findings)
+
+    def test_malformed_bundle_is_not_exempt(self) -> None:
+        payload = base64.b64encode(b"certificate" * 200).decode()
+        content = (
+            f'{{"mediaType":"{static_runner._SIGSTORE_BUNDLE_MEDIA_TYPE}","rawBytes":"{payload}"'
+        )
+        state = {"components": ["skill.oms.sig"], "file_cache": {"skill.oms.sig": content}}
+
+        findings = static_runner.run_static_patterns(state, [sc_module])
+
+        assert any(finding.rule_id == "SC3" for finding in findings)
 
 
 class TestCharacterLimit:


### PR DESCRIPTION
## Summary

- mask only certificate `rawBytes` inside structurally valid Sigstore v0.3 `skill.oms.sig` bundles before static pattern matching
- preserve byte-for-character offsets so findings in every other bundle field keep correct locations
- keep malformed bundles, differently named files, and non-certificate payloads fully visible to analyzers

## Why this approach

Signed skills currently receive SC3 and MP2 findings from base64-encoded DER certificates. Skipping the whole signature file would create a forgeable analysis bypass; this instead implements the narrow field-level suppression suggested in the review of #261. Unknown fields and attacker-controlled content remain scanned.

Closes #336.

## Validation

- `uv run pytest tests/nodes/analyzers/test_static_runner_filtering.py tests/nodes/analyzers/test_static_patterns.py tests/nodes/analyzers/test_mp2_regex_backtracking.py -q` — 139 passed
- `uv run ruff check src/skillspector/nodes/analyzers/static_runner.py tests/nodes/analyzers/test_static_runner_filtering.py`
- `uv run ruff format --check src/skillspector/nodes/analyzers/static_runner.py tests/nodes/analyzers/test_static_runner_filtering.py`
- `git diff --check`

## Risk

The exemption is limited to the exact certificate chain path in a valid v0.3 bundle named `skill.oms.sig`. It does not verify the signature or attest trust; it only prevents opaque certificate bytes from reaching generic content heuristics.
