### PR TITLE
fix(nv_build): retire the dead models and point the default at a served one

### DIFF
--- a/src/skillspector/providers/nv_build/model_registry.yaml
+++ b/src/skillspector/providers/nv_build/model_registry.yaml
@@ -15,8 +15,17 @@
 
 models:
   # NVIDIA-curated NIMs on build.nvidia.com.
+  # 202749 e' il tetto COMBINATO ingresso+uscita che l'endpoint impone, ed e' riportato
+  # alla lettera nel 400 che restituisce quando lo si supera. Dichiarando la finestra
+  # nominale di 1000000, model_info calcolava un budget d'uscita di 250000 token
+  # (ctx * (1 - MAX_INPUT_TOKENS_PCT)) e OGNI chiamata falliva:
+  #   "This model configuration accepts at most 202749 combined input and output tokens.
+  #    However, your request has 1249 input tokens and asks for 250000 output tokens"
+  # Una finestra sovrastimata non degrada con grazia: azzera lo stadio LLM. Sottostimare
+  # e' sicuro, sovrastimare no.
   "z-ai/glm-5.2":
-    context_length: 1000000
+    context_length: 202749
+    max_output_tokens: 32768
 
   "z-ai/glm-5.1":
     context_length: 205000

--- a/src/skillspector/providers/nv_build/model_registry.yaml
+++ b/src/skillspector/providers/nv_build/model_registry.yaml
@@ -27,19 +27,15 @@ models:
     context_length: 202749
     max_output_tokens: 32768
 
-  "z-ai/glm-5.1":
-    context_length: 205000
-
   "moonshotai/kimi-k2.6":
     context_length: 256000
 
-  "deepseek-ai/deepseek-v4-pro":
-    context_length: 1000000
-    max_output_tokens: 128000
-
-  "deepseek-ai/deepseek-v4-flash":
-    context_length: 1000000
-    max_output_tokens: 128000
+  # deepseek-v4-flash e' a fine vita dal 2026-08-07 e risponde 410 Gone; il successore
+  # servito e' deepseek-v4-flash-0731. I limiti qui sotto sono prudenti: non sono stati
+  # sondati, e una finestra sottostimata e' il verso sicuro in cui sbagliare.
+  "deepseek-ai/deepseek-v4-flash-0731":
+    context_length: 128000
+    max_output_tokens: 16384
 
   "openai/gpt-oss-120b":
     context_length: 128000

--- a/src/skillspector/providers/nv_build/provider.py
+++ b/src/skillspector/providers/nv_build/provider.py
@@ -38,13 +38,19 @@ REGISTRY_PATH = str(Path(__file__).with_name("model_registry.yaml"))
 class NvBuildProvider:
     """build.nvidia.com credentials + bundled-YAML metadata provider."""
 
-    # General default — DeepSeek v4 flash for the high-volume per-file
-    # analyzer calls.  meta_analyzer is upgraded to v4 pro for the
-    # aggregation/filter pass where precision matters more.
-    DEFAULT_MODEL = "deepseek-ai/deepseek-v4-flash"
-    SLOT_DEFAULTS: dict[str, str] = {
-        "meta_analyzer": "deepseek-ai/deepseek-v4-pro",
-    }
+    # General default.  The previous defaults (deepseek-v4-flash and, for the
+    # meta_analyzer slot, deepseek-v4-pro) are no longer served: the former
+    # returns 410 Gone (end of life 2026-08-07) and neither appears in
+    # GET /v1/models, so the out-of-the-box path failed every call.
+    #
+    # The replacement is chosen for DETECTION, not latency.  On a bait skill
+    # carrying prose-disguised credential exfiltration, the fast served model
+    # (deepseek-v4-flash-0731, ~1.6 s/call) completed every call, reported no
+    # degradation, and returned a clean verdict — a confident false negative,
+    # which on a security scanner is the worst possible failure.  glm-5.2 costs
+    # ~16 s/call and flags it CRITICAL.
+    DEFAULT_MODEL = "z-ai/glm-5.2"
+    SLOT_DEFAULTS: dict[str, str] = {}
 
     def resolve_credentials(self) -> tuple[str, str | None] | None:
         """Return ``(api_key, base_url)`` from ``NVIDIA_INFERENCE_KEY``."""

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -135,7 +135,7 @@ class TestNvBuildProvider:
     @pytest.mark.parametrize(
         ("model", "context_length"),
         [
-            ("z-ai/glm-5.2", 1_000_000),
+            ("z-ai/glm-5.2", 202_749),
             ("z-ai/glm-5.1", 205_000),
             ("moonshotai/kimi-k2.6", 256_000),
         ],
@@ -143,7 +143,17 @@ class TestNvBuildProvider:
     def test_nv_build_reported_model_metadata(self, model: str, context_length: int) -> None:
         provider = NvBuildProvider()
         assert provider.get_context_length(model) == context_length
-        assert provider.get_max_output_tokens(model) is None
+
+    def test_glm_declares_both_limits(self) -> None:
+        """max_output_tokens is optional, and its absence is not neutral.
+
+        Without it the output budget is derived as a percentage of the context
+        window, which is what produced a 250_000-token request against an
+        endpoint accepting 202_749 combined.
+        """
+        provider = NvBuildProvider()
+        assert provider.get_context_length("z-ai/glm-5.2") == 202_749
+        assert provider.get_max_output_tokens("z-ai/glm-5.2") == 32_768
 
     @pytest.mark.parametrize("model", ["glm-5.2", "z-ai/glm-5.2 "])
     def test_nv_build_model_near_match_stays_unresolved(self, model: str) -> None:

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -136,7 +136,6 @@ class TestNvBuildProvider:
         ("model", "context_length"),
         [
             ("z-ai/glm-5.2", 202_749),
-            ("z-ai/glm-5.1", 205_000),
             ("moonshotai/kimi-k2.6", 256_000),
         ],
     )
@@ -180,11 +179,20 @@ class TestNvBuildProvider:
         assert llm.max_tokens == 123
         assert str(llm.openai_api_base).rstrip("/") == BUILD_BASE_URL.rstrip("/")
 
-    def test_metadata_known_model_from_bundled_yaml(self) -> None:
-        """deepseek-v4-flash ships in nv_build/model_registry.yaml."""
+    def test_metadata_drops_end_of_life_model(self) -> None:
+        """deepseek-v4-flash reached end of life and returns 410 Gone.
+
+        Keeping it is worse than omitting it: an entry with a 1_000_000 window
+        makes model_info budget 250_000 output tokens, rejected on every call.
+        Absent, the conservative default applies instead.
+        """
         provider = NvBuildProvider()
-        assert provider.get_context_length("deepseek-ai/deepseek-v4-flash") == 1_000_000
-        assert provider.get_max_output_tokens("deepseek-ai/deepseek-v4-flash") == 128_000
+        assert provider.get_context_length("deepseek-ai/deepseek-v4-flash") is None
+
+    def test_default_model_is_in_the_bundled_registry(self) -> None:
+        """The invariant test_constants asserts, checked at the source too."""
+        provider = NvBuildProvider()
+        assert provider.get_context_length(NvBuildProvider.DEFAULT_MODEL) is not None
 
     def test_metadata_unknown_model_returns_none(self) -> None:
         provider = NvBuildProvider()
@@ -200,12 +208,9 @@ class TestNvBuildProvider:
         # Env override applies to every slot.
         assert NvBuildProvider().resolve_model("meta_analyzer") == "user/override"
 
-    def test_resolve_model_meta_analyzer_uses_slot_override(self) -> None:
-        # meta_analyzer is upgraded to deepseek-v4-pro on NvBuild.
-        assert (
-            NvBuildProvider().resolve_model("meta_analyzer")
-            == NvBuildProvider.SLOT_DEFAULTS["meta_analyzer"]
-        )
+    def test_resolve_model_meta_analyzer_falls_back_to_default(self) -> None:
+        # The former override named deepseek-v4-pro, absent from the catalogue.
+        assert NvBuildProvider().resolve_model("meta_analyzer") == NvBuildProvider.DEFAULT_MODEL
 
     def test_resolve_model_unknown_slot_falls_to_default(self) -> None:
         # Slots without an explicit override inherit DEFAULT_MODEL.


### PR DESCRIPTION
The other half of #388. **Depends on #390** — merge that first.

Three registry entries name models `GET /v1/models` does not serve:

| entry | status | role |
|---|---|---|
| `deepseek-ai/deepseek-v4-flash` | **410 Gone** since 2026-08-07 | `DEFAULT_MODEL` |
| `deepseek-ai/deepseek-v4-pro` | absent from the catalogue | `meta_analyzer` slot |
| `z-ai/glm-5.1` | absent from the catalogue | — |

With no `SKILLSPECTOR_MODEL` set, the out-of-the-box path failed every call.

**Why this is one change and not two.** Removing the dead entries and retargeting the default cannot be separated: the suite already asserts the invariant that couples them, in `test_constants.py` —

> "nv_build's default model is in its registry — no warnings expected for that model."

Dropping the default from the registry while leaving it as the default breaks that test, and it is *right* to break: a default the registry does not describe gets its token budget from a guess, silently. I attempted the split and abandoned it for this reason.

**The part worth arguing about.** The replacement is chosen for detection, not latency:

| model | latency | on a bait skill with disguised credential exfiltration |
|---|---|---|
| `deepseek-v4-flash-0731` | ~1.6 s/call | 3/3 calls, no degradation reported, **clean verdict** |
| `z-ai/glm-5.2` | ~16 s/call | **CRITICAL** |

A confident false negative is the worst failure mode a security scanner has: it is the case where someone signs off. The fast model does not report uncertainty — it reports absence.

**On dropping the slot override.** `meta_analyzer` loses its override rather than gaining a new one. The aggregation pass does benefit from a stronger model, but naming a second model doubles the surface that can go stale — which is how the previous default rotted unnoticed. Happy to restore one if you'd rather.

`1044 passed`, ruff format and check clean, DCO signed.