### PR TITLE
fix: simplify redundant error-message assertion

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -238,7 +238,7 @@ def test_cli_scan_nonexistent_exits_2() -> None:
     """scan with nonexistent path exits with code 2."""
     result = runner.invoke(app, ["scan", "/nonexistent/path/xyz"])
     assert result.exit_code == 2
-    assert "Error" in result.output or "error" in result.output.lower()
+    assert "error" in result.output.lower()
 
 
 def test_cli_mcp_registry_routes_and_writes_json(tmp_path: Path) -> None:


### PR DESCRIPTION
This PR addresses the following issue in `tests/unit/test_cli.py`: simplify redundant error-message assertion.

## Changes
- `tests/unit/test_cli.py`: simplify redundant error-message assertion.

## Details
```diff
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,1 +1,1 @@
-    assert "Error" in result.output or "error" in result.output.lower()
+    assert "error" in result.output.lower()
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).