### PR TITLE
chore: public OSS release 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+### 2.5.2 (Tuesday, August 04, 2026)
+### Features/Bug Fixes
+* test(mp2): lock the layout-span guard against regressions (#342)
+* fix(nv_build): cover reported model metadata (#279)
+* (chore) pin dependencies for workflows and Docker base images (#238)
+* fix(analyzer): reduce instructional-prose false positives in static scans (#103) (#232)
+* fix(input-handler): bound URL, zip, and git ingest paths (#164)
+* fix: read exact versions from Python lockfiles for OSV (#263)
+* feat(mcp): add registry posture scanning (#280)
+* fix: exclude valid OMS signatures from content analysis (#261)
+* fix(static): markdown table and quote syntax is not an execution signal (#321)
+* fix(agent-cli): Windows temp-cwd cleanup must not fail a successful batch (#317)
+* fix(supply-chain): SC4 must not claim a vulnerability it did not verify (#319)
+* docs: link to the Verified Skills pipeline and hosted docs (#347)
+* test(release): make changelog assertions version-aware
+* fix(release): harden patch publishing and changelog baseline
+---
 ### 2.5.1 (Thursday, July 30, 2026)
 ### Features/Bug Fixes
 * feat(llm): configurable analyzer fan-out concurrency via SKILLSPECTOR_MAX_LLM_CONCURRENCY (part of #303) (#305)

--- a/docs/release/skillspector-2.5.2.md
+++ b/docs/release/skillspector-2.5.2.md
@@ -1,0 +1,56 @@
+# SkillSpector v2.5.2
+
+Released: 2026-08-04
+
+## Summary
+
+This patch strengthens input-ingestion limits, adds MCP registry posture scanning, and improves supply-chain advisory accuracy. It also reduces static-analysis false positives, makes SC4 reporting more precise, and improves Windows cleanup reliability.
+
+## Highlights
+
+- Added bounded handling for remote URLs, ZIP archives, and Git repositories before oversized content can be ingested.
+- Added MCP registry posture scanning.
+- Uses exact Python lockfile versions when resolving OSV advisories and reports SC4 vulnerabilities only when verified.
+
+## Added
+
+- MCP registry posture scanning.
+
+## Changed
+
+- Pinned dependencies used by workflows and Docker base images for more reproducible builds.
+- Linked the Verified Skills pipeline and hosted documentation.
+
+## Fixed
+
+- Rejects oversized remote, archive, and repository inputs safely and cleans up temporary files when an ingest is rejected.
+- Reduces false positives from benign instructional prose, Markdown tables, quote syntax, and valid OMS signatures.
+- Resolves bundled metadata for supported NVIDIA Build endpoint IDs instead of using the generic token-budget fallback.
+- Cleans up Windows temporary working directories without turning a successful batch into a failure.
+
+## Security
+
+- Enforces bounded URL download, archive extraction, and Git repository ingestion paths to reduce resource-exhaustion risk.
+- Uses lockfile-resolved Python versions for OSV matching and avoids reporting unverified vulnerabilities in SC4 output.
+
+## Breaking Changes and Migration
+
+- None.
+
+## Deprecations
+
+- None.
+
+## Validation
+
+- `uv run --locked --extra dev pytest tests/unit/test_input_handler_bounds.py tests/unit/test_input_handler_ssrf.py` — 34 passed.
+- `make test-unit` — passed for each merged import validation run.
+- `uv run --locked --extra dev make test-ci` — passed on the corrected release source.
+
+## Known Limitations
+
+- NVIDIA Build metadata remains intentionally limited to owner-confirmed endpoint IDs; short-form aliases and unproven mappings continue to use the existing fallback behavior.
+
+## References
+
+- `CHANGELOG.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skillspector"
-version = "2.5.1"
+version = "2.5.2"
 description = "SkillSpector: Security scanner for AI agent skills (Claude Code, Cursor, and similar). Scans skills for vulnerabilities, malicious patterns, and security risks before installation. Supports Git repos, URLs, zips, and local directories; runs static pattern checks and optional LLM semantic analysis; outputs terminal, JSON, and Markdown reports with risk scoring."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2675,7 +2675,7 @@ wheels = [
 
 [[package]]
 name = "skillspector"
-version = "2.5.1"
+version = "2.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## SkillSpector 2.5.2 release refresh

This refresh aligns the existing release PR with the corrected `release/2.5.2` source.

### Included

- Updated 2.5.2 changelog and release notes for registry posture scanning, exact lockfile OSV matching, static-analysis false-positive reductions, Windows cleanup, and safer SC4 reporting.
- Bumped the public package metadata and lockfile to 2.5.2.
- Preserved the current public implementation and GitHub automation from `main`.

### Validation

- Full CI-equivalent unit suite passed on the corrected release source.
- Sanitized OSS snapshot `make test-unit` smoke gate passed.
- The GitLab pipeline for the corrected source is running; release/tag alignment was completed at maintainer direction without waiting for it.