### PR TITLE
release: SkillSpector 2.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 2.9.5 (Friday, August 14, 2026)
+### Features/Bug Fixes
+* Scope the locality guard to the namespace (#365)
+* Use byte offsets for YARA line lookup (#364)
+* feat(cli): opt-in discovery of an author-shipped baseline (#278) (#286)
+* feat: add Ollama, Azure OpenAI, and generic OpenAI-compatible providers (#179)
+* fix: bound MCP extra to supported major version (#339)
+* fix(analyzers): reduce false positives for negated safety constraints (#254)
+* feat(analyzer): detect insecure deserialization (AST10, TT6, DS1–DS4) (#246)
+---
 ### 2.9.4 (Wednesday, August 12, 2026)
 ### Features/Bug Fixes
 * fix(mcp): reject local targets over HTTP transport (#196)

--- a/docs/release/skillspector-2.9.5.md
+++ b/docs/release/skillspector-2.9.5.md
@@ -1,0 +1,61 @@
+# SkillSpector v2.9.5
+
+Released: 2026-08-14
+
+## Summary
+
+SkillSpector 2.9.5 expands provider support, adds opt-in author-shipped baselines, and strengthens static detection for insecure deserialization. It also improves analyzer accuracy and compatibility across safety-pattern, MCP dependency, and YARA scanning paths.
+
+## Highlights
+
+- Add Ollama, Azure OpenAI, and generic OpenAI-compatible providers.
+- Add static detection coverage for insecure deserialization patterns.
+- Improve scan accuracy with opt-in shipped baselines, lower false positives, and more precise YARA source locations.
+
+## Added
+
+- Add Ollama support for local OpenAI-compatible inference, Azure OpenAI deployment routing, and a configurable provider for other OpenAI-compatible endpoints.
+- Add opt-in discovery of a top-level `.skillspector-baseline.yaml` while keeping explicitly supplied baselines authoritative.
+- Add analyzer coverage for insecure deserialization patterns represented by AST10, TT6, and DS1–DS4 findings.
+
+## Changed
+
+- Use byte offsets when mapping YARA matches back to source lines so non-ASCII content is reported accurately.
+- Scope the destructive-autonomy YARA post-filter to SkillSpector's built-in rule namespace and preserve deterministic built-in rule precedence.
+
+## Fixed
+
+- Reduce false positives when safety-sensitive language explicitly negates unsafe behavior.
+- Bound the optional MCP dependency to the supported major version.
+
+## Security
+
+- Expand static analysis for insecure deserialization behavior and prevent custom YARA rules that reuse a built-in rule name from being incorrectly post-filtered.
+
+## Breaking Changes and Migration
+
+- None.
+
+## Deprecations
+
+- None.
+
+## Validation
+
+- Targeted and regression suites for provider selection, shipped baselines, deserialization analysis, safety-pattern controls, MCP packaging, and YARA analysis passed for the prepared imports.
+- Ruff lint, Ruff formatting checks, and `git diff --check` passed for every prepared import.
+- Required CI lint, unit, integration, Docker smoke, and Sonar checks passed for all seven imported changes.
+
+## Known Limitations
+
+- Ollama support requires a reachable local Ollama service; Azure OpenAI and generic OpenAI-compatible providers require their provider-specific endpoint and credential configuration.
+
+## References
+
+- [GitHub PR #246](https://github.com/NVIDIA/SkillSpector/pull/246)
+- [GitHub PR #254](https://github.com/NVIDIA/SkillSpector/pull/254)
+- [GitHub PR #339](https://github.com/NVIDIA/SkillSpector/pull/339)
+- [GitHub PR #179](https://github.com/NVIDIA/SkillSpector/pull/179)
+- [GitHub PR #286](https://github.com/NVIDIA/SkillSpector/pull/286)
+- [GitHub PR #364](https://github.com/NVIDIA/SkillSpector/pull/364)
+- [GitHub PR #365](https://github.com/NVIDIA/SkillSpector/pull/365)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skillspector"
-version = "2.9.4"
+version = "2.9.5"
 description = "SkillSpector: Security scanner for AI agent skills (Claude Code, Cursor, and similar). Scans skills for vulnerabilities, malicious patterns, and security risks before installation. Supports Git repos, URLs, zips, and local directories; runs static pattern checks and optional LLM semantic analysis; outputs terminal, JSON, and Markdown reports with risk scoring."
 readme = "README.md"
 license = "Apache-2.0"
@@ -81,8 +81,12 @@ Issues = "https://github.com/NVIDIA/skillspector/issues"
 [tool.hatch.build]
 exclude = [".claude/", ".cursor/", ".agents/"]
 
+[tool.hatch.build.targets.sdist]
+core-metadata-version = "2.4"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/skillspector"]
+core-metadata-version = "2.4"
 
 [tool.ruff]
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -2675,7 +2675,7 @@ wheels = [
 
 [[package]]
 name = "skillspector"
-version = "2.9.4"
+version = "2.9.5"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## SkillSpector 2.9.5

Publishes the sanitized public OSS snapshot for SkillSpector 2.9.5.

## Source

- Internal release source: `main` / `release/2.9.5` at `68d00548312ebd3873bc75f6b97ce4fdde32a1bb`.
- Internal sanitized branch: `release/oss-2026-08-14`.
- Sanitized orphan commit: `7fb612286a8bd7558f40b6c782dbb8b48c49020f`.
- Public snapshot commit: `6b836e925c294ed87777e0feaaed886d1e85e6c0`.
- Release notes: `docs/release/skillspector-2.9.5.md`.

## Included

- Adds Ollama, Azure OpenAI, and generic OpenAI-compatible provider support.
- Adds opt-in author-shipped baselines and insecure-deserialization detection.
- Improves safety-pattern false positives, MCP dependency compatibility, and YARA namespace and byte-offset handling.
- Updates version metadata, the lockfile, changelog, and public release notes.
- Pins wheel and sdist Core Metadata to 2.4 for compatibility with the supported publishing toolchain.

## Public boundary

- No public-only files, GitHub workflows, templates, or policy files were removed or changed.
- Removed one scrubber-only trailing blank line so the public Makefile remains unchanged.

## Validation

- Internal release pipeline 62803328: lint, unit, integration, Docker smoke, and Sonar passed.
- Sanitized snapshot `make test-unit`: 2,190 passed, 13 skipped, 38 deselected, and 4 expected failures.
- Final public `git diff --cached --check`: passed.
- Final public GitNexus scope: low risk, four files, zero affected execution flows.
- Internal 2.9.5 sdist and wheel were published and their SHA-256 digests verified through Artifactory.
