### PR TITLE
fix: assert combined report file exists in recursive scan test

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -740,6 +740,7 @@ def test_cli_scan_recursive_json_includes_full_skill_payload(
         ],
     )
     assert result.exit_code == 0
+    assert out_file.exists()
     payload = json.loads(out_file.read_text(encoding="utf-8"))
     assert payload["multi_skill"] is True
     assert payload["skill_count"] == 5


### PR DESCRIPTION
This PR addresses the following issue in `tests/unit/test_cli.py`: assert combined report file exists in recursive scan test.

## Changes
- `tests/unit/test_cli.py`: assert combined report file exists in recursive scan test.

## Details
```diff
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,2 +1,3 @@
-    assert result.exit_code == 0
-    payload = json.loads(out_file.read_text(encoding="utf-8"))
+    assert result.exit_code == 0
+    assert out_file.exists()
+    payload = json.loads(out_file.read_text(encoding="utf-8"))
```

## Tests
- `tests/unit/test_cli.py`

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).