### PR TITLE
fix(nv_build): declare glm-5.2's real limits so calls stop failing

### DIFF
--- a/src/skillspector/providers/nv_build/model_registry.yaml
+++ b/src/skillspector/providers/nv_build/model_registry.yaml
@@ -15,8 +15,17 @@
 
 models:
   # NVIDIA-curated NIMs on build.nvidia.com.
+  # 202749 e' il tetto COMBINATO ingresso+uscita che l'endpoint impone, ed e' riportato
+  # alla lettera nel 400 che restituisce quando lo si supera. Dichiarando la finestra
+  # nominale di 1000000, model_info calcolava un budget d'uscita di 250000 token
+  # (ctx * (1 - MAX_INPUT_TOKENS_PCT)) e OGNI chiamata falliva:
+  #   "This model configuration accepts at most 202749 combined input and output tokens.
+  #    However, your request has 1249 input tokens and asks for 250000 output tokens"
+  # Una finestra sovrastimata non degrada con grazia: azzera lo stadio LLM. Sottostimare
+  # e' sicuro, sovrastimare no.
   "z-ai/glm-5.2":
-    context_length: 1000000
+    context_length: 202749
+    max_output_tokens: 32768
 
   "z-ai/glm-5.1":
     context_length: 205000

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -135,7 +135,7 @@ class TestNvBuildProvider:
     @pytest.mark.parametrize(
         ("model", "context_length"),
         [
-            ("z-ai/glm-5.2", 1_000_000),
+            ("z-ai/glm-5.2", 202_749),
             ("z-ai/glm-5.1", 205_000),
             ("moonshotai/kimi-k2.6", 256_000),
         ],
@@ -143,7 +143,17 @@ class TestNvBuildProvider:
     def test_nv_build_reported_model_metadata(self, model: str, context_length: int) -> None:
         provider = NvBuildProvider()
         assert provider.get_context_length(model) == context_length
-        assert provider.get_max_output_tokens(model) is None
+
+    def test_glm_declares_both_limits(self) -> None:
+        """max_output_tokens is optional, and its absence is not neutral.
+
+        Without it the output budget is derived as a percentage of the context
+        window, which is what produced a 250_000-token request against an
+        endpoint accepting 202_749 combined.
+        """
+        provider = NvBuildProvider()
+        assert provider.get_context_length("z-ai/glm-5.2") == 202_749
+        assert provider.get_max_output_tokens("z-ai/glm-5.2") == 32_768
 
     @pytest.mark.parametrize("model", ["glm-5.2", "z-ai/glm-5.2 "])
     def test_nv_build_model_near_match_stays_unresolved(self, model: str) -> None:


### PR DESCRIPTION
Part of #388, and deliberately one entry wide.

The bundled registry gave `z-ai/glm-5.2` a 1 000 000-token context window and no output cap. `model_info` derives the output budget as `ctx * (1 - MAX_INPUT_TOKENS_PCT)`, so every request asked for 250 000 output tokens:

```
400 This model configuration accepts at most 202749 combined input and output tokens.
    However, your request has 1249 input tokens and asks for 250000 output tokens
```

`202749` is quoted verbatim by the endpoint in that 400. With the entry corrected, the same scan completes with **4/4 LLM calls** and the meta-analyzer applied.

An over-stated context window does not degrade gracefully: it zeroes the LLM stage, and nothing in the error points at the registry. Under-stating is safe, over-stating is not. Limits may vary per account, now noted in the YAML.

**On scope.** The registry also names three models the catalogue no longer serves. Removing them is coupled to `DEFAULT_MODEL` by an invariant this suite already asserts — *"nv_build's default model is in its registry"* (`test_constants.py`) — so that change travels with the default in #391. I tried splitting it the other way first; the test correctly refused.

`1044 passed`, ruff format and check clean, DCO signed.