### PR TITLE
docs: link to the Verified Skills pipeline and hosted docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ AI agent skills (used by Claude Code, Codex CLI, Gemini CLI, etc.) execute with 
 
 SkillSpector helps you answer: **"Is this skill safe to install?"**
 
+SkillSpector is part of the [NVIDIA Verified Skills pipeline](https://docs.nvidia.com/skills/), which scans, evaluates, and signs agent skills before publication. Skills that pass are published to the [NVIDIA skills catalog](https://github.com/NVIDIA/skills).
+
 ## Documentation
 
+- **[Scan agent skills before installation](https://docs.nvidia.com/skills/scanning-agent-skills)** — Hosted guide: when to scan, how to read a report, and how to gate installs.
 - **[Development guide](docs/DEVELOPMENT.md)** — Architecture, package layout, and how to extend the analyzer pipeline.
 - **[Pi extension](docs/PI_EXTENSION.md)** — Install SkillSpector as a Pi tool for scanning skills from inside agent sessions.
 


### PR DESCRIPTION
## What this changes

The README has no mention of the Verified Skills pipeline, the skills catalog, or the hosted documentation. A reader arriving at this repo has no path to any of them.

Two additions:

1. **Overview** — one line placing SkillSpector in the [Verified Skills pipeline](https://docs.nvidia.com/skills/), linking the docs home and the [skills catalog](https://github.com/NVIDIA/skills).
2. **Documentation** — leads with the hosted [Scan agent skills before installation](https://docs.nvidia.com/skills/scanning-agent-skills) guide, ahead of the repo-local developer docs, since that is what most readers arriving here want.

All three links verified returning 200.

## Also needed, but requires admin

These cannot be done in a PR. Flagging them here because they are the same discoverability problem and this repo is the most visible one we have (14k+ stars, 1.1k forks):

| Field | Current | Suggested |
|---|---|---|
| `homepage` | not set | `https://docs.nvidia.com/skills/scanning-agent-skills` |
| Topics | none set | `agent-skills`, `agent-security`, `agentic-ai`, `security-scanner`, `ai-security`, `prompt-injection`, `supply-chain-security`, `mcp`, `claude-code` |

A repo with no topics cannot surface in topic-filtered browsing at all, and the homepage field is what links the repo to its documentation from the GitHub sidebar.

The description could also carry the terms people actually search for. Something like: "Security scanner for AI agent skills. Detect prompt injection, data exfiltration, and supply-chain risks in Claude Code, Codex, and MCP skills before you install them."

@rng1995 could you apply those three? Happy to supply exact values if that is easier.
