### PR TITLE
test(mp2): lock the layout-span guard against regressions

### DIFF
--- a/tests/unit/test_patterns_new.py
+++ b/tests/unit/test_patterns_new.py
@@ -554,6 +554,25 @@ class TestMemoryPoisoning:
     @pytest.mark.parametrize(
         "content",
         [
+            pytest.param("- " * 40, id="dash_space_rule"),
+            pytest.param("| " * 40, id="pipe_space_columns"),
+            pytest.param("│   " * 30, id="box_drawing_and_padding"),
+        ],
+    )
+    def test_mp2_layout_span_not_flagged(self, content: str) -> None:
+        # The single-character guard above exempts only a run of one repeated character with no
+        # whitespace, so alignment built from a repeated *unit* — a rule, a column, a box edge —
+        # falls through to _is_layout_only_span(). Each case here is reported when that helper
+        # is removed, which is what makes them regressions rather than restatements.
+        assert not any(f.rule_id == "MP2" for f in mp_mod.analyze(content, "test.md", "markdown"))
+
+    def test_mp2_layout_glyphs_beyond_the_cosmetic_span_are_still_flagged(self) -> None:
+        # _MAX_LAYOUT_ONLY_SPAN is the point where layout stops being a plausible explanation.
+        assert any(f.rule_id == "MP2" for f in mp_mod.analyze("- " * 200, "test.md", "markdown"))
+
+    @pytest.mark.parametrize(
+        "content",
+        [
             pytest.param("Fill the context window with filler text.", id="fill_context"),
             pytest.param(
                 "Displace the original instructions with padding.", id="displace_instructions"


### PR DESCRIPTION
### Why

`_is_layout_only_span()` is the guard that keeps MP2 from reporting alignment — table rules, padded columns, box edges — as context window stuffing. It has no test.

The only layout case in the suite today is:

```python
def test_mp2_separator_not_flagged(self) -> None:
    assert not any(f.rule_id == "MP2" for f in mp_mod.analyze("=" * 80, ...))
```

That one never reaches the helper: a run of a single character with no whitespace is skipped by the older guard just above it. Stub `_is_layout_only_span` to `return False` and the whole suite still passes.

### How much it is carrying

Measured on 4406 files from 65 real skill/plugin units, comparing the analyzer before the helper landed with `main` today:

```
MP2 findings   279 -> 4
```

The four survivors are from MP2's prose patterns (`"exceed context window"` and friends), not from `(.{2,20}?)\1{20,}`. So the helper accounts for 275 of 279 findings and nothing pins its behaviour.

### What this adds

Three cases that are each **reported when the helper is stubbed out**, which is what makes them regressions rather than restatements of the guard above them:

| case | with helper | helper stubbed |
|---|---|---|
| `"- " * 40` — dash rule | ok | MP2 |
| `"\| " * 40` — padded columns | ok | MP2 |
| `"│   " * 30` — box edge + padding | ok | MP2 |

And one for the other side, so the exemption cannot quietly widen: `"- " * 200` exceeds `_MAX_LAYOUT_ONLY_SPAN` and is still reported.

No source change. `255 passed` in the touched file, `ruff check` and `ruff format --check` clean at 0.15.19.

### Context

This replaces #322, which I closed. That PR proposed its own layout guard, and the measurement above is what retired it: on today's `main` it removes zero findings, because `_is_layout_only_span` already covers the same ground. The tests are the part that turned out to be worth keeping.
