### PR TITLE
Inspect concealed executables in nested artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unreleased
+### Features/Bug Fixes
+* Inspect hidden and nested ZIP-compatible artifacts under cumulative safety bounds.
+* Report HIGH SC9 findings for executables concealed in documents or hidden/disguised artifacts.
+---
 ### 2.9.6 (Tuesday, August 18, 2026)
 ### Features/Bug Fixes
 * fix(pe3): distinguish OAuth token nouns from access actions (#392)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SkillSpector is part of the [NVIDIA Verified Skills pipeline](https://docs.nvidi
 ## Features
 
 - **Multi-format input**: Scan Git repos, URLs, zip files, directories, or single files
-- **69 vulnerability patterns** across 17 categories: prompt injection, data exfiltration, privilege escalation, supply chain, excessive agency, output handling, system prompt leakage, memory poisoning, tool misuse, rogue agent, anti-refusal, trigger abuse, dangerous code (AST), taint tracking, YARA signatures, MCP least privilege, and MCP tool poisoning
+- **70 vulnerability patterns** across 17 categories: prompt injection, data exfiltration, privilege escalation, supply chain, excessive agency, output handling, system prompt leakage, memory poisoning, tool misuse, rogue agent, anti-refusal, trigger abuse, dangerous code (AST), taint tracking, YARA signatures, MCP least privilege, and MCP tool poisoning
 - **Two-stage analysis**: Fast static analysis + optional LLM semantic evaluation
 - **Live vulnerability lookups**: SC4 queries [OSV.dev](https://osv.dev) for real-time CVE data with automatic offline fallback
 - **Multiple output formats**: Terminal, JSON, Markdown, and SARIF reports
@@ -353,7 +353,7 @@ claude mcp add skillspector -- skillspector mcp
 
 ## Vulnerability Patterns
 
-SkillSpector detects **69 vulnerability patterns** across 17 categories:
+SkillSpector detects **70 vulnerability patterns** across 17 categories:
 
 ### Prompt Injection (6 patterns)
 
@@ -391,7 +391,7 @@ SkillSpector detects **69 vulnerability patterns** across 17 categories:
 | PE2 | Sudo/Root Execution | MEDIUM | Invoking elevated system privileges |
 | PE3 | Credential Access | HIGH | Reading SSH keys, tokens, passwords |
 
-### Supply Chain (7+ patterns)
+### Supply Chain (9+ patterns)
 
 | ID | Pattern | Severity | Description |
 |----|---------|----------|-------------|
@@ -402,6 +402,7 @@ SkillSpector detects **69 vulnerability patterns** across 17 categories:
 | SC5 | Abandoned Dependencies | MEDIUM | Unmaintained packages without security updates |
 | SC6 | Typosquatting | HIGH | Package names similar to popular packages |
 | SC8 | Shipped Python Bytecode | HIGH | `__pycache__` / `.pyc` present (discovery skips; malicious bytecode bypass) |
+| SC9 | Concealed Executable Artifact | HIGH | Executable nested in a document container or hidden/disguised artifact |
 
 ### Excessive Agency (4 patterns)
 

--- a/docs/NESTED_ARTIFACT_INSPECTION.md
+++ b/docs/NESTED_ARTIFACT_INSPECTION.md
@@ -1,0 +1,53 @@
+# Nested Artifact Inspection
+
+SkillSpector inventories hidden regular files and inspects ZIP-compatible content locally. The
+container is recognized from its bytes and internal structure rather than its filename extension.
+Supported document containers are DOCX, XLSX, and PPTX; generic ZIP and nested ZIP-compatible
+members use the same traversal policy.
+
+Nested members use a stable virtual path that retains their full provenance:
+
+```text
+outer-file!/nested.zip!/scripts/setup.sh
+```
+
+## Security invariants
+
+- Members are read in memory. SkillSpector never extracts, renders, imports, installs, or executes
+  archive content.
+- Absolute paths, parent traversal, drive-qualified paths, and link members are not followed.
+- Hidden files, recognized containers, and all nested content are local-only and are never included
+  in an external LLM request.
+- Deterministic HIGH findings survive optional LLM meta-analysis.
+- A zero-finding result does not make opaque or uninspected content complete.
+
+## Cumulative bounds
+
+The following fixed limits apply to one outer container and every nested container below it:
+
+| Bound | Limit |
+|---|---:|
+| Container depth | 3 |
+| Members | 1,000 |
+| Declared/uncompressed content | 25 MiB |
+| Materialized member | 1 MiB |
+| Compression ratio | 100:1 |
+| Inspection wall time | 5 seconds |
+
+These are resource-safety limits, not trust configuration. They are intentionally not user-managed
+allowlists.
+
+## Failure and completeness behavior
+
+Malformed, encrypted, truncated, unreadable, unsafe-path, link, unsupported, and over-budget
+members are recorded as inspection-ledger exceptions. The scan continues safely when possible, but
+the analysis is marked incomplete. Outer and nested paths remain visible in terminal, JSON,
+Markdown, and SARIF output.
+
+## SC9: Concealed Executable Artifact
+
+SC9 is a deterministic HIGH finding when executable content is concealed inside an Office document
+container or a hidden/disguised artifact. Executability is established from an executable suffix,
+a shebang, or archive mode bits. A benign document without executable members does not produce SC9.
+
+SC9 reports evidence and risk; it does not execute the member or prescribe an installation decision.

--- a/src/skillspector/inspection_ledger.py
+++ b/src/skillspector/inspection_ledger.py
@@ -60,6 +60,17 @@ class LedgerReason(StrEnum):
     NO_APPLICABLE_FILES = "no_applicable_files"
     OMS_SIGNATURE = "oms_signature"
     BASELINE_FILE = "baseline_file"
+    ARCHIVE_MALFORMED = "archive_malformed"
+    ARCHIVE_ENCRYPTED = "archive_encrypted"
+    ARCHIVE_TRUNCATED = "archive_truncated"
+    ARCHIVE_UNSAFE_MEMBER_PATH = "archive_unsafe_member_path"
+    ARCHIVE_LINK_MEMBER = "archive_link_member"
+    ARCHIVE_DEPTH_LIMIT = "archive_depth_limit"
+    ARCHIVE_MEMBER_LIMIT = "archive_member_limit"
+    ARCHIVE_SIZE_LIMIT = "archive_size_limit"
+    ARCHIVE_MEMBER_SIZE_LIMIT = "archive_member_size_limit"
+    ARCHIVE_COMPRESSION_RATIO = "archive_compression_ratio"
+    ARCHIVE_TIME_LIMIT = "archive_time_limit"
 
 
 REASON_MESSAGES: Final[dict[LedgerReason, str]] = {
@@ -99,6 +110,21 @@ REASON_MESSAGES: Final[dict[LedgerReason, str]] = {
     LedgerReason.BASELINE_FILE: (
         "The explicitly selected suppression baseline is excluded from content analysis."
     ),
+    LedgerReason.ARCHIVE_MALFORMED: "ZIP-compatible content is malformed or unsupported.",
+    LedgerReason.ARCHIVE_ENCRYPTED: "Archive member is encrypted and could not be inspected.",
+    LedgerReason.ARCHIVE_TRUNCATED: "Archive member is truncated or unreadable.",
+    LedgerReason.ARCHIVE_UNSAFE_MEMBER_PATH: (
+        "Archive member uses an absolute, traversal, or otherwise unsafe path."
+    ),
+    LedgerReason.ARCHIVE_LINK_MEMBER: "Archive link member was not followed or read.",
+    LedgerReason.ARCHIVE_DEPTH_LIMIT: "Nested archive depth limit was reached.",
+    LedgerReason.ARCHIVE_MEMBER_LIMIT: "Cumulative archive member limit was reached.",
+    LedgerReason.ARCHIVE_SIZE_LIMIT: "Cumulative archive content size limit was reached.",
+    LedgerReason.ARCHIVE_MEMBER_SIZE_LIMIT: "Archive member exceeds the per-file analysis limit.",
+    LedgerReason.ARCHIVE_COMPRESSION_RATIO: (
+        "Archive member exceeds the permitted compression ratio."
+    ),
+    LedgerReason.ARCHIVE_TIME_LIMIT: "Cumulative archive inspection time limit was reached.",
 }
 
 

--- a/src/skillspector/inspection_ledger.py
+++ b/src/skillspector/inspection_ledger.py
@@ -60,10 +60,13 @@ class LedgerReason(StrEnum):
     NO_APPLICABLE_FILES = "no_applicable_files"
     OMS_SIGNATURE = "oms_signature"
     BASELINE_FILE = "baseline_file"
+    ARCHIVE_FORMAT_MISMATCH = "archive_format_mismatch"
     ARCHIVE_MALFORMED = "archive_malformed"
     ARCHIVE_ENCRYPTED = "archive_encrypted"
+    ARCHIVE_UNSUPPORTED_COMPRESSION = "archive_unsupported_compression"
     ARCHIVE_TRUNCATED = "archive_truncated"
     ARCHIVE_UNSAFE_MEMBER_PATH = "archive_unsafe_member_path"
+    ARCHIVE_AMBIGUOUS_MEMBER_PATH = "archive_ambiguous_member_path"
     ARCHIVE_LINK_MEMBER = "archive_link_member"
     ARCHIVE_DEPTH_LIMIT = "archive_depth_limit"
     ARCHIVE_MEMBER_LIMIT = "archive_member_limit"
@@ -110,11 +113,20 @@ REASON_MESSAGES: Final[dict[LedgerReason, str]] = {
     LedgerReason.BASELINE_FILE: (
         "The explicitly selected suppression baseline is excluded from content analysis."
     ),
-    LedgerReason.ARCHIVE_MALFORMED: "ZIP-compatible content is malformed or unsupported.",
+    LedgerReason.ARCHIVE_FORMAT_MISMATCH: (
+        "Artifact bytes do not match the container format implied by its filename."
+    ),
+    LedgerReason.ARCHIVE_MALFORMED: "ZIP-compatible content is malformed.",
     LedgerReason.ARCHIVE_ENCRYPTED: "Archive member is encrypted and could not be inspected.",
+    LedgerReason.ARCHIVE_UNSUPPORTED_COMPRESSION: (
+        "Archive member uses an unsupported compression method."
+    ),
     LedgerReason.ARCHIVE_TRUNCATED: "Archive member is truncated or unreadable.",
     LedgerReason.ARCHIVE_UNSAFE_MEMBER_PATH: (
         "Archive member uses an absolute, traversal, or otherwise unsafe path."
+    ),
+    LedgerReason.ARCHIVE_AMBIGUOUS_MEMBER_PATH: (
+        "Archive member name has an ambiguous or duplicate provenance identity."
     ),
     LedgerReason.ARCHIVE_LINK_MEMBER: "Archive link member was not followed or read.",
     LedgerReason.ARCHIVE_DEPTH_LIMIT: "Nested archive depth limit was reached.",

--- a/src/skillspector/models.py
+++ b/src/skillspector/models.py
@@ -60,6 +60,7 @@ class AnalyzerFinding:
     tags: list[str] = field(default_factory=list)
     context: str | None = None
     matched_text: str | None = None
+    evidence: dict[str, object] = field(default_factory=dict)
 
 
 def _new_finding_id() -> str:
@@ -89,6 +90,7 @@ class Finding:
     tags: list[str] = field(default_factory=list)
     context: str | None = None
     matched_text: str | None = None
+    evidence: dict[str, object] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable dict representation (full finding shape)."""
@@ -112,6 +114,7 @@ class Finding:
             # Tags surface markers like "llm-unconfirmed" (a high-severity static
             # finding the LLM filter did not confirm but which is preserved anyway).
             "tags": list(self.tags),
+            "evidence": dict(self.evidence),
         }
 
     def __str__(self) -> str:

--- a/src/skillspector/nested_artifacts.py
+++ b/src/skillspector/nested_artifacts.py
@@ -41,7 +41,31 @@ ARCHIVE_MAX_SECONDS = 5.0
 
 _ZIP_SIGNATURES = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
 _EXECUTABLE_SUFFIXES = frozenset(
-    {".py", ".sh", ".bash", ".zsh", ".js", ".ts", ".rb", ".go", ".rs", ".pl"}
+    {
+        ".app",
+        ".bash",
+        ".bat",
+        ".bin",
+        ".cmd",
+        ".com",
+        ".dll",
+        ".dylib",
+        ".exe",
+        ".go",
+        ".js",
+        ".msi",
+        ".pl",
+        ".ps1",
+        ".py",
+        ".pyc",
+        ".pyo",
+        ".rb",
+        ".rs",
+        ".sh",
+        ".so",
+        ".ts",
+        ".zsh",
+    }
 )
 _OOXML_MARKERS: tuple[tuple[str, str], ...] = (
     ("word/", "docx"),
@@ -95,9 +119,26 @@ def _container_type(names: list[str]) -> str:
     return "zip"
 
 
+def _expected_container_type(path: str) -> str | None:
+    suffix = Path(path).suffix.lower()
+    return next(
+        (
+            container_type
+            for container_type, suffixes in _EXPECTED_SUFFIXES.items()
+            if suffix in suffixes
+        ),
+        None,
+    )
+
+
 def _safe_member_name(name: str) -> str | None:
     normalized = name.replace("\\", "/")
-    if not normalized or "\x00" in normalized or normalized.startswith(("/", "//")):
+    if (
+        not normalized
+        or "\x00" in normalized
+        or "!/" in normalized
+        or normalized.startswith(("/", "//"))
+    ):
         return None
     if len(normalized) >= 2 and normalized[1] == ":":
         return None
@@ -112,10 +153,46 @@ def _zip_member_is_link(info: zipfile.ZipInfo) -> bool:
     return bool(mode and stat.S_ISLNK(mode))
 
 
+def is_executable_content(path: str, data: bytes, mode: int = 0) -> bool:
+    """Classify filesystem and archive content with one static-only policy."""
+    suffix = Path(path).suffix.lower()
+    executable_magic = data.startswith(
+        (b"#!", b"MZ", b"\x7fELF", b"\xfe\xed\xfa", b"\xcf\xfa\xed\xfe")
+    )
+    return suffix in _EXECUTABLE_SUFFIXES or executable_magic or bool(mode & 0o111)
+
+
 def _member_executable(info: zipfile.ZipInfo, safe_name: str, data: bytes) -> bool:
-    suffix = Path(safe_name).suffix.lower()
-    mode = info.external_attr >> 16
-    return suffix in _EXECUTABLE_SUFFIXES or data.startswith(b"#!") or bool(mode & 0o111)
+    return is_executable_content(safe_name, data, info.external_attr >> 16)
+
+
+def _nested_path(outer_path: str, virtual_path: str) -> str:
+    prefix = f"{outer_path}!/"
+    return virtual_path[len(prefix) :] if virtual_path.startswith(prefix) else virtual_path
+
+
+def _sorted_infos(infos: list[zipfile.ZipInfo]) -> list[zipfile.ZipInfo]:
+    return sorted(infos, key=lambda item: item.filename)
+
+
+def _record_outer_metadata(
+    result: NestedInspectionResult,
+    *,
+    path: str,
+    container_type: str,
+    hidden: bool,
+    disguised: bool,
+) -> None:
+    result.outer_metadata[path] = {
+        "type": container_type,
+        "container_type": container_type,
+        "container_ancestry": [container_type],
+        "hidden": hidden,
+        "disguised": disguised,
+        # Recognized and expected containers are never provider input,
+        # including when their bytes cannot be fully inspected.
+        "local_only": True,
+    }
 
 
 def _virtual_type(path: str, data: bytes, nested_type: str | None) -> str:
@@ -171,6 +248,8 @@ def _add_unreadable_component(
     outer_path: str,
     member_path: str,
     container_type: str,
+    container_ancestry: tuple[str, ...],
+    concealment_reasons: tuple[str, ...],
     depth: int,
 ) -> None:
     if virtual_path not in result.file_cache:
@@ -188,10 +267,12 @@ def _add_unreadable_component(
                 "outer_path": outer_path,
                 "nested_path": member_path,
                 "container_type": container_type,
+                "container_ancestry": list(container_ancestry),
                 "container_depth": depth,
                 "hidden": _is_hidden_path(member_path),
                 "local_only": True,
                 "concealed_executable": False,
+                "concealment_reasons": list(concealment_reasons),
             }
         )
 
@@ -203,19 +284,64 @@ def _inspect_zip_bytes(
     container_virtual_path: str,
     depth: int,
     outer_hidden: bool,
-    outer_disguised: bool,
+    outer_disguised: bool | None,
+    outer_expected_type: str | None,
+    ancestor_container_types: tuple[str, ...],
     budget: _Budget,
     result: NestedInspectionResult,
 ) -> None:
+    if budget.expired():
+        _exception(result, path=container_virtual_path, reason=LedgerReason.ARCHIVE_TIME_LIMIT)
+        return
     try:
         archive = zipfile.ZipFile(io.BytesIO(data))
     except (zipfile.BadZipFile, OSError, ValueError):
-        _exception(result, path=container_virtual_path, reason=LedgerReason.ARCHIVE_MALFORMED)
+        reason = LedgerReason.ARCHIVE_MALFORMED if depth == 1 else LedgerReason.ARCHIVE_TRUNCATED
+        _exception(result, path=container_virtual_path, reason=reason)
         return
 
     with archive:
-        infos = sorted(archive.infolist(), key=lambda item: item.filename)
+        if budget.expired():
+            _exception(result, path=container_virtual_path, reason=LedgerReason.ARCHIVE_TIME_LIMIT)
+            return
+
+        # ZipFile has already parsed the central directory. Enforce the cumulative
+        # entry budget before sorting or inspecting any attacker-controlled names.
+        infos = archive.filelist
+        remaining_members = ARCHIVE_MAX_MEMBERS - budget.members
+        if len(infos) > remaining_members:
+            _exception(
+                result,
+                path=container_virtual_path,
+                reason=LedgerReason.ARCHIVE_MEMBER_LIMIT,
+            )
+            return
+        budget.members += len(infos)
+        infos = _sorted_infos(infos)
         current_type = _container_type([info.filename for info in infos])
+        effective_outer_disguised = (
+            outer_disguised
+            if outer_disguised is not None
+            else outer_expected_type is None or outer_expected_type != current_type
+        )
+        if depth == 1:
+            _record_outer_metadata(
+                result,
+                path=outer_path,
+                container_type=current_type,
+                hidden=outer_hidden,
+                disguised=effective_outer_disguised,
+            )
+        container_ancestry = (*ancestor_container_types, current_type)
+        inherited_reason_list: list[str] = []
+        if any(item in {"docx", "xlsx", "pptx"} for item in container_ancestry):
+            inherited_reason_list.append("document_container")
+        if outer_hidden:
+            inherited_reason_list.append("hidden_artifact")
+        if effective_outer_disguised:
+            inherited_reason_list.append("disguised_container")
+        inherited_reasons = tuple(inherited_reason_list)
+        seen_names: set[str] = set()
 
         for info in infos:
             if info.is_dir():
@@ -225,13 +351,6 @@ def _inspect_zip_bytes(
                     result, path=container_virtual_path, reason=LedgerReason.ARCHIVE_TIME_LIMIT
                 )
                 return
-            if budget.members >= ARCHIVE_MAX_MEMBERS:
-                _exception(
-                    result, path=container_virtual_path, reason=LedgerReason.ARCHIVE_MEMBER_LIMIT
-                )
-                return
-            budget.members += 1
-
             safe_name = _safe_member_name(info.filename)
             if safe_name is None:
                 _exception(
@@ -241,14 +360,33 @@ def _inspect_zip_bytes(
                 )
                 continue
             virtual_path = f"{container_virtual_path}!/{safe_name}"
+            if safe_name in seen_names or virtual_path in result.file_cache:
+                _exception(
+                    result,
+                    path=virtual_path,
+                    reason=LedgerReason.ARCHIVE_AMBIGUOUS_MEMBER_PATH,
+                )
+                continue
+            seen_names.add(safe_name)
+            member_path = _nested_path(outer_path, virtual_path)
+            concealment_reasons = tuple(
+                dict.fromkeys(
+                    (
+                        *inherited_reasons,
+                        *(("hidden_artifact",) if _is_hidden_path(safe_name) else ()),
+                    )
+                )
+            )
 
             if _zip_member_is_link(info):
                 _add_unreadable_component(
                     result,
                     virtual_path=virtual_path,
                     outer_path=outer_path,
-                    member_path=safe_name,
+                    member_path=member_path,
                     container_type=current_type,
+                    container_ancestry=container_ancestry,
+                    concealment_reasons=concealment_reasons,
                     depth=depth,
                 )
                 _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_LINK_MEMBER)
@@ -258,8 +396,10 @@ def _inspect_zip_bytes(
                     result,
                     virtual_path=virtual_path,
                     outer_path=outer_path,
-                    member_path=safe_name,
+                    member_path=member_path,
                     container_type=current_type,
+                    container_ancestry=container_ancestry,
+                    concealment_reasons=concealment_reasons,
                     depth=depth,
                 )
                 _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_ENCRYPTED)
@@ -271,8 +411,10 @@ def _inspect_zip_bytes(
                     result,
                     virtual_path=virtual_path,
                     outer_path=outer_path,
-                    member_path=safe_name,
+                    member_path=member_path,
                     container_type=current_type,
+                    container_ancestry=container_ancestry,
+                    concealment_reasons=concealment_reasons,
                     depth=depth,
                 )
                 _exception(
@@ -288,8 +430,10 @@ def _inspect_zip_bytes(
                     result,
                     virtual_path=virtual_path,
                     outer_path=outer_path,
-                    member_path=safe_name,
+                    member_path=member_path,
                     container_type=current_type,
+                    container_ancestry=container_ancestry,
+                    concealment_reasons=concealment_reasons,
                     depth=depth,
                 )
                 _exception(
@@ -305,8 +449,10 @@ def _inspect_zip_bytes(
                     result,
                     virtual_path=virtual_path,
                     outer_path=outer_path,
-                    member_path=safe_name,
+                    member_path=member_path,
                     container_type=current_type,
+                    container_ancestry=container_ancestry,
+                    concealment_reasons=concealment_reasons,
                     depth=depth,
                 )
                 _exception(
@@ -321,24 +467,50 @@ def _inspect_zip_bytes(
             try:
                 with archive.open(info) as source:
                     member_data = source.read(MAX_FILE_BYTES + 1)
-            except RuntimeError:
+            except NotImplementedError:
                 _add_unreadable_component(
                     result,
                     virtual_path=virtual_path,
                     outer_path=outer_path,
-                    member_path=safe_name,
+                    member_path=member_path,
                     container_type=current_type,
+                    container_ancestry=container_ancestry,
+                    concealment_reasons=concealment_reasons,
                     depth=depth,
                 )
-                _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_ENCRYPTED)
+                _exception(
+                    result,
+                    path=virtual_path,
+                    reason=LedgerReason.ARCHIVE_UNSUPPORTED_COMPRESSION,
+                )
+                continue
+            except RuntimeError as exc:
+                _add_unreadable_component(
+                    result,
+                    virtual_path=virtual_path,
+                    outer_path=outer_path,
+                    member_path=member_path,
+                    container_type=current_type,
+                    container_ancestry=container_ancestry,
+                    concealment_reasons=concealment_reasons,
+                    depth=depth,
+                )
+                reason = (
+                    LedgerReason.ARCHIVE_UNSUPPORTED_COMPRESSION
+                    if "compress" in str(exc).lower() or "not supported" in str(exc).lower()
+                    else LedgerReason.ARCHIVE_TRUNCATED
+                )
+                _exception(result, path=virtual_path, reason=reason)
                 continue
             except (zipfile.BadZipFile, EOFError, OSError, ValueError):
                 _add_unreadable_component(
                     result,
                     virtual_path=virtual_path,
                     outer_path=outer_path,
-                    member_path=safe_name,
+                    member_path=member_path,
                     container_type=current_type,
+                    container_ancestry=container_ancestry,
+                    concealment_reasons=concealment_reasons,
                     depth=depth,
                 )
                 _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_TRUNCATED)
@@ -349,8 +521,10 @@ def _inspect_zip_bytes(
                     result,
                     virtual_path=virtual_path,
                     outer_path=outer_path,
-                    member_path=safe_name,
+                    member_path=member_path,
                     container_type=current_type,
+                    container_ancestry=container_ancestry,
+                    concealment_reasons=concealment_reasons,
                     depth=depth,
                 )
                 _exception(
@@ -362,26 +536,65 @@ def _inspect_zip_bytes(
                 )
                 continue
 
+            if budget.expired():
+                _add_unreadable_component(
+                    result,
+                    virtual_path=virtual_path,
+                    outer_path=outer_path,
+                    member_path=member_path,
+                    container_type=current_type,
+                    container_ancestry=container_ancestry,
+                    concealment_reasons=concealment_reasons,
+                    depth=depth,
+                )
+                _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_TIME_LIMIT)
+                return
+            if budget.uncompressed_bytes + len(member_data) > ARCHIVE_MAX_UNCOMPRESSED_BYTES:
+                _add_unreadable_component(
+                    result,
+                    virtual_path=virtual_path,
+                    outer_path=outer_path,
+                    member_path=member_path,
+                    container_type=current_type,
+                    container_ancestry=container_ancestry,
+                    concealment_reasons=concealment_reasons,
+                    depth=depth,
+                )
+                _exception(
+                    result,
+                    path=virtual_path,
+                    reason=LedgerReason.ARCHIVE_SIZE_LIMIT,
+                    observed_bytes=budget.uncompressed_bytes + len(member_data),
+                    limit_bytes=ARCHIVE_MAX_UNCOMPRESSED_BYTES,
+                )
+                return
+            if len(member_data) > compressed * ARCHIVE_MAX_COMPRESSION_RATIO:
+                _add_unreadable_component(
+                    result,
+                    virtual_path=virtual_path,
+                    outer_path=outer_path,
+                    member_path=member_path,
+                    container_type=current_type,
+                    container_ancestry=container_ancestry,
+                    concealment_reasons=concealment_reasons,
+                    depth=depth,
+                )
+                _exception(
+                    result,
+                    path=virtual_path,
+                    reason=LedgerReason.ARCHIVE_COMPRESSION_RATIO,
+                    observed_bytes=len(member_data),
+                    limit_bytes=compressed * ARCHIVE_MAX_COMPRESSION_RATIO,
+                )
+                continue
+
             budget.uncompressed_bytes += len(member_data)
-            nested_type: str | None = None
             nested_zip = _is_zip_signature(member_data)
-            if nested_zip and zipfile.is_zipfile(io.BytesIO(member_data)):
-                try:
-                    with zipfile.ZipFile(io.BytesIO(member_data)) as nested_archive:
-                        nested_type = _container_type(
-                            [nested_info.filename for nested_info in nested_archive.infolist()]
-                        )
-                except (zipfile.BadZipFile, OSError, ValueError):
-                    nested_type = "zip"
+            nested_type: str | None = "zip" if nested_zip else None
 
             executable = _member_executable(info, safe_name, member_data)
             member_hidden = _is_hidden_path(safe_name)
-            concealed = executable and (
-                current_type in {"docx", "xlsx", "pptx"}
-                or outer_hidden
-                or outer_disguised
-                or member_hidden
-            )
+            concealed = executable and bool(concealment_reasons)
             virtual_type = _virtual_type(safe_name, member_data, nested_type)
             result.components.append(virtual_path)
             result.file_cache[virtual_path] = member_data.decode("utf-8", errors="replace")
@@ -397,21 +610,20 @@ def _inspect_zip_bytes(
                     "executable": executable,
                     "size_bytes": len(member_data),
                     "outer_path": outer_path,
-                    "nested_path": safe_name,
+                    "nested_path": member_path,
                     "container_type": current_type,
+                    "container_ancestry": list(container_ancestry),
                     "container_depth": depth,
                     "hidden": member_hidden,
                     "outer_hidden": outer_hidden,
-                    "outer_disguised": outer_disguised,
+                    "outer_disguised": effective_outer_disguised,
                     "local_only": True,
                     "concealed_executable": concealed,
+                    "concealment_reasons": list(concealment_reasons),
                 }
             )
 
             if not nested_zip:
-                continue
-            if not zipfile.is_zipfile(io.BytesIO(member_data)):
-                _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_MALFORMED)
                 continue
             if depth >= ARCHIVE_MAX_DEPTH:
                 _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_DEPTH_LIMIT)
@@ -422,7 +634,9 @@ def _inspect_zip_bytes(
                 container_virtual_path=virtual_path,
                 depth=depth + 1,
                 outer_hidden=outer_hidden,
-                outer_disguised=outer_disguised,
+                outer_disguised=effective_outer_disguised,
+                outer_expected_type=outer_expected_type,
+                ancestor_container_types=container_ancestry,
                 budget=budget,
                 result=result,
             )
@@ -438,6 +652,9 @@ def inspect_nested_artifacts(
     result = NestedInspectionResult()
     for path in components:
         full_path = skill_dir / path
+        expected_type = _expected_container_type(path)
+        hidden = _is_hidden_path(path)
+
         try:
             size = full_path.stat().st_size
         except OSError:
@@ -451,12 +668,32 @@ def inspect_nested_artifacts(
             except (OSError, _FileOpenError, _UnsafeFileError):
                 continue
             if _is_zip_signature(signature):
+                _record_outer_metadata(
+                    result,
+                    path=path,
+                    container_type=expected_type or "zip",
+                    hidden=hidden,
+                    disguised=expected_type is None,
+                )
                 _exception(
                     result,
                     path=path,
                     reason=LedgerReason.ARCHIVE_SIZE_LIMIT,
                     observed_bytes=size,
                     limit_bytes=ARCHIVE_MAX_UNCOMPRESSED_BYTES,
+                )
+            elif expected_type is not None:
+                _record_outer_metadata(
+                    result,
+                    path=path,
+                    container_type=expected_type,
+                    hidden=hidden,
+                    disguised=False,
+                )
+                _exception(
+                    result,
+                    path=path,
+                    reason=LedgerReason.ARCHIVE_FORMAT_MISMATCH,
                 )
             continue
         try:
@@ -465,27 +702,29 @@ def inspect_nested_artifacts(
         except (OSError, _FileOpenError, _UnsafeFileError):
             continue
         if not _is_zip_signature(data):
+            if expected_type is not None:
+                _record_outer_metadata(
+                    result,
+                    path=path,
+                    container_type=expected_type,
+                    hidden=hidden,
+                    disguised=False,
+                )
+                _exception(
+                    result,
+                    path=path,
+                    reason=LedgerReason.ARCHIVE_FORMAT_MISMATCH,
+                )
             continue
-        if not zipfile.is_zipfile(io.BytesIO(data)):
-            _exception(result, path=path, reason=LedgerReason.ARCHIVE_MALFORMED)
-            continue
-
-        try:
-            with zipfile.ZipFile(io.BytesIO(data)) as archive:
-                container_type = _container_type([info.filename for info in archive.infolist()])
-        except (zipfile.BadZipFile, OSError, ValueError):
-            _exception(result, path=path, reason=LedgerReason.ARCHIVE_MALFORMED)
-            continue
-
-        hidden = _is_hidden_path(path)
-        disguised = Path(path).suffix.lower() not in _EXPECTED_SUFFIXES[container_type]
-        result.outer_metadata[path] = {
-            "type": container_type,
-            "container_type": container_type,
-            "hidden": hidden,
-            "disguised": disguised,
-            "local_only": hidden or disguised,
-        }
+        # Record a conservative local-only identity before parsing the central
+        # directory. The bounded inspector refines this after its early checks.
+        _record_outer_metadata(
+            result,
+            path=path,
+            container_type=expected_type or "zip",
+            hidden=hidden,
+            disguised=expected_type is None,
+        )
         budget = _Budget(started_at=clock(), clock=clock)
         _inspect_zip_bytes(
             data,
@@ -493,7 +732,9 @@ def inspect_nested_artifacts(
             container_virtual_path=path,
             depth=1,
             outer_hidden=hidden,
-            outer_disguised=disguised,
+            outer_disguised=None,
+            outer_expected_type=expected_type,
+            ancestor_container_types=(),
             budget=budget,
             result=result,
         )

--- a/src/skillspector/nested_artifacts.py
+++ b/src/skillspector/nested_artifacts.py
@@ -1,0 +1,502 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded, local-only inspection of ZIP-compatible nested artifacts.
+
+The inspector never extracts members to disk and never renders, imports, or
+executes their contents.  It recognizes ZIP-compatible content by bytes, gives
+every member a stable virtual path, and returns text projections solely for
+deterministic analyzers.
+"""
+
+from __future__ import annotations
+
+import io
+import stat
+import time
+import zipfile
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+
+from skillspector.constants import MAX_FILE_BYTES
+from skillspector.input_handler import (
+    _FileOpenError,
+    _open_regular_file_no_follow,
+    _UnsafeFileError,
+)
+from skillspector.inspection_ledger import (
+    InspectionLedgerEvent,
+    LedgerOutcome,
+    LedgerReason,
+    LedgerRecordType,
+    ledger_event,
+)
+
+ARCHIVE_MAX_DEPTH = 3
+ARCHIVE_MAX_MEMBERS = 1_000
+ARCHIVE_MAX_UNCOMPRESSED_BYTES = 25 * 1024 * 1024
+ARCHIVE_MAX_COMPRESSION_RATIO = 100
+ARCHIVE_MAX_SECONDS = 5.0
+
+_ZIP_SIGNATURES = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
+_EXECUTABLE_SUFFIXES = frozenset(
+    {".py", ".sh", ".bash", ".zsh", ".js", ".ts", ".rb", ".go", ".rs", ".pl"}
+)
+_OOXML_MARKERS: tuple[tuple[str, str], ...] = (
+    ("word/", "docx"),
+    ("xl/", "xlsx"),
+    ("ppt/", "pptx"),
+)
+_EXPECTED_SUFFIXES: dict[str, frozenset[str]] = {
+    "docx": frozenset({".docx", ".docm", ".dotx", ".dotm"}),
+    "xlsx": frozenset({".xlsx", ".xlsm", ".xltx", ".xltm"}),
+    "pptx": frozenset({".pptx", ".pptm", ".potx", ".potm", ".ppsx", ".ppsm"}),
+    "zip": frozenset({".zip"}),
+}
+
+
+@dataclass
+class NestedInspectionResult:
+    """Virtual inventory and local-only content derived from nested artifacts."""
+
+    components: list[str] = field(default_factory=list)
+    file_cache: dict[str, str] = field(default_factory=dict)
+    metadata: list[dict[str, object]] = field(default_factory=list)
+    outer_metadata: dict[str, dict[str, object]] = field(default_factory=dict)
+    ledger_events: list[InspectionLedgerEvent] = field(default_factory=list)
+
+
+@dataclass
+class _Budget:
+    started_at: float
+    clock: Callable[[], float]
+    members: int = 0
+    uncompressed_bytes: int = 0
+
+    def expired(self) -> bool:
+        return self.clock() - self.started_at > ARCHIVE_MAX_SECONDS
+
+
+def _is_zip_signature(data: bytes) -> bool:
+    return data.startswith(_ZIP_SIGNATURES)
+
+
+def _is_hidden_path(path: str) -> bool:
+    return any(part.startswith(".") for part in path.replace("\\", "/").split("/") if part)
+
+
+def _container_type(names: list[str]) -> str:
+    normalized = [name.replace("\\", "/").lower() for name in names]
+    if "[content_types].xml" in normalized:
+        for marker, container_type in _OOXML_MARKERS:
+            if any(name.startswith(marker) for name in normalized):
+                return container_type
+    return "zip"
+
+
+def _safe_member_name(name: str) -> str | None:
+    normalized = name.replace("\\", "/")
+    if not normalized or "\x00" in normalized or normalized.startswith(("/", "//")):
+        return None
+    if len(normalized) >= 2 and normalized[1] == ":":
+        return None
+    parts = PurePosixPath(normalized).parts
+    if not parts or any(part in ("", ".", "..") for part in parts):
+        return None
+    return PurePosixPath(*parts).as_posix()
+
+
+def _zip_member_is_link(info: zipfile.ZipInfo) -> bool:
+    mode = info.external_attr >> 16
+    return bool(mode and stat.S_ISLNK(mode))
+
+
+def _member_executable(info: zipfile.ZipInfo, safe_name: str, data: bytes) -> bool:
+    suffix = Path(safe_name).suffix.lower()
+    mode = info.external_attr >> 16
+    return suffix in _EXECUTABLE_SUFFIXES or data.startswith(b"#!") or bool(mode & 0o111)
+
+
+def _virtual_type(path: str, data: bytes, nested_type: str | None) -> str:
+    if nested_type is not None:
+        return nested_type
+    suffix = Path(path).suffix.lower()
+    return {
+        ".md": "markdown",
+        ".markdown": "markdown",
+        ".py": "python",
+        ".sh": "shell",
+        ".bash": "shell",
+        ".zsh": "shell",
+        ".json": "json",
+        ".yaml": "yaml",
+        ".yml": "yaml",
+        ".toml": "toml",
+        ".txt": "text",
+        ".js": "javascript",
+        ".ts": "typescript",
+        ".rb": "ruby",
+        ".go": "go",
+        ".rs": "rust",
+        ".xml": "xml",
+    }.get(suffix, "binary" if b"\x00" in data[:8192] else "text")
+
+
+def _exception(
+    result: NestedInspectionResult,
+    *,
+    path: str,
+    reason: LedgerReason,
+    observed_bytes: int | None = None,
+    limit_bytes: int | None = None,
+) -> None:
+    result.ledger_events.append(
+        ledger_event(
+            outcome=LedgerOutcome.SKIPPED,
+            record_type=LedgerRecordType.SYSTEM,
+            phase="nested_artifact_inspection",
+            path=path,
+            reason=reason,
+            observed_bytes=observed_bytes,
+            limit_bytes=limit_bytes,
+        )
+    )
+
+
+def _add_unreadable_component(
+    result: NestedInspectionResult,
+    *,
+    virtual_path: str,
+    outer_path: str,
+    member_path: str,
+    container_type: str,
+    depth: int,
+) -> None:
+    if virtual_path not in result.file_cache:
+        result.components.append(virtual_path)
+        # A binary sentinel lets ordinary analyzers account for the component
+        # without pretending that inaccessible bytes were inspected as text.
+        result.file_cache[virtual_path] = "\x00"
+        result.metadata.append(
+            {
+                "path": virtual_path,
+                "type": "binary",
+                "lines": 0,
+                "executable": False,
+                "size_bytes": 0,
+                "outer_path": outer_path,
+                "nested_path": member_path,
+                "container_type": container_type,
+                "container_depth": depth,
+                "hidden": _is_hidden_path(member_path),
+                "local_only": True,
+                "concealed_executable": False,
+            }
+        )
+
+
+def _inspect_zip_bytes(
+    data: bytes,
+    *,
+    outer_path: str,
+    container_virtual_path: str,
+    depth: int,
+    outer_hidden: bool,
+    outer_disguised: bool,
+    budget: _Budget,
+    result: NestedInspectionResult,
+) -> None:
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(data))
+    except (zipfile.BadZipFile, OSError, ValueError):
+        _exception(result, path=container_virtual_path, reason=LedgerReason.ARCHIVE_MALFORMED)
+        return
+
+    with archive:
+        infos = sorted(archive.infolist(), key=lambda item: item.filename)
+        current_type = _container_type([info.filename for info in infos])
+
+        for info in infos:
+            if info.is_dir():
+                continue
+            if budget.expired():
+                _exception(
+                    result, path=container_virtual_path, reason=LedgerReason.ARCHIVE_TIME_LIMIT
+                )
+                return
+            if budget.members >= ARCHIVE_MAX_MEMBERS:
+                _exception(
+                    result, path=container_virtual_path, reason=LedgerReason.ARCHIVE_MEMBER_LIMIT
+                )
+                return
+            budget.members += 1
+
+            safe_name = _safe_member_name(info.filename)
+            if safe_name is None:
+                _exception(
+                    result,
+                    path=container_virtual_path,
+                    reason=LedgerReason.ARCHIVE_UNSAFE_MEMBER_PATH,
+                )
+                continue
+            virtual_path = f"{container_virtual_path}!/{safe_name}"
+
+            if _zip_member_is_link(info):
+                _add_unreadable_component(
+                    result,
+                    virtual_path=virtual_path,
+                    outer_path=outer_path,
+                    member_path=safe_name,
+                    container_type=current_type,
+                    depth=depth,
+                )
+                _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_LINK_MEMBER)
+                continue
+            if info.flag_bits & 0x1:
+                _add_unreadable_component(
+                    result,
+                    virtual_path=virtual_path,
+                    outer_path=outer_path,
+                    member_path=safe_name,
+                    container_type=current_type,
+                    depth=depth,
+                )
+                _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_ENCRYPTED)
+                continue
+
+            compressed = max(info.compress_size, 1)
+            if info.file_size > compressed * ARCHIVE_MAX_COMPRESSION_RATIO:
+                _add_unreadable_component(
+                    result,
+                    virtual_path=virtual_path,
+                    outer_path=outer_path,
+                    member_path=safe_name,
+                    container_type=current_type,
+                    depth=depth,
+                )
+                _exception(
+                    result,
+                    path=virtual_path,
+                    reason=LedgerReason.ARCHIVE_COMPRESSION_RATIO,
+                    observed_bytes=info.file_size,
+                    limit_bytes=compressed * ARCHIVE_MAX_COMPRESSION_RATIO,
+                )
+                continue
+            if budget.uncompressed_bytes + info.file_size > ARCHIVE_MAX_UNCOMPRESSED_BYTES:
+                _add_unreadable_component(
+                    result,
+                    virtual_path=virtual_path,
+                    outer_path=outer_path,
+                    member_path=safe_name,
+                    container_type=current_type,
+                    depth=depth,
+                )
+                _exception(
+                    result,
+                    path=virtual_path,
+                    reason=LedgerReason.ARCHIVE_SIZE_LIMIT,
+                    observed_bytes=budget.uncompressed_bytes + info.file_size,
+                    limit_bytes=ARCHIVE_MAX_UNCOMPRESSED_BYTES,
+                )
+                continue
+            if info.file_size > MAX_FILE_BYTES:
+                _add_unreadable_component(
+                    result,
+                    virtual_path=virtual_path,
+                    outer_path=outer_path,
+                    member_path=safe_name,
+                    container_type=current_type,
+                    depth=depth,
+                )
+                _exception(
+                    result,
+                    path=virtual_path,
+                    reason=LedgerReason.ARCHIVE_MEMBER_SIZE_LIMIT,
+                    observed_bytes=info.file_size,
+                    limit_bytes=MAX_FILE_BYTES,
+                )
+                continue
+
+            try:
+                with archive.open(info) as source:
+                    member_data = source.read(MAX_FILE_BYTES + 1)
+            except RuntimeError:
+                _add_unreadable_component(
+                    result,
+                    virtual_path=virtual_path,
+                    outer_path=outer_path,
+                    member_path=safe_name,
+                    container_type=current_type,
+                    depth=depth,
+                )
+                _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_ENCRYPTED)
+                continue
+            except (zipfile.BadZipFile, EOFError, OSError, ValueError):
+                _add_unreadable_component(
+                    result,
+                    virtual_path=virtual_path,
+                    outer_path=outer_path,
+                    member_path=safe_name,
+                    container_type=current_type,
+                    depth=depth,
+                )
+                _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_TRUNCATED)
+                continue
+
+            if len(member_data) > MAX_FILE_BYTES:
+                _add_unreadable_component(
+                    result,
+                    virtual_path=virtual_path,
+                    outer_path=outer_path,
+                    member_path=safe_name,
+                    container_type=current_type,
+                    depth=depth,
+                )
+                _exception(
+                    result,
+                    path=virtual_path,
+                    reason=LedgerReason.ARCHIVE_MEMBER_SIZE_LIMIT,
+                    observed_bytes=len(member_data),
+                    limit_bytes=MAX_FILE_BYTES,
+                )
+                continue
+
+            budget.uncompressed_bytes += len(member_data)
+            nested_type: str | None = None
+            nested_zip = _is_zip_signature(member_data)
+            if nested_zip and zipfile.is_zipfile(io.BytesIO(member_data)):
+                try:
+                    with zipfile.ZipFile(io.BytesIO(member_data)) as nested_archive:
+                        nested_type = _container_type(
+                            [nested_info.filename for nested_info in nested_archive.infolist()]
+                        )
+                except (zipfile.BadZipFile, OSError, ValueError):
+                    nested_type = "zip"
+
+            executable = _member_executable(info, safe_name, member_data)
+            member_hidden = _is_hidden_path(safe_name)
+            concealed = executable and (
+                current_type in {"docx", "xlsx", "pptx"}
+                or outer_hidden
+                or outer_disguised
+                or member_hidden
+            )
+            virtual_type = _virtual_type(safe_name, member_data, nested_type)
+            result.components.append(virtual_path)
+            result.file_cache[virtual_path] = member_data.decode("utf-8", errors="replace")
+            result.metadata.append(
+                {
+                    "path": virtual_path,
+                    "type": virtual_type,
+                    "lines": (
+                        0
+                        if virtual_type == "binary"
+                        else len(result.file_cache[virtual_path].splitlines())
+                    ),
+                    "executable": executable,
+                    "size_bytes": len(member_data),
+                    "outer_path": outer_path,
+                    "nested_path": safe_name,
+                    "container_type": current_type,
+                    "container_depth": depth,
+                    "hidden": member_hidden,
+                    "outer_hidden": outer_hidden,
+                    "outer_disguised": outer_disguised,
+                    "local_only": True,
+                    "concealed_executable": concealed,
+                }
+            )
+
+            if not nested_zip:
+                continue
+            if not zipfile.is_zipfile(io.BytesIO(member_data)):
+                _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_MALFORMED)
+                continue
+            if depth >= ARCHIVE_MAX_DEPTH:
+                _exception(result, path=virtual_path, reason=LedgerReason.ARCHIVE_DEPTH_LIMIT)
+                continue
+            _inspect_zip_bytes(
+                member_data,
+                outer_path=outer_path,
+                container_virtual_path=virtual_path,
+                depth=depth + 1,
+                outer_hidden=outer_hidden,
+                outer_disguised=outer_disguised,
+                budget=budget,
+                result=result,
+            )
+
+
+def inspect_nested_artifacts(
+    skill_dir: Path,
+    components: list[str],
+    *,
+    clock: Callable[[], float] = time.monotonic,
+) -> NestedInspectionResult:
+    """Inspect ZIP-compatible filesystem components under cumulative bounds."""
+    result = NestedInspectionResult()
+    for path in components:
+        full_path = skill_dir / path
+        try:
+            size = full_path.stat().st_size
+        except OSError:
+            continue
+        if size > ARCHIVE_MAX_UNCOMPRESSED_BYTES:
+            # Only classify content that begins like ZIP; avoid reading arbitrary
+            # large files merely to decide whether they are containers.
+            try:
+                with _open_regular_file_no_follow(full_path) as source:
+                    signature = source.read(4)
+            except (OSError, _FileOpenError, _UnsafeFileError):
+                continue
+            if _is_zip_signature(signature):
+                _exception(
+                    result,
+                    path=path,
+                    reason=LedgerReason.ARCHIVE_SIZE_LIMIT,
+                    observed_bytes=size,
+                    limit_bytes=ARCHIVE_MAX_UNCOMPRESSED_BYTES,
+                )
+            continue
+        try:
+            with _open_regular_file_no_follow(full_path) as source:
+                data = source.read(ARCHIVE_MAX_UNCOMPRESSED_BYTES + 1)
+        except (OSError, _FileOpenError, _UnsafeFileError):
+            continue
+        if not _is_zip_signature(data):
+            continue
+        if not zipfile.is_zipfile(io.BytesIO(data)):
+            _exception(result, path=path, reason=LedgerReason.ARCHIVE_MALFORMED)
+            continue
+
+        try:
+            with zipfile.ZipFile(io.BytesIO(data)) as archive:
+                container_type = _container_type([info.filename for info in archive.infolist()])
+        except (zipfile.BadZipFile, OSError, ValueError):
+            _exception(result, path=path, reason=LedgerReason.ARCHIVE_MALFORMED)
+            continue
+
+        hidden = _is_hidden_path(path)
+        disguised = Path(path).suffix.lower() not in _EXPECTED_SUFFIXES[container_type]
+        result.outer_metadata[path] = {
+            "type": container_type,
+            "container_type": container_type,
+            "hidden": hidden,
+            "disguised": disguised,
+            "local_only": hidden or disguised,
+        }
+        budget = _Budget(started_at=clock(), clock=clock)
+        _inspect_zip_bytes(
+            data,
+            outer_path=path,
+            container_virtual_path=path,
+            depth=1,
+            outer_hidden=hidden,
+            outer_disguised=disguised,
+            budget=budget,
+            result=result,
+        )
+
+    result.components = list(dict.fromkeys(result.components))
+    return result

--- a/src/skillspector/nodes/analyzers/behavioral_ast.py
+++ b/src/skillspector/nodes/analyzers/behavioral_ast.py
@@ -332,7 +332,7 @@ def _analyze_python(python_ast: ParsedPythonFile, file_path: str) -> list[Analyz
 def node(state: SkillspectorState) -> AnalyzerNodeResponse:
     """Parse Python files via AST and detect dangerous execution patterns."""
     components: list[str] = state.get("components") or []
-    file_cache: dict[str, str] = state.get("file_cache") or {}
+    file_cache: dict[str, str] = state.get("local_file_cache") or state.get("file_cache") or {}
     python_ast_cache_key = state.get("python_ast_cache_key")
     all_findings: list[Finding] = []
     ledger_events: list[InspectionLedgerEvent] = []

--- a/src/skillspector/nodes/analyzers/behavioral_taint_tracking.py
+++ b/src/skillspector/nodes/analyzers/behavioral_taint_tracking.py
@@ -461,7 +461,7 @@ def _analyze_python(python_ast: ParsedPythonFile, file_path: str) -> list[Analyz
 def node(state: SkillspectorState) -> AnalyzerNodeResponse:
     """Parse Python files and detect source\u2192sink data flows."""
     components: list[str] = state.get("components") or []
-    file_cache: dict[str, str] = state.get("file_cache") or {}
+    file_cache: dict[str, str] = state.get("local_file_cache") or state.get("file_cache") or {}
     python_ast_cache_key = state.get("python_ast_cache_key")
     all_findings: list[Finding] = []
     ledger_events: list[InspectionLedgerEvent] = []

--- a/src/skillspector/nodes/analyzers/mcp_least_privilege.py
+++ b/src/skillspector/nodes/analyzers/mcp_least_privilege.py
@@ -214,7 +214,7 @@ def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
 def node(state: SkillspectorState) -> AnalyzerNodeResponse:
     """Analyze manifest permissions vs code capabilities; emit LP1-LP4 findings."""
     manifest: dict = state.get("manifest") or {}
-    file_cache: dict[str, str] = state.get("file_cache") or {}
+    file_cache: dict[str, str] = state.get("local_file_cache") or state.get("file_cache") or {}
     component_metadata: list[dict] = state.get("component_metadata") or []
 
     # Skip: no manifest

--- a/src/skillspector/nodes/analyzers/mcp_rug_pull.py
+++ b/src/skillspector/nodes/analyzers/mcp_rug_pull.py
@@ -369,7 +369,7 @@ def _check_rp3(manifest: dict) -> list[Finding]:
 def node(state: SkillspectorState) -> AnalyzerNodeResponse:
     """Analyze skill for rug-pull risks (RP1–RP3)."""
     manifest: dict = state.get("manifest") or {}
-    file_cache: dict[str, str] = state.get("file_cache") or {}
+    file_cache: dict[str, str] = state.get("local_file_cache") or state.get("file_cache") or {}
     previous_manifest: dict | None = state.get("previous_manifest")
 
     if not manifest and not file_cache:

--- a/src/skillspector/nodes/analyzers/pattern_defaults.py
+++ b/src/skillspector/nodes/analyzers/pattern_defaults.py
@@ -94,6 +94,7 @@ DEFAULT_EXPLANATIONS: dict[str, str] = {
     "SC6": "Package name closely resembles a popular package, suggesting possible typosquatting. Attackers publish malicious packages with similar names to trick developers into installing them.",
     "SC7": "Code pulls a container image with signature or registry verification disabled (--disable-content-trust, DOCKER_CONTENT_TRUST=0, --insecure-registry). This accepts tampered or unverified images and is a container supply-chain risk.",
     "SC8": "Skill ships Python bytecode (__pycache__/ or .pyc/.pyo). Discovery skips these paths, so malicious bytecode can score SAFE while decoy sources look clean.",
+    "SC9": "Executable content is concealed inside a document container or hidden/disguised artifact, where extension-based review can miss it.",
     # Trigger Abuse
     "TR1": "Skill uses overly broad trigger patterns that match common words or phrases, causing it to activate in unintended contexts and potentially shadow other skills.",
     "TR2": "Skill trigger shadows a common built-in command or another skill's trigger, potentially intercepting requests meant for trusted functionality.",
@@ -193,6 +194,7 @@ RULE_ID_TO_CATEGORY: dict[str, str] = {
     "SC6": PatternCategory.SUPPLY_CHAIN.value,
     "SC7": PatternCategory.SUPPLY_CHAIN.value,
     "SC8": PatternCategory.SUPPLY_CHAIN.value,
+    "SC9": PatternCategory.SUPPLY_CHAIN.value,
     "TR1": PatternCategory.TRIGGER_ABUSE.value,
     "TR2": PatternCategory.TRIGGER_ABUSE.value,
     "TR3": PatternCategory.TRIGGER_ABUSE.value,
@@ -279,6 +281,7 @@ PATTERN_NAMES: dict[str, str] = {
     "SC6": "Typosquatting Dependency",
     "SC7": "Untrusted Container Image",
     "SC8": "Shipped Python Bytecode",
+    "SC9": "Concealed Executable Artifact",
     "TR1": "Overly Broad Trigger",
     "TR2": "Shadow Command Trigger",
     "TR3": "Keyword Baiting Trigger",
@@ -374,6 +377,7 @@ DEFAULT_REMEDIATIONS: dict[str, str] = {
     "SC6": "Verify the package name is correct and not a typosquatting variant. Compare against the official package name on PyPI or npm.",
     "SC7": "Keep image signature verification (Docker Content Trust / cosign) and registry TLS enabled. Pull only signed images from trusted registries; never disable content-trust or use insecure registries in skill code.",
     "SC8": "Do not ship __pycache__/ or .pyc/.pyo in skills. Delete bytecode before packaging; if presence is intentional for a lab fixture, quarantine it outside the skill install path.",
+    "SC9": "Keep executable files explicit and directly reviewable. Review the artifact provenance and why executable content is packaged inside a document, hidden file, or disguised container.",
     # Trigger Abuse
     "TR1": "Use specific, narrow trigger patterns that match only the skill's intended use case. Avoid single-word or common-phrase triggers.",
     "TR2": "Choose triggers that do not conflict with built-in commands or other skills. Prefix with a unique namespace if necessary.",

--- a/src/skillspector/nodes/analyzers/semantic_security_discovery.py
+++ b/src/skillspector/nodes/analyzers/semantic_security_discovery.py
@@ -97,7 +97,11 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
         }
 
     file_cache: dict[str, str] = state.get("file_cache") or {}
-    components: list[str] = state.get("components") or sorted(file_cache.keys())
+    components: list[str] = (
+        state.get("llm_components", [])
+        if "llm_components" in state
+        else state.get("components") or sorted(file_cache.keys())
+    )
     if not components:
         return {
             "findings": [],

--- a/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Static patterns: supply chain (SC1–SC8) and trigger analysis (TR1–TR3).
+"""Static patterns: supply chain (SC1–SC9) and trigger analysis (TR1–TR3).
 
 SC1–SC3: regex-based pattern matching (original implementation).
 SC4: Known vulnerable dependencies — live OSV.dev lookup with static fallback.
@@ -21,6 +21,7 @@ SC5: Abandoned dependencies — flags known-abandoned or archived packages.
 SC6: Typosquatting — flags package names similar to popular packages.
 SC7: Untrusted container image — flags image signature / registry-verification bypass.
 SC8: Shipped Python bytecode — flags __pycache__/ and *.pyc/*.pyo that discovery skips.
+SC9: Concealed executable artifact — flags executables nested in document or hidden artifacts.
 TR1–TR3: Trigger analysis — flags overly broad, shadowing, or baiting triggers.
 
 Node and analyze() in one module.
@@ -1260,13 +1261,72 @@ def _analyze_shipped_bytecode(skill_path: str) -> list[Finding]:
     return findings
 
 
+def _analyze_concealed_executables(
+    component_metadata: list[dict[str, object]],
+) -> list[Finding]:
+    """Emit SC9 for executable content concealed in a local-only artifact."""
+    findings: list[Finding] = []
+    for metadata in component_metadata:
+        if not metadata.get("concealed_executable"):
+            continue
+        path = str(metadata.get("path", ""))
+        if not path:
+            continue
+        outer_path = str(metadata.get("outer_path", path.split("!/", 1)[0]))
+        nested_path = path.split("!/", 1)[1] if "!/" in path else path
+        container_type = str(metadata.get("container_type", "zip"))
+        if container_type in {"docx", "xlsx", "pptx"}:
+            concealment = "document_container"
+        elif metadata.get("outer_hidden") or metadata.get("hidden"):
+            concealment = "hidden_artifact"
+        else:
+            concealment = "disguised_container"
+        findings.append(
+            Finding(
+                rule_id="SC9",
+                message=(
+                    "Executable content is concealed inside a document, hidden, "
+                    "or disguised artifact."
+                ),
+                severity="HIGH",
+                confidence=1.0,
+                file=path,
+                start_line=1,
+                category="Supply Chain",
+                pattern="Concealed Executable Artifact",
+                finding=nested_path,
+                explanation=(
+                    "An executable nested in a document or hidden/disguised artifact can "
+                    "evade ordinary extension-based review while still being available to "
+                    "the skill at runtime."
+                ),
+                remediation=(
+                    "Review the artifact provenance and the reason executable content is "
+                    "packaged in this location; keep executable files explicit and directly "
+                    "reviewable."
+                ),
+                tags=["supply-chain", "concealed-executable", "local-only"],
+                matched_text=path,
+                evidence={
+                    "outer_path": outer_path,
+                    "nested_path": nested_path,
+                    "container_type": container_type,
+                    "container_depth": metadata.get("container_depth", 1),
+                    "concealment": concealment,
+                    "local_only": True,
+                },
+            )
+        )
+    return findings
+
+
 # ---------------------------------------------------------------------------
 # Graph node
 # ---------------------------------------------------------------------------
 
 
 def node(state: SkillspectorState) -> AnalyzerNodeResponse:
-    """Run supply_chain patterns (SC1–SC8) and trigger analysis (TR1–TR3)."""
+    """Run supply_chain patterns (SC1–SC9) and trigger analysis (TR1–TR3)."""
     # SC1–SC3 via static_runner
     response = static_runner.run_static_patterns_with_ledger(state, [sys.modules[__name__]])
     findings = response["findings"]
@@ -1296,7 +1356,7 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
 
     # SC4–SC6: dependency-level analysis on dependency files
     components: list[str] = state.get("components") or []
-    file_cache: dict[str, str] = state.get("file_cache") or {}
+    file_cache: dict[str, str] = state.get("local_file_cache") or state.get("file_cache") or {}
     locked_versions = _collect_locked_versions(file_cache, components)
     for path in components:
         lower_path = path.lower()
@@ -1353,6 +1413,17 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
                 ],
                 f"{ANALYZER_ID}_bytecode",
             )
+
+    # SC9: executables concealed in document containers or hidden/disguised artifacts.
+    component_metadata: list[dict[str, object]] = state.get("component_metadata") or []
+    concealed_findings = _analyze_concealed_executables(component_metadata)
+    findings.extend(concealed_findings)
+    for finding_path in sorted({finding.file for finding in concealed_findings}):
+        record_extra_findings(
+            finding_path,
+            [finding for finding in concealed_findings if finding.file == finding_path],
+            f"{ANALYZER_ID}_concealed_executable",
+        )
 
     logger.info("%s: %d findings", ANALYZER_ID, len(findings))
     response["analyzer_status_events"] = [

--- a/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
@@ -1273,14 +1273,22 @@ def _analyze_concealed_executables(
         if not path:
             continue
         outer_path = str(metadata.get("outer_path", path.split("!/", 1)[0]))
-        nested_path = path.split("!/", 1)[1] if "!/" in path else path
+        nested_path = str(
+            metadata.get("nested_path", path.split("!/", 1)[1] if "!/" in path else path)
+        )
         container_type = str(metadata.get("container_type", "zip"))
-        if container_type in {"docx", "xlsx", "pptx"}:
-            concealment = "document_container"
-        elif metadata.get("outer_hidden") or metadata.get("hidden"):
-            concealment = "hidden_artifact"
-        else:
-            concealment = "disguised_container"
+        raw_reasons = metadata.get("concealment_reasons", [])
+        concealment_reasons = (
+            [str(item) for item in raw_reasons] if isinstance(raw_reasons, list) else []
+        )
+        if not concealment_reasons:
+            if container_type in {"docx", "xlsx", "pptx"}:
+                concealment_reasons.append("document_container")
+            elif metadata.get("outer_hidden") or metadata.get("hidden"):
+                concealment_reasons.append("hidden_artifact")
+            else:
+                concealment_reasons.append("disguised_container")
+        concealment = concealment_reasons[0]
         findings.append(
             Finding(
                 rule_id="SC9",
@@ -1311,8 +1319,10 @@ def _analyze_concealed_executables(
                     "outer_path": outer_path,
                     "nested_path": nested_path,
                     "container_type": container_type,
+                    "container_ancestry": metadata.get("container_ancestry", [container_type]),
                     "container_depth": metadata.get("container_depth", 1),
                     "concealment": concealment,
+                    "concealment_reasons": concealment_reasons,
                     "local_only": True,
                 },
             )

--- a/src/skillspector/nodes/analyzers/static_runner.py
+++ b/src/skillspector/nodes/analyzers/static_runner.py
@@ -310,6 +310,7 @@ def analyzer_finding_to_finding(
         explanation=get_explanation(af.rule_id),
         code_snippet=af.context,
         intent=None,
+        evidence=dict(af.evidence),
     )
 
 
@@ -398,11 +399,21 @@ def run_static_patterns(
     converts all AnalyzerFindings to Finding via analyzer_finding_to_finding, returns combined list.
     """
     components = cast(list[str], state.get("components") or [])
-    file_cache = cast(dict[str, str], state.get("file_cache") or {})
+    file_cache = cast(
+        dict[str, str], state.get("local_file_cache") or state.get("file_cache") or {}
+    )
     python_ast_cache_key = cast(str | None, state.get("python_ast_cache_key"))
+    container_paths = {
+        str(metadata.get("path", ""))
+        for metadata in cast(list[dict[str, object]], state.get("component_metadata") or [])
+        if metadata.get("container_type") in {"zip", "docx", "xlsx", "pptx"}
+        and "!/" not in str(metadata.get("path", ""))
+    }
     findings: list[Finding] = []
 
     for path in components:
+        if path in container_paths:
+            continue
         if _is_eval_dataset(path):
             logger.debug("Skipping eval dataset prose for static pattern scan: %s", path)
             continue
@@ -433,13 +444,28 @@ def run_static_patterns_with_ledger(
     """Run one static analyzer and account for every planned file work item."""
     analyzer_id = str(getattr(pattern_modules[0], "ANALYZER_ID", "static_patterns"))
     components = cast(list[str], state.get("components") or [])
-    file_cache = cast(dict[str, str], state.get("file_cache") or {})
+    file_cache = cast(
+        dict[str, str], state.get("local_file_cache") or state.get("file_cache") or {}
+    )
     python_ast_cache_key = cast(str | None, state.get("python_ast_cache_key"))
+    container_paths = {
+        str(metadata.get("path", ""))
+        for metadata in cast(list[dict[str, object]], state.get("component_metadata") or [])
+        if metadata.get("container_type") in {"zip", "docx", "xlsx", "pptx"}
+        and "!/" not in str(metadata.get("path", ""))
+    }
     findings: list[Finding] = []
     events: list[InspectionLedgerEvent] = []
 
     for path in components:
-        if _is_eval_dataset(path):
+        if path in container_paths:
+            event = ledger_event(
+                outcome=LedgerOutcome.COMPLETED,
+                phase="static",
+                analyzer_id=analyzer_id,
+                path=path,
+            )
+        elif _is_eval_dataset(path):
             event = ledger_event(
                 outcome=LedgerOutcome.SKIPPED,
                 phase="static",

--- a/src/skillspector/nodes/analyzers/static_yara.py
+++ b/src/skillspector/nodes/analyzers/static_yara.py
@@ -335,7 +335,7 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
         }
 
     components: list[str] = state.get("components") or []
-    file_cache: dict[str, str] = state.get("file_cache") or {}
+    file_cache: dict[str, str] = state.get("local_file_cache") or state.get("file_cache") or {}
     findings = []
     events: list[InspectionLedgerEvent] = []
 

--- a/src/skillspector/nodes/build_context.py
+++ b/src/skillspector/nodes/build_context.py
@@ -46,7 +46,7 @@ from skillspector.inspection_ledger import (
     ledger_event,
 )
 from skillspector.logging_config import get_logger
-from skillspector.nested_artifacts import inspect_nested_artifacts
+from skillspector.nested_artifacts import inspect_nested_artifacts, is_executable_content
 from skillspector.python_ast import prewarm_python_ast_cache
 from skillspector.state import SkillspectorState
 from skillspector.structured_skill import extract_structured_skill_context
@@ -77,10 +77,6 @@ _FILE_TYPES: dict[str, str] = {
     ".go": "go",
     ".rs": "rust",
 }
-_EXECUTABLE_EXTENSIONS = frozenset(
-    {".py", ".sh", ".bash", ".zsh", ".js", ".ts", ".rb", ".go", ".rs", ".pl"}
-)
-
 _OMS_SIGNATURE_PATH = "skill.oms.sig"
 _SIGSTORE_BUNDLE_MEDIA_TYPE = "application/vnd.dev.sigstore.bundle.v0.3+json"
 _IN_TOTO_PAYLOAD_TYPE = "application/vnd.in-toto+json"
@@ -295,11 +291,12 @@ def _is_valid_oms_signature(file_path: Path) -> bool:
         return False
 
     statement = _decode_base64_json(envelope.get("payload"))
+    predicate_type = statement.get("predicateType") if statement else None
     return bool(
         statement
         and statement.get("_type") == _IN_TOTO_STATEMENT_TYPE
-        and isinstance(statement.get("predicateType"), str)
-        and statement["predicateType"].startswith(_OMS_PREDICATE_TYPE_PREFIX)
+        and isinstance(predicate_type, str)
+        and predicate_type.startswith(_OMS_PREDICATE_TYPE_PREFIX)
     )
 
 
@@ -324,7 +321,6 @@ def _build_component_metadata(
     has_executable = False
     for path in components:
         full = skill_dir / path
-        suffix = full.suffix.lower()
         file_type = "oms_signature" if path in recognized_oms_signatures else _infer_file_type(path)
         content = file_cache.get(path)
         lines = (
@@ -334,14 +330,18 @@ def _build_component_metadata(
             if path in recognized_oms_signatures
             else 0
         )
-        executable = suffix in _EXECUTABLE_EXTENSIONS
-        if executable:
-            has_executable = True
         try:
-            size_bytes = full.stat().st_size
+            file_stat = full.stat()
+            size_bytes = file_stat.st_size
+            mode = file_stat.st_mode
         except OSError:
             logger.debug("Could not stat file: %s", path)
             size_bytes = 0
+            mode = 0
+        data = content.encode("utf-8", errors="replace") if content is not None else b""
+        executable = is_executable_content(path, data, mode)
+        if executable:
+            has_executable = True
         component: dict[str, object] = {
             "path": path,
             "type": file_type,
@@ -358,9 +358,11 @@ def _build_component_metadata(
                         "outer_path": path,
                         "nested_path": path,
                         "container_type": "filesystem",
+                        "container_ancestry": ["filesystem"],
                         "container_depth": 0,
                         "outer_hidden": True,
                         "concealed_executable": True,
+                        "concealment_reasons": ["hidden_artifact"],
                     }
                 )
         metadata.append(component)
@@ -616,7 +618,7 @@ def build_context(state: SkillspectorState) -> dict[str, object]:
     )
     structured_skill_context = extract_structured_skill_context(skill_dir)
 
-    result = {
+    result: dict[str, object] = {
         "components": components,
         "llm_components": llm_components,
         "file_cache": file_cache,

--- a/src/skillspector/nodes/build_context.py
+++ b/src/skillspector/nodes/build_context.py
@@ -46,6 +46,7 @@ from skillspector.inspection_ledger import (
     ledger_event,
 )
 from skillspector.logging_config import get_logger
+from skillspector.nested_artifacts import inspect_nested_artifacts
 from skillspector.python_ast import prewarm_python_ast_cache
 from skillspector.state import SkillspectorState
 from skillspector.structured_skill import extract_structured_skill_context
@@ -164,8 +165,8 @@ def _walk_skill_files(
 ) -> tuple[list[str], list[InspectionLedgerEvent]]:
     """Walk skill files and record scan-scope exclusions.
 
-    Skips _SKIP_DIRS, hidden files except those starting with .claude, and
-    symlinks, which must never supply content to remote LLM analyzers.
+    Skips _SKIP_DIRS and symlinks. Hidden regular files remain in the local
+    deterministic inventory; build_context excludes them from the LLM view.
     """
     paths: list[str] = []
     exclusions: list[InspectionLedgerEvent] = []
@@ -206,18 +207,6 @@ def _walk_skill_files(
 
         for filename in filenames:
             relative_path = (relative_root / filename).as_posix()
-            if filename.startswith(".") and not filename.startswith(".claude"):
-                exclusions.append(
-                    ledger_event(
-                        outcome=LedgerOutcome.OUT_OF_SCOPE,
-                        record_type=LedgerRecordType.SCOPE_BOUNDARY,
-                        phase="discovery",
-                        path=relative_path,
-                        reason=LedgerReason.HIDDEN_FILE,
-                    )
-                )
-                continue
-
             # Use forward slashes on every OS: these relative paths are dict keys
             # and SARIF/URI locations, so they must be portable.  Other
             # non-regular entries remain inventoried for cache-phase evidence;
@@ -244,6 +233,11 @@ def _infer_file_type(path: str) -> str:
     idx = path.rfind(".")
     suffix = path[idx:].lower() if idx >= 0 else ""
     return _FILE_TYPES.get(suffix, "other")
+
+
+def _is_hidden_component(path: str) -> bool:
+    """Return whether any segment of a relative component path is hidden."""
+    return any(part.startswith(".") for part in path.replace("\\", "/").split("/") if part)
 
 
 def _decode_base64_json(value: object) -> dict[str, object] | None:
@@ -348,15 +342,28 @@ def _build_component_metadata(
         except OSError:
             logger.debug("Could not stat file: %s", path)
             size_bytes = 0
-        metadata.append(
-            {
-                "path": path,
-                "type": file_type,
-                "lines": lines,
-                "executable": executable,
-                "size_bytes": size_bytes,
-            }
-        )
+        component: dict[str, object] = {
+            "path": path,
+            "type": file_type,
+            "lines": lines,
+            "executable": executable,
+            "size_bytes": size_bytes,
+        }
+        if _is_hidden_component(path):
+            component["hidden"] = True
+            component["local_only"] = True
+            if executable:
+                component.update(
+                    {
+                        "outer_path": path,
+                        "nested_path": path,
+                        "container_type": "filesystem",
+                        "container_depth": 0,
+                        "outer_hidden": True,
+                        "concealed_executable": True,
+                    }
+                )
+        metadata.append(component)
     return metadata, has_executable
 
 
@@ -571,25 +578,55 @@ def build_context(state: SkillspectorState) -> dict[str, object]:
         )
         for path in sorted(selected_baselines)
     ]
-    file_cache, cache_events = _read_file_cache(skill_dir, components)
-    python_ast_cache_key = prewarm_python_ast_cache(components, file_cache)
+    local_file_cache, cache_events = _read_file_cache(skill_dir, components)
+    nested = inspect_nested_artifacts(skill_dir, components)
+    components.extend(path for path in nested.components if path not in components)
+    local_file_cache.update(nested.file_cache)
+
+    # Only ordinary, visible filesystem text remains eligible for remote LLM
+    # analysis. Hidden files and every recognized container/nested member stay
+    # in the deterministic local-only view.
+    recognized_containers = frozenset(nested.outer_metadata)
+    llm_components = [
+        path
+        for path in components
+        if path not in recognized_containers
+        and path not in nested.file_cache
+        and not _is_hidden_component(path)
+    ]
+    file_cache = {
+        path: local_file_cache[path] for path in llm_components if path in local_file_cache
+    }
+    python_ast_cache_key = prewarm_python_ast_cache(components, local_file_cache)
     manifest = _parse_manifest(skill_dir)
     metadata_components = [
         path for path in inventoried_components if path not in selected_baselines
     ]
     component_metadata, has_executable_scripts = _build_component_metadata(
-        skill_dir, metadata_components, file_cache, recognized_oms_signatures
+        skill_dir, metadata_components, local_file_cache, recognized_oms_signatures
+    )
+    for metadata in component_metadata:
+        path = str(metadata.get("path", ""))
+        if path in nested.outer_metadata:
+            metadata.update(nested.outer_metadata[path])
+            metadata["lines"] = 0
+    component_metadata.extend(nested.metadata)
+    has_executable_scripts = has_executable_scripts or any(
+        bool(metadata.get("executable")) for metadata in nested.metadata
     )
     structured_skill_context = extract_structured_skill_context(skill_dir)
 
     result = {
         "components": components,
+        "llm_components": llm_components,
         "file_cache": file_cache,
+        "local_file_cache": local_file_cache,
         "inspection_ledger": [
             *discovery_events,
             *signature_events,
             *baseline_events,
             *cache_events,
+            *nested.ledger_events,
         ],
         "ast_cache": {},
         "python_ast_cache_key": python_ast_cache_key,

--- a/src/skillspector/nodes/meta_analyzer.py
+++ b/src/skillspector/nodes/meta_analyzer.py
@@ -280,6 +280,7 @@ def _fallback_filtered(findings: list[Finding]) -> list[Finding]:
                 explanation=getattr(f, "explanation", None),
                 code_snippet=getattr(f, "code_snippet", None) or f.context,
                 intent=None,
+                evidence=dict(f.evidence),
             )
         )
     logger.info(
@@ -317,6 +318,7 @@ def _passthrough_with_defaults(findings: list[Finding]) -> list[Finding]:
             explanation=getattr(f, "explanation", None),
             code_snippet=getattr(f, "code_snippet", None) or f.context,
             intent=None,
+            evidence=dict(f.evidence),
         )
         for f in findings
     ]
@@ -478,6 +480,7 @@ class LLMMetaAnalyzer(LLMAnalyzerBase):
                             explanation=getattr(f, "explanation", None),
                             code_snippet=getattr(f, "code_snippet", None) or f.context,
                             intent=None,
+                            evidence=dict(f.evidence),
                         )
                     )
                 # MEDIUM/LOW: preserve existing behaviour (LLM may filter as false-positive).
@@ -502,6 +505,7 @@ class LLMMetaAnalyzer(LLMAnalyzerBase):
                     explanation=expl,
                     code_snippet=getattr(f, "code_snippet", None) or f.context,
                     intent=None,
+                    evidence=dict(f.evidence),
                 )
             )
         return result
@@ -619,6 +623,52 @@ def meta_analyzer(state: SkillspectorState) -> MetaAnalyzerResponse:
             ],
         }
 
+    # Findings derived from hidden or nested content remain local-only. They
+    # bypass prompt construction entirely and are preserved by deterministic
+    # fallback policy instead of being exposed to an external provider.
+    local_only_paths = {
+        str(metadata.get("path", ""))
+        for metadata in state.get("component_metadata", [])
+        if metadata.get("local_only") is True
+    }
+    local_only_findings = [
+        finding
+        for finding in findings
+        if finding.file in local_only_paths
+        or "local-only" in finding.tags
+        or finding.evidence.get("local_only") is True
+    ]
+    llm_findings = [finding for finding in findings if finding not in local_only_findings]
+
+    def local_only_events(filtered_local: list[Finding]) -> list[InspectionLedgerEvent]:
+        events: list[InspectionLedgerEvent] = []
+        by_file: dict[str, list[Finding]] = {}
+        for finding in filtered_local:
+            by_file.setdefault(finding.file, []).append(finding)
+        for path, path_findings in sorted(by_file.items()):
+            finding_ids = [finding.finding_id for finding in path_findings]
+            events.append(
+                ledger_event(
+                    analyzer_id="meta_analyzer",
+                    outcome=LedgerOutcome.COMPLETED,
+                    phase="meta",
+                    path=path,
+                    input_finding_ids=finding_ids,
+                    emitted_finding_ids=finding_ids,
+                )
+            )
+        return events
+
+    if not llm_findings:
+        filtered_local = _fallback_filtered(local_only_findings)
+        events = local_only_events(filtered_local)
+        return {
+            "findings": filtered_local,
+            "effective_finding_ids": [finding.finding_id for finding in filtered_local],
+            "inspection_ledger": events,
+            "analyzer_status_events": [analyzer_status_for_events("meta_analyzer", events)],
+        }
+
     file_cache: dict[str, str] = state.get("file_cache") or {}
     manifest: dict[str, object] = state.get("manifest") or {}
     model_config: dict[str, str] = state.get("model_config") or {}
@@ -629,7 +679,7 @@ def meta_analyzer(state: SkillspectorState) -> MetaAnalyzerResponse:
     )
 
     metadata_text = _format_metadata(manifest)
-    files_with_findings = sorted({f.file for f in findings})
+    files_with_findings = sorted({f.file for f in llm_findings})
 
     analyzer: LLMMetaAnalyzer | None = None
     batches: list[Batch] = []
@@ -638,7 +688,7 @@ def meta_analyzer(state: SkillspectorState) -> MetaAnalyzerResponse:
         # and recorded as a degraded LLM call (consistent with the semantic
         # analyzers) rather than crashing the whole graph.
         analyzer = LLMMetaAnalyzer(model=model)
-        batches = analyzer.get_batches(files_with_findings, file_cache, findings)
+        batches = analyzer.get_batches(files_with_findings, file_cache, llm_findings)
         batches = [batch for batch in batches if batch.findings]
         logger.debug(
             "Meta-analyzer: %d files -> %d batches (model=%s)",
@@ -681,10 +731,12 @@ def meta_analyzer(state: SkillspectorState) -> MetaAnalyzerResponse:
             analysed_ids = {
                 finding.finding_id for batch, _ in batch_results for finding in batch.findings
             }
-            analysed = [finding for finding in findings if finding.finding_id in analysed_ids]
-            unanalysed = [finding for finding in findings if finding.finding_id not in analysed_ids]
+            analysed = [finding for finding in llm_findings if finding.finding_id in analysed_ids]
+            unanalysed = [
+                finding for finding in llm_findings if finding.finding_id not in analysed_ids
+            ]
         else:
-            analysed, unanalysed = findings, []
+            analysed, unanalysed = llm_findings, []
 
         filtered = analyzer.apply_filter(analysed, batch_results)
         if unanalysed:
@@ -697,6 +749,8 @@ def meta_analyzer(state: SkillspectorState) -> MetaAnalyzerResponse:
                 len({f.file for f in unanalysed}),
             )
             filtered.extend(_fallback_filtered(unanalysed))
+        filtered_local = _fallback_filtered(local_only_findings)
+        filtered.extend(filtered_local)
 
         logger.debug(
             "LLM filtering done: %d findings -> %d after filter",
@@ -704,6 +758,8 @@ def meta_analyzer(state: SkillspectorState) -> MetaAnalyzerResponse:
             len(filtered),
         )
         ledger_events, status = _meta_ledger_response(batches, detailed, filtered)
+        ledger_events.extend(local_only_events(filtered_local))
+        status = analyzer_status_for_events("meta_analyzer", ledger_events)
         return {
             "findings": filtered,
             "effective_finding_ids": list(
@@ -741,6 +797,18 @@ def meta_analyzer(state: SkillspectorState) -> MetaAnalyzerResponse:
                 ),
                 filtered,
             )
+            ledger_events.extend(
+                local_only_events(
+                    [
+                        finding
+                        for finding in filtered
+                        if finding.file in local_only_paths
+                        or "local-only" in finding.tags
+                        or finding.evidence.get("local_only") is True
+                    ]
+                )
+            )
+            status = analyzer_status_for_events("meta_analyzer", ledger_events)
         else:
             ledger_events = []
             status = analyzer_status_event(analyzer_id="meta_analyzer", status="unavailable")

--- a/src/skillspector/nodes/report.py
+++ b/src/skillspector/nodes/report.py
@@ -989,8 +989,8 @@ def _format_markdown(
                 lines.append("")
             if f.evidence:
                 lines.append("**Evidence:**")
-                for key, value in sorted(f.evidence.items()):
-                    lines.append(f"- **{key}:** `{value}`")
+                for key, evidence_value in sorted(f.evidence.items()):
+                    lines.append(f"- **{key}:** `{evidence_value}`")
                 lines.append("")
             lines.append("---\n")
 

--- a/src/skillspector/nodes/report.py
+++ b/src/skillspector/nodes/report.py
@@ -104,6 +104,10 @@ def _clean_text(value: str | None) -> str | None:
 
 def _sanitize_finding(finding: Finding) -> Finding:
     """Return a copy of *finding* with control/ANSI bytes stripped from text fields."""
+    evidence = {
+        _clean_text(str(key)) or "": _clean_text(value) if isinstance(value, str) else value
+        for key, value in finding.evidence.items()
+    }
     return replace(
         finding,
         message=_clean_text(finding.message) or "",
@@ -113,6 +117,7 @@ def _sanitize_finding(finding: Finding) -> Finding:
         context=_clean_text(finding.context),
         matched_text=_clean_text(finding.matched_text),
         code_snippet=_clean_text(finding.code_snippet),
+        evidence=evidence,
     )
 
 
@@ -131,6 +136,7 @@ def _build_sarif_properties(finding: Finding) -> dict[str, object] | None:
         "code_snippet": finding_dict["code_snippet"],
         "intent": finding_dict["intent"],
         "tags": finding_dict["tags"],
+        "evidence": finding_dict["evidence"],
     }
     cleaned = {key: value for key, value in metadata.items() if value is not None}
     return cleaned or None
@@ -641,6 +647,9 @@ def _format_terminal(
             console.print(f"    [dim]Confidence:[/dim] {f.confidence:.0%}")
             if f.remediation:
                 console.print(f"    [dim]Remediation:[/dim] {(f.remediation or '')[:150]}...")
+            if f.evidence:
+                rendered = ", ".join(f"{key}={value}" for key, value in sorted(f.evidence.items()))
+                console.print(f"    [dim]Evidence:[/dim] {rendered}")
             console.print()
     else:
         console.print("\n[green]No security issues detected.[/green]\n")
@@ -978,6 +987,11 @@ def _format_markdown(
             if f.remediation:
                 lines.append(f"**Remediation:** {f.remediation}")
                 lines.append("")
+            if f.evidence:
+                lines.append("**Evidence:**")
+                for key, value in sorted(f.evidence.items()):
+                    lines.append(f"- **{key}:** `{value}`")
+                lines.append("")
             lines.append("---\n")
 
     if suppressed:
@@ -1054,7 +1068,7 @@ def report(state: SkillspectorState) -> dict[str, object]:
         state.get("execution_successful", analysis_completeness.get("execution_successful", True))
     )
     component_metadata = state.get("component_metadata") or []
-    file_cache = state.get("file_cache") or {}
+    file_cache = state.get("local_file_cache") or state.get("file_cache") or {}
     has_executable_scripts = state.get("has_executable_scripts", False)
     manifest = state.get("manifest") or {}
     skill_path = state.get("skill_path")

--- a/src/skillspector/state.py
+++ b/src/skillspector/state.py
@@ -58,7 +58,11 @@ class SkillspectorState(TypedDict, total=False):
 
     # build_context node populates these
     components: list[str]
+    # Visible authored text that may be submitted to external LLM providers.
+    llm_components: list[str]
     file_cache: dict[str, str]
+    # Full local-only deterministic view, including hidden and nested content.
+    local_file_cache: dict[str, str]
     # Retained for compatibility with the persisted workflow-state schema.
     ast_cache: dict[str, str]
     # Key for the process-local parsed-AST cache.  The ASTs themselves stay

--- a/tests/nodes/test_build_context.py
+++ b/tests/nodes/test_build_context.py
@@ -450,18 +450,19 @@ def test_build_context_reports_exclusion_boundary_without_descendants(tmp_path: 
     assert "node_modules/pkg/index.js" not in result["components"]
 
 
-def test_build_context_reports_hidden_file_as_a_scope_exclusion(tmp_path: Path) -> None:
-    """Hidden files are excluded individually without a directory marker."""
+def test_build_context_inventories_hidden_file_for_local_analysis(tmp_path: Path) -> None:
+    """Hidden regular files stay local and never enter the LLM-visible cache."""
     (tmp_path / "SKILL.md").write_text("# Skill\n", encoding="utf-8")
     (tmp_path / ".env").write_text("TOKEN=not-reported\n", encoding="utf-8")
 
     result = build_context({"skill_path": str(tmp_path)})
-    exclusions = [
-        event for event in result["inspection_ledger"] if event["outcome"] == "out_of_scope"
-    ]
-
-    assert [event["path"] for event in exclusions] == [".env"]
-    assert ".env" not in result["components"]
+    assert ".env" in result["components"]
+    assert ".env" in result["local_file_cache"]
+    assert ".env" not in result["file_cache"]
+    assert ".env" not in result["llm_components"]
+    assert not any(
+        event.get("reason_code") == "hidden_file" for event in result["inspection_ledger"]
+    )
 
 
 def test_build_context_reports_read_error_without_fake_empty_content(

--- a/tests/nodes/test_meta_analyzer.py
+++ b/tests/nodes/test_meta_analyzer.py
@@ -592,6 +592,31 @@ class TestMetaAnalyzerPartialBatchFailure:
         assert completeness["ledger_exceptions"] == []
 
 
+def test_local_only_high_finding_never_constructs_llm_analyzer() -> None:
+    finding = Finding(
+        rule_id="SC9",
+        message="concealed executable",
+        finding_id="local-finding",
+        severity="HIGH",
+        file=".hidden.docx!/payload.sh",
+        tags=[],
+        evidence={"outer_path": ".hidden.docx"},
+    )
+    state = {
+        "findings": [finding],
+        "file_cache": {"SKILL.md": "sentinel-visible-content"},
+        "component_metadata": [{"path": ".hidden.docx!/payload.sh", "local_only": True}],
+        "use_llm": True,
+    }
+
+    with patch("skillspector.nodes.meta_analyzer.LLMMetaAnalyzer") as analyzer_cls:
+        result = meta_analyzer(state)
+
+    analyzer_cls.assert_not_called()
+    assert result["effective_finding_ids"] == ["local-finding"]
+    assert result["findings"][0].severity == "HIGH"
+
+
 # ---------------------------------------------------------------------------
 # LLM-call telemetry + fail-closed construction (drives the report's
 # degradation signal).

--- a/tests/nodes/test_nested_artifacts.py
+++ b/tests/nodes/test_nested_artifacts.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for bounded, local-only nested artifact inspection."""
+
+from __future__ import annotations
+
+import io
+import stat
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from skillspector.inspection_ledger import LedgerReason
+from skillspector.nested_artifacts import inspect_nested_artifacts
+from skillspector.nodes.analyzers.static_patterns_supply_chain import (
+    _analyze_concealed_executables,
+)
+from skillspector.nodes.build_context import build_context
+
+
+def _zip_bytes(
+    members: dict[str, bytes],
+    *,
+    compression: int = zipfile.ZIP_STORED,
+    link: str | None = None,
+) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=compression) as archive:
+        for name, content in members.items():
+            if name == link:
+                info = zipfile.ZipInfo(name)
+                info.create_system = 3
+                info.external_attr = (stat.S_IFLNK | 0o777) << 16
+                archive.writestr(info, content)
+            else:
+                archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+def _write_archive(path: Path, members: dict[str, bytes]) -> None:
+    path.write_bytes(_zip_bytes(members))
+
+
+def _document_members(**extra: bytes) -> dict[str, bytes]:
+    return {
+        "[Content_Types].xml": b"<Types/>",
+        "word/document.xml": b"<document>ordinary text</document>",
+        **extra,
+    }
+
+
+def test_hidden_disguised_document_inventories_nested_executable_locally(tmp_path: Path) -> None:
+    archive_path = tmp_path / ".instructions.docx.txt"
+    _write_archive(archive_path, _document_members(**{"word/sync1.sh": b"#!/bin/sh\necho ok\n"}))
+    (tmp_path / "SKILL.md").write_text("# Context loader\n", encoding="utf-8")
+
+    context = build_context({"skill_path": str(tmp_path)})
+    virtual_path = ".instructions.docx.txt!/word/sync1.sh"
+
+    assert ".instructions.docx.txt" in context["components"]
+    assert virtual_path in context["components"]
+    assert virtual_path in context["local_file_cache"]
+    assert ".instructions.docx.txt" not in context["file_cache"]
+    assert virtual_path not in context["file_cache"]
+    outer = next(
+        item for item in context["component_metadata"] if item["path"] == archive_path.name
+    )
+    nested = next(item for item in context["component_metadata"] if item["path"] == virtual_path)
+    assert outer["type"] == "docx"
+    assert outer["hidden"] is True
+    assert outer["disguised"] is True
+    assert nested["executable"] is True
+    assert nested["concealed_executable"] is True
+
+    findings = _analyze_concealed_executables(context["component_metadata"])
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.rule_id == "SC9"
+    assert finding.severity == "HIGH"
+    assert finding.file == virtual_path
+    assert finding.evidence["outer_path"] == archive_path.name
+    assert finding.evidence["nested_path"] == "word/sync1.sh"
+    assert finding.evidence["container_type"] == "docx"
+
+
+def test_benign_document_without_executable_has_no_sc9(tmp_path: Path) -> None:
+    archive_path = tmp_path / "notes.docx"
+    _write_archive(archive_path, _document_members())
+
+    context = build_context({"skill_path": str(tmp_path)})
+
+    assert not _analyze_concealed_executables(context["component_metadata"])
+
+
+def test_hidden_standalone_executable_has_sc9_and_stays_local(tmp_path: Path) -> None:
+    (tmp_path / ".setup.sh").write_text("#!/bin/sh\necho local\n", encoding="utf-8")
+
+    context = build_context({"skill_path": str(tmp_path)})
+    findings = _analyze_concealed_executables(context["component_metadata"])
+
+    assert ".setup.sh" in context["components"]
+    assert ".setup.sh" in context["local_file_cache"]
+    assert ".setup.sh" not in context["file_cache"]
+    assert len(findings) == 1
+    assert findings[0].file == ".setup.sh"
+    assert findings[0].evidence["container_type"] == "filesystem"
+    assert findings[0].evidence["concealment"] == "hidden_artifact"
+
+
+def test_nested_zip_preserves_full_virtual_provenance(tmp_path: Path) -> None:
+    inner = _zip_bytes({"payload.sh": b"#!/bin/sh\necho nested\n"})
+    outer_path = tmp_path / ".bundle.txt"
+    _write_archive(outer_path, {"nested.bin": inner})
+
+    result = inspect_nested_artifacts(tmp_path, [outer_path.name])
+
+    assert ".bundle.txt!/nested.bin!/payload.sh" in result.components
+    metadata = next(item for item in result.metadata if item["path"].endswith("!/payload.sh"))
+    assert metadata["container_depth"] == 2
+    assert metadata["concealed_executable"] is True
+
+
+@pytest.mark.parametrize(
+    ("member", "reason"),
+    [
+        ("../escape.sh", LedgerReason.ARCHIVE_UNSAFE_MEMBER_PATH),
+        ("/absolute.sh", LedgerReason.ARCHIVE_UNSAFE_MEMBER_PATH),
+        ("C:\\escape.sh", LedgerReason.ARCHIVE_UNSAFE_MEMBER_PATH),
+    ],
+)
+def test_unsafe_member_paths_are_not_inventoried(
+    tmp_path: Path, member: str, reason: LedgerReason
+) -> None:
+    path = tmp_path / "unsafe.zip"
+    _write_archive(path, {member: b"#!/bin/sh\n"})
+
+    result = inspect_nested_artifacts(tmp_path, [path.name])
+
+    assert not result.components
+    assert any(event.get("reason_code") == reason for event in result.ledger_events)
+
+
+def test_archive_link_member_is_not_followed(tmp_path: Path) -> None:
+    path = tmp_path / "links.zip"
+    path.write_bytes(_zip_bytes({"payload.sh": b"target.sh"}, link="payload.sh"))
+
+    result = inspect_nested_artifacts(tmp_path, [path.name])
+
+    assert "links.zip!/payload.sh" in result.components
+    assert result.file_cache["links.zip!/payload.sh"] == "\x00"
+    assert any(
+        event.get("reason_code") == LedgerReason.ARCHIVE_LINK_MEMBER
+        for event in result.ledger_events
+    )
+
+
+def test_malformed_zip_marks_inspection_incomplete(tmp_path: Path) -> None:
+    path = tmp_path / "broken.txt"
+    path.write_bytes(b"PK\x03\x04not-a-zip")
+
+    result = inspect_nested_artifacts(tmp_path, [path.name])
+
+    assert any(
+        event.get("reason_code") == LedgerReason.ARCHIVE_MALFORMED for event in result.ledger_events
+    )
+
+
+def test_encrypted_member_is_inventoried_but_not_read(tmp_path: Path) -> None:
+    encoded = bytearray(_zip_bytes({"secret.sh": b"#!/bin/sh\n"}))
+    local_header = encoded.find(b"PK\x03\x04")
+    central_header = encoded.find(b"PK\x01\x02")
+    assert local_header >= 0 and central_header >= 0
+    for offset in (local_header + 6, central_header + 8):
+        flags = int.from_bytes(encoded[offset : offset + 2], "little") | 0x1
+        encoded[offset : offset + 2] = flags.to_bytes(2, "little")
+    path = tmp_path / "encrypted.zip"
+    path.write_bytes(bytes(encoded))
+
+    result = inspect_nested_artifacts(tmp_path, [path.name])
+
+    assert "encrypted.zip!/secret.sh" in result.components
+    assert result.file_cache["encrypted.zip!/secret.sh"] == "\x00"
+    assert any(
+        event.get("reason_code") == LedgerReason.ARCHIVE_ENCRYPTED for event in result.ledger_events
+    )
+
+
+def test_compression_ratio_limit_is_cumulative_safety_boundary(tmp_path: Path) -> None:
+    path = tmp_path / "compressed.zip"
+    path.write_bytes(_zip_bytes({"large.txt": b"A" * 100_000}, compression=zipfile.ZIP_DEFLATED))
+
+    result = inspect_nested_artifacts(tmp_path, [path.name])
+
+    assert any(
+        event.get("reason_code") == LedgerReason.ARCHIVE_COMPRESSION_RATIO
+        for event in result.ledger_events
+    )
+
+
+def test_depth_member_size_and_time_limits_are_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import skillspector.nested_artifacts as nested
+
+    deepest = _zip_bytes({"payload.sh": b"#!/bin/sh\n"})
+    for index in range(4):
+        deepest = _zip_bytes({f"level-{index}.bin": deepest})
+    depth_path = tmp_path / "depth.zip"
+    depth_path.write_bytes(deepest)
+    depth_result = inspect_nested_artifacts(tmp_path, [depth_path.name])
+    assert any(
+        event.get("reason_code") == LedgerReason.ARCHIVE_DEPTH_LIMIT
+        for event in depth_result.ledger_events
+    )
+
+    monkeypatch.setattr(nested, "ARCHIVE_MAX_MEMBERS", 1)
+    member_path = tmp_path / "members.zip"
+    _write_archive(member_path, {"one.txt": b"1", "two.txt": b"2"})
+    member_result = inspect_nested_artifacts(tmp_path, [member_path.name])
+    assert any(
+        event.get("reason_code") == LedgerReason.ARCHIVE_MEMBER_LIMIT
+        for event in member_result.ledger_events
+    )
+
+    monkeypatch.setattr(nested, "ARCHIVE_MAX_MEMBERS", 1_000)
+    monkeypatch.setattr(nested, "ARCHIVE_MAX_UNCOMPRESSED_BYTES", 3)
+    size_path = tmp_path / "size.zip"
+    _write_archive(size_path, {"four.txt": b"1234"})
+    size_result = inspect_nested_artifacts(tmp_path, [size_path.name])
+    assert any(
+        event.get("reason_code") == LedgerReason.ARCHIVE_SIZE_LIMIT
+        for event in size_result.ledger_events
+    )
+
+    monkeypatch.setattr(nested, "ARCHIVE_MAX_UNCOMPRESSED_BYTES", 25 * 1024 * 1024)
+    ticks = iter((0.0, 6.0))
+    time_result = inspect_nested_artifacts(tmp_path, [member_path.name], clock=lambda: next(ticks))
+    assert any(
+        event.get("reason_code") == LedgerReason.ARCHIVE_TIME_LIMIT
+        for event in time_result.ledger_events
+    )

--- a/tests/nodes/test_nested_artifacts.py
+++ b/tests/nodes/test_nested_artifacts.py
@@ -51,6 +51,16 @@ def _document_members(**extra: bytes) -> dict[str, bytes]:
     }
 
 
+def _with_unsupported_compression(data: bytes, method: int = 99) -> bytes:
+    encoded = bytearray(data)
+    local_header = encoded.find(b"PK\x03\x04")
+    central_header = encoded.find(b"PK\x01\x02")
+    assert local_header >= 0 and central_header >= 0
+    encoded[local_header + 8 : local_header + 10] = method.to_bytes(2, "little")
+    encoded[central_header + 10 : central_header + 12] = method.to_bytes(2, "little")
+    return bytes(encoded)
+
+
 def test_hidden_disguised_document_inventories_nested_executable_locally(tmp_path: Path) -> None:
     archive_path = tmp_path / ".instructions.docx.txt"
     _write_archive(archive_path, _document_members(**{"word/sync1.sh": b"#!/bin/sh\necho ok\n"}))
@@ -122,6 +132,62 @@ def test_nested_zip_preserves_full_virtual_provenance(tmp_path: Path) -> None:
     assert metadata["concealed_executable"] is True
 
 
+def test_visible_document_concealment_survives_recursive_zip(tmp_path: Path) -> None:
+    inner = _zip_bytes({"payload.sh": b"#!/bin/sh\necho nested\n"})
+    outer_path = tmp_path / "nested.docx"
+    _write_archive(outer_path, _document_members(**{"word/embedded.zip": inner}))
+
+    context = build_context({"skill_path": str(tmp_path)})
+    virtual_path = "nested.docx!/word/embedded.zip!/payload.sh"
+    metadata = next(item for item in context["component_metadata"] if item["path"] == virtual_path)
+    findings = _analyze_concealed_executables(context["component_metadata"])
+
+    assert metadata["nested_path"] == "word/embedded.zip!/payload.sh"
+    assert metadata["container_ancestry"] == ["docx", "zip"]
+    assert metadata["concealment_reasons"] == ["document_container"]
+    finding = next(item for item in findings if item.file == virtual_path)
+    assert finding.severity == "HIGH"
+    assert finding.evidence["nested_path"] == "word/embedded.zip!/payload.sh"
+    assert finding.evidence["container_ancestry"] == ["docx", "zip"]
+
+
+@pytest.mark.parametrize(
+    ("member_name", "content"),
+    [
+        ("payload.ps1", b"Write-Host 'review'\n"),
+        ("payload.pyc", b"\x42\x0d\x0d\x0a bytecode"),
+        ("payload.exe", b"MZ executable"),
+    ],
+)
+def test_document_execution_relevant_suffixes_emit_sc9(
+    tmp_path: Path, member_name: str, content: bytes
+) -> None:
+    outer_path = tmp_path / "payloads.docx"
+    _write_archive(outer_path, _document_members(**{f"word/{member_name}": content}))
+
+    context = build_context({"skill_path": str(tmp_path)})
+    findings = _analyze_concealed_executables(context["component_metadata"])
+
+    finding = next(item for item in findings if item.file.endswith(member_name))
+    assert finding.rule_id == "SC9"
+    assert finding.severity == "HIGH"
+    assert finding.evidence["concealment"] == "document_container"
+
+
+def test_hidden_extensionless_executable_shebang_file_emits_sc9(tmp_path: Path) -> None:
+    path = tmp_path / ".bootstrap"
+    path.write_text("#!/bin/sh\necho local\n", encoding="utf-8")
+    path.chmod(0o755)
+
+    context = build_context({"skill_path": str(tmp_path)})
+    metadata = next(item for item in context["component_metadata"] if item["path"] == path.name)
+    findings = _analyze_concealed_executables(context["component_metadata"])
+
+    assert metadata["executable"] is True
+    assert metadata["concealed_executable"] is True
+    assert findings[0].severity == "HIGH"
+
+
 @pytest.mark.parametrize(
     ("member", "reason"),
     [
@@ -164,6 +230,49 @@ def test_malformed_zip_marks_inspection_incomplete(tmp_path: Path) -> None:
 
     assert any(
         event.get("reason_code") == LedgerReason.ARCHIVE_MALFORMED for event in result.ledger_events
+    )
+
+
+def test_expected_document_with_incompatible_bytes_is_incomplete_and_local_only(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "broken.docx"
+    path.write_bytes(b"not an office container")
+
+    context = build_context({"skill_path": str(tmp_path)})
+
+    assert path.name not in context["file_cache"]
+    assert path.name in context["local_file_cache"]
+    metadata = next(item for item in context["component_metadata"] if item["path"] == path.name)
+    assert metadata["local_only"] is True
+    assert any(
+        event.get("reason_code") == LedgerReason.ARCHIVE_FORMAT_MISMATCH
+        and event.get("path") == path.name
+        for event in context["inspection_ledger"]
+    )
+
+
+def test_unsupported_compression_is_not_reported_as_encryption(tmp_path: Path) -> None:
+    path = tmp_path / "unsupported.zip"
+    path.write_bytes(_with_unsupported_compression(_zip_bytes({"payload.sh": b"#!/bin/sh\n"})))
+
+    result = inspect_nested_artifacts(tmp_path, [path.name])
+    reasons = {event.get("reason_code") for event in result.ledger_events}
+
+    assert LedgerReason.ARCHIVE_UNSUPPORTED_COMPRESSION in reasons
+    assert LedgerReason.ARCHIVE_ENCRYPTED not in reasons
+
+
+def test_truncated_nested_archive_retains_full_provenance(tmp_path: Path) -> None:
+    path = tmp_path / "outer.zip"
+    _write_archive(path, {"nested.zip": b"PK\x03\x04truncated"})
+
+    result = inspect_nested_artifacts(tmp_path, [path.name])
+
+    assert any(
+        event.get("reason_code") == LedgerReason.ARCHIVE_TRUNCATED
+        and event.get("path") == "outer.zip!/nested.zip"
+        for event in result.ledger_events
     )
 
 
@@ -240,4 +349,53 @@ def test_depth_member_size_and_time_limits_are_reported(
     assert any(
         event.get("reason_code") == LedgerReason.ARCHIVE_TIME_LIMIT
         for event in time_result.ledger_events
+    )
+
+
+def test_member_limit_is_checked_before_sorting_attacker_controlled_names(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import skillspector.nested_artifacts as nested
+
+    monkeypatch.setattr(nested, "ARCHIVE_MAX_MEMBERS", 1)
+    path = tmp_path / "members.zip"
+    _write_archive(path, {"two.txt": b"2", "one.txt": b"1"})
+    zip_sort_calls = 0
+
+    def guarded_sort(infos: list[zipfile.ZipInfo]) -> list[zipfile.ZipInfo]:
+        nonlocal zip_sort_calls
+        zip_sort_calls += 1
+        return infos
+
+    monkeypatch.setattr(nested, "_sorted_infos", guarded_sort)
+
+    result = inspect_nested_artifacts(tmp_path, [path.name])
+
+    assert zip_sort_calls == 0
+    assert any(
+        event.get("reason_code") == LedgerReason.ARCHIVE_MEMBER_LIMIT
+        for event in result.ledger_events
+    )
+
+
+def test_reserved_virtual_delimiter_cannot_collide_with_recursive_provenance(
+    tmp_path: Path,
+) -> None:
+    inner = _zip_bytes({"payload.sh": b"#!/bin/sh\n"})
+    path = tmp_path / "collision.zip"
+    _write_archive(
+        path,
+        {
+            "evil": inner,
+            "evil!/payload.sh": b"#!/bin/sh\necho impersonated\n",
+        },
+    )
+
+    result = inspect_nested_artifacts(tmp_path, [path.name])
+
+    assert result.components.count("collision.zip!/evil!/payload.sh") == 1
+    assert result.file_cache["collision.zip!/evil!/payload.sh"] == "#!/bin/sh\n"
+    assert any(
+        event.get("reason_code") == LedgerReason.ARCHIVE_UNSAFE_MEMBER_PATH
+        for event in result.ledger_events
     )

--- a/tests/nodes/test_report.py
+++ b/tests/nodes/test_report.py
@@ -679,6 +679,45 @@ class TestReportNode:
             assert "outer_path" in result["report_body"]
             assert "archive.docx" in result["report_body"]
 
+    @pytest.mark.parametrize("output_format", ["terminal", "json", "markdown", "sarif"])
+    def test_report_preserves_nested_inspection_limit_reason_and_path(
+        self, output_format: str
+    ) -> None:
+        completeness = {
+            "total_components": 1,
+            "scanned_components": 0,
+            "coverage_percent": 0.0,
+            "is_complete": False,
+            "execution_successful": True,
+            "fully_inspected_files": 0,
+            "partially_inspected_files": 0,
+            "entirely_uninspected_files": 1,
+            "ledger_exceptions": [
+                {
+                    "reason_code": "archive_member_limit",
+                    "path": "outer.zip!/nested.zip",
+                    "message": "Cumulative archive member limit was reached.",
+                    "fatal": False,
+                }
+            ],
+            "scope_exclusions": [],
+            "analyzer_statuses": [],
+            "limitations": [],
+        }
+        state: SkillspectorState = {
+            "filtered_findings": [],
+            "component_metadata": [],
+            "has_executable_scripts": False,
+            "manifest": {},
+            "output_format": output_format,
+            "analysis_completeness": completeness,  # type: ignore[typeddict-item]
+        }
+
+        body = report(state)["report_body"]
+
+        assert "archive_member_limit" in body
+        assert "outer.zip!/nested.zip" in body
+
     def test_report_default_output_format_is_sarif(self) -> None:
         """When output_format is missing, report uses sarif."""
         state: SkillspectorState = {

--- a/tests/nodes/test_report.py
+++ b/tests/nodes/test_report.py
@@ -646,6 +646,39 @@ class TestReportNode:
         assert result_row["properties"]["intent"] == "secret_exfiltration"
         assert result_row["properties"]["tags"] == ["env", "secret"]
 
+    @pytest.mark.parametrize("output_format", ["terminal", "json", "markdown", "sarif"])
+    def test_report_preserves_structured_evidence(self, output_format: str) -> None:
+        finding = _finding(
+            "SC9",
+            "HIGH",
+            "concealed executable",
+            confidence=1.0,
+            file="archive.docx!/payload.sh",
+        )
+        finding.evidence = {
+            "outer_path": "archive.docx",
+            "nested_path": "payload.sh",
+        }
+        state: SkillspectorState = {
+            "filtered_findings": [finding],
+            "component_metadata": [],
+            "has_executable_scripts": False,
+            "manifest": {},
+            "output_format": output_format,
+        }
+
+        result = report(state)
+
+        if output_format == "json":
+            issue = json.loads(result["report_body"])["issues"][0]
+            assert issue["evidence"] == finding.evidence
+        elif output_format == "sarif":
+            row = json.loads(result["report_body"])["runs"][0]["results"][0]
+            assert row["properties"]["evidence"] == finding.evidence
+        else:
+            assert "outer_path" in result["report_body"]
+            assert "archive.docx" in result["report_body"]
+
     def test_report_default_output_format_is_sarif(self) -> None:
         """When output_format is missing, report uses sarif."""
         state: SkillspectorState = {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -34,3 +34,16 @@ def test_finding_reducer_replaces_same_id_without_duplicating_payload() -> None:
     assert len(merged) == 1
     assert merged[0].finding_id == "finding-a"
     assert merged[0].message == "confirmed"
+
+
+def test_finding_serializes_structured_evidence() -> None:
+    finding = Finding(
+        rule_id="SC9",
+        message="concealed executable",
+        evidence={"outer_path": "archive.docx", "nested_path": "payload.sh"},
+    )
+
+    assert finding.to_dict()["evidence"] == {
+        "outer_path": "archive.docx",
+        "nested_path": "payload.sh",
+    }


### PR DESCRIPTION
## Summary

Add bounded, local inspection for hidden files and ZIP-compatible nested artifacts, and report deterministic HIGH SC9 findings when executable content is concealed inside a document or disguised artifact.

The implementation recognizes DOCX, XLSX, PPTX, and ZIP content from bytes and internal structure rather than trusting filename extensions. Members are read in memory and represented with provenance-preserving virtual paths such as `outer-file!/nested.zip!/scripts/setup.sh`.

## Root cause

The component inventory previously skipped hidden paths and treated document/archive files as opaque. A skill could therefore carry executable content behind a misleading extension without the executable entering deterministic analysis, the inspection ledger, or the final risk assessment.

## BEFORE behavior

For a published regression case containing a shell payload inside a hidden, double-extension document:

- only `SKILL.md` entered the component inventory;
- the nested shell member was not analyzed;
- no concealment-specific finding or provenance was reported;
- result: **0 / LOW / SAFE**.

Renaming or expanding the same artifact did not change that outcome because discovery remained extension-oriented.

## AFTER behavior

The same case now produces:

- virtual component `.instructions.docx.txt!/word/sync1.sh`;
- deterministic **SC9 HIGH** at the nested executable;
- evidence for outer path, nested path, container type, depth, concealment reason, and local-only handling;
- result: **32 / MEDIUM / CAUTION**.

The scan inventories 21 components in this case and marks opaque binary font members as incomplete rather than treating them as successfully inspected.

## Design

- Inventory hidden regular files without following links.
- Recognize ZIP-compatible containers using content signatures and structural markers.
- Traverse nested members entirely in memory; never extract, render, import, install, or execute them.
- Preserve full provenance in every virtual member path.
- Feed hidden and nested text to deterministic analyzers through a local-only cache.
- Keep local-only content out of semantic and meta-analyzer prompts.
- Preserve deterministic HIGH findings through optional LLM filtering.
- Project nested failures and exclusions into the inspection ledger and every report format.
- Add structured finding evidence to terminal, JSON, Markdown, and SARIF output.

## Fixed cumulative bounds

| Bound | Limit |
|---|---:|
| Container depth | 3 |
| Members | 1,000 |
| Declared/uncompressed content | 25 MiB |
| Materialized member | 1 MiB |
| Compression ratio | 100:1 |
| Inspection wall time | 5 seconds |

Malformed, encrypted, truncated, unreadable, unsafe-path, link, unsupported, and over-budget members are skipped safely, recorded as ledger exceptions, and make analysis incomplete where applicable.

## Security and compatibility invariants

- No archive member is written to disk or executed.
- Absolute, parent-traversal, drive-qualified, and link paths are never followed.
- Hidden/nested content cannot leave the process through optional LLM analysis.
- Existing `file_cache` behavior remains available for compatibility; deterministic analyzers receive the expanded local cache explicitly.
- Finding evidence is additive for existing output consumers.
- A zero-finding result does not convert opaque or partially inspected content into a complete scan.

## Validation

- Focused nested-artifact, context, meta-analysis, reporting, and model suites: **144 passed**.
- Full suite on the combined two-PR stack: **2,226 passed, 13 skipped, 38 deselected, 4 xfailed**.
- Standalone source distribution and wheel build passed; `nested_artifacts.py` is present in the wheel.
- Ruff formatting/lint passed for all changed files.
- Focused mypy and `git diff --check` passed.

## Out of scope

- Executing, rendering, or reputation-checking nested content.
- General-purpose extraction for non-ZIP formats such as TAR or 7z.
- User-managed allowlists or unbounded recursive inspection.
