### PR TITLE
Scope the locality guard to the namespace

### DIFF
--- a/src/skillspector/nodes/analyzers/static_yara.py
+++ b/src/skillspector/nodes/analyzers/static_yara.py
@@ -72,14 +72,20 @@ _rules_hash: str | None = None
 
 
 def _collect_rule_files(*dirs: Path) -> list[Path]:
-    """Collect all YARA rule files under one or more directories, sorted for determinism."""
-    files: set[Path] = set()
+    """Collect YARA files deterministically while preserving directory precedence."""
+    files: list[Path] = []
+    seen: set[Path] = set()
     for d in dirs:
         if not d.is_dir():
             continue
+        directory_files: set[Path] = set()
         for ext in _RULE_EXTENSIONS:
-            files.update(d.rglob(ext))
-    return sorted(files)
+            directory_files.update(d.rglob(ext))
+        for rule_file in sorted(directory_files):
+            if rule_file not in seen:
+                seen.add(rule_file)
+                files.append(rule_file)
+    return files
 
 
 def _content_hash(rule_files: list[Path]) -> str:

--- a/src/skillspector/nodes/analyzers/static_yara.py
+++ b/src/skillspector/nodes/analyzers/static_yara.py
@@ -62,6 +62,7 @@ _CATEGORY_MAP: dict[str, tuple[str, Severity]] = {
 _DEFAULT_RULE_ID = "YR4"
 _DEFAULT_SEVERITY = Severity.MEDIUM
 _DEFAULT_CONFIDENCE = 0.7
+_DESTRUCTIVE_AUTONOMY_NAMESPACE = "agent_skills"
 _DESTRUCTIVE_AUTONOMY_RULE = "agent_skill_destructive_autonomous_actions"
 _MAX_DESTRUCTIVE_AUTONOMY_LINE_DISTANCE = 3
 
@@ -278,7 +279,8 @@ def _match_file(rules: yara.Rules, content: str, file_path: str) -> list[Analyze
     findings: list[AnalyzerFinding] = []
     for match in matches:
         if (
-            match.rule == _DESTRUCTIVE_AUTONOMY_RULE
+            match.namespace == _DESTRUCTIVE_AUTONOMY_NAMESPACE
+            and match.rule == _DESTRUCTIVE_AUTONOMY_RULE
             and not _has_local_destructive_autonomy_evidence(match, data)
         ):
             logger.debug(

--- a/tests/nodes/analyzers/test_static_yara.py
+++ b/tests/nodes/analyzers/test_static_yara.py
@@ -504,6 +504,45 @@ user approves the plan, do not prompt per file. Delete only approved paths.
 
         assert _has_rule(findings, "agent_skill_destructive_autonomous_actions")
 
+    def test_user_agent_skills_file_cannot_claim_builtin_namespace(self, tmp_path, monkeypatch):
+        builtin_dir = tmp_path / "z_builtin"
+        user_dir = tmp_path / "a_user"
+        builtin_dir.mkdir()
+        user_dir.mkdir()
+        (builtin_dir / "agent_skills.yar").write_text(
+            """
+rule agent_skill_destructive_autonomous_actions {
+    strings:
+        $destructive_action = "DELETE_MARKER"
+        $autonomy_action = "AUTONOMY_MARKER"
+    condition:
+        all of them
+}
+"""
+        )
+        (user_dir / "agent_skills.yar").write_text(
+            """
+rule agent_skill_destructive_autonomous_actions {
+    strings:
+        $custom = "CUSTOM_DESTRUCTIVE_MARKER"
+    condition:
+        $custom
+}
+"""
+        )
+        monkeypatch.setattr(static_yara, "_BUILTIN_RULES_DIR", builtin_dir)
+
+        intervening_lines = "\n".join(f"review step {index}" for index in range(6))
+        content = (
+            f"DELETE_MARKER\n{intervening_lines}\nAUTONOMY_MARKER\nCUSTOM_DESTRUCTIVE_MARKER\n"
+        )
+
+        findings = _run(content, "custom.txt", str(user_dir))
+
+        assert len(findings) == 1
+        assert _has_rule(findings, "agent_skill_destructive_autonomous_actions")
+        assert "[a_user/agent_skills]" in findings[0].message
+
     def test_credential_webhook_requires_collection_and_transmission(self):
         content = """
 # Document how to rotate OPENAI_API_KEY.

--- a/tests/nodes/analyzers/test_static_yara.py
+++ b/tests/nodes/analyzers/test_static_yara.py
@@ -491,6 +491,19 @@ user approves the plan, do not prompt per file. Delete only approved paths.
         findings = _run_builtin("rm -rf /\n", "setup.sh")
         assert _has_rule(findings, "agent_skill_destructive_autonomous_actions")
 
+    def test_user_rule_with_destructive_rule_name_is_not_post_filtered(self, tmp_path):
+        _write_rule(
+            tmp_path,
+            "agent_skill_destructive_autonomous_actions",
+            category="hack_tool",
+            severity="MEDIUM",
+            strings={"custom": "CUSTOM_DESTRUCTIVE_MARKER"},
+        )
+
+        findings = _run("CUSTOM_DESTRUCTIVE_MARKER", "custom.txt", str(tmp_path))
+
+        assert _has_rule(findings, "agent_skill_destructive_autonomous_actions")
+
     def test_credential_webhook_requires_collection_and_transmission(self):
         content = """
 # Document how to rotate OPENAI_API_KEY.


### PR DESCRIPTION
## Summary

- Restrict the destructive/autonomy locality post-filter to the packaged `agent_skills` namespace.
- Keep the existing rule-name check as the second half of the rule identity.
- Add regression coverage for a user-supplied rule that intentionally reuses the built-in rule name.

## Problem

SkillSpector compiles built-in and user-supplied YARA files into separate namespaces, but the locality guard introduced for `agent_skill_destructive_autonomous_actions` previously checked only `match.rule`.

Because YARA rule names need only be unique within a namespace, a user rule can legally use the same name with unrelated string identifiers and semantics. The built-in post-filter would then inspect that custom match, find no built-in destructive/autonomy identifiers, and silently discard a valid user-defined finding.

## Implementation

- Define the packaged destructive-action namespace as `agent_skills`.
- Apply the locality filter only when both namespace and rule name identify the built-in rule.
- Leave all other namespaces on the normal finding path, including same-named user rules.

## Security invariants

- The built-in cross-context false-positive suppression remains unchanged.
- Built-in local destructive/autonomy evidence still produces a HIGH finding.
- Built-in `rm -rf /` detection remains unconditionally blocking.
- User-supplied rules are no longer altered solely because their rule name collides with a built-in rule in another namespace.

## User impact

Custom YARA rules retain their declared behavior even when their rule names collide with built-in rules in a different namespace. The packaged destructive-action guard continues to suppress only its intended cross-context false positives.

## Validation

- `61 passed` in `tests/nodes/analyzers/test_static_yara.py`.
- Added a regression proving built-in directory precedence is preserved even when a same-named user rule path sorts first.\n- The regression also proves the packaged distant-evidence match is locality-filtered while the user-namespaced match is reported.
- Existing regressions for distant built-in evidence, local destructive/autonomy evidence, and root deletion all pass.
- Ruff lint and format checks passed for both changed files.
- `git diff --check` passed.

## Files changed

- `src/skillspector/nodes/analyzers/static_yara.py`
- `tests/nodes/analyzers/test_static_yara.py`
