### PR TITLE
release: SkillSpector 2.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.9.6 (Tuesday, August 18, 2026)
+### Features/Bug Fixes
+* fix(pe3): distinguish OAuth token nouns from access actions (#392)
+---
 ### 2.9.5 (Friday, August 14, 2026)
 ### Features/Bug Fixes
 * Scope the locality guard to the namespace (#365)

--- a/docs/release/skillspector-2.9.6.md
+++ b/docs/release/skillspector-2.9.6.md
@@ -1,0 +1,51 @@
+# SkillSpector v2.9.6
+
+Released: 2026-08-18
+
+## Summary
+
+SkillSpector 2.9.6 improves PE3 credential-access accuracy for OAuth documentation. It now distinguishes compound-noun uses of `access token` and `access tokens` from instructions that access credentials, removing HIGH-severity false positives without weakening detection of actionable credential access.
+
+## Highlights
+
+- Stop flagging ordinary OAuth glossary entries, return-value descriptions, revocation behavior, storage guidance, and supported-token tables as credential-access findings.
+- Preserve PE3 findings for imperative and modal access instructions, sensitive credential sources, and read, copy, send, post, leak, and exfiltration actions.
+
+## Added
+
+- Add benign and adversarial regression coverage for OAuth terminology in Markdown tables, headings, later clauses, URL navigation, action inflections, and HTTP POST token flows.
+
+## Changed
+
+- Classify noun-shaped `access token` terminology in documentation using bounded grammatical context instead of a narrow OAuth lifecycle allowlist.
+
+## Fixed
+
+- Prevent ordinary OAuth terminology in documentation from producing HIGH-severity PE3 findings while retaining findings for credential-access actions embedded in or adjacent to benign prose.
+
+## Security
+
+- Keep the OAuth documentation exception fail-closed when bounded context contains credential actions or sensitive sources.
+
+## Breaking Changes and Migration
+
+- None.
+
+## Deprecations
+
+- None.
+
+## Validation
+
+- `uv run pytest -q tests/unit/test_patterns.py tests/nodes/analyzers/test_binary_and_pe3_filtering.py tests/nodes/analyzers/test_static_runner_filtering.py` — 204 passed.
+- `uv run pytest -q --ignore=tests/unit/test_input_handler.py --ignore=tests/unit/test_input_handler_ssrf.py` — 2,158 passed, 13 skipped, and 4 expected failures.
+- `uv run ruff check src/ tests/` — passed.
+- `uv run ruff format --check src/ tests/` — passed.
+
+## Known Limitations
+
+- The documentation exception is intentionally limited to Markdown and text files under recognized documentation paths; other file types and locations continue to use the stricter PE3 rule.
+
+## References
+
+- [GitHub PR #392](https://github.com/NVIDIA/SkillSpector/pull/392)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "skillspector"
-version = "2.9.5"
+version = "2.9.6"
 description = "SkillSpector: Security scanner for AI agent skills (Claude Code, Cursor, and similar). Scans skills for vulnerabilities, malicious patterns, and security risks before installation. Supports Git repos, URLs, zips, and local directories; runs static pattern checks and optional LLM semantic analysis; outputs terminal, JSON, and Markdown reports with risk scoring."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2675,7 +2675,7 @@ wheels = [
 
 [[package]]
 name = "skillspector"
-version = "2.9.5"
+version = "2.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## SkillSpector 2.9.6

Prepares the public SkillSpector 2.9.6 patch release from current `main`.

## Included

- bump the package and lockfile version from 2.9.5 to 2.9.6
- add the 2.9.6 changelog entry
- add versioned public release notes for the PE3 OAuth accuracy fix from #392
- document that ordinary OAuth terminology no longer produces HIGH-severity credential-access findings while actionable access remains detected

## Why a patch release

Only one fix has merged since v2.9.5, so this is a patch release. The fix removes a broad class of real-world HIGH-severity false positives across OAuth glossaries, return-value descriptions, revocation behavior, storage guidance, and supported-token tables. It replaces the narrow lifecycle allowlist with bounded grammatical classification while retaining fail-closed handling for credential actions and sensitive sources.

## Release artifacts

No built artifacts are committed or manually uploaded in this PR. The established `release:publish` workflow builds and validates the wheel and sdist after this labeled PR merges, creates tag `v2.9.6`, and attaches both artifacts to the GitHub Release.

## Validation

- `uv lock --check`
- focused release-workflow and PE3 suite: 132 passed
- suite excluding the two network-bound DNS/SSRF files: 2,158 passed, 13 skipped, 38 deselected, 4 expected failures
- full suite: 2,203 passed, 13 skipped, 38 deselected, 4 expected failures; seven known environment-specific failures because public GitHub/GitLab hosts resolve to internal addresses on this network
- `ruff check src/ tests/ scripts/`
- `ruff format --check src/ tests/ scripts/`
- built `skillspector-2.9.6-py3-none-any.whl` and `skillspector-2.9.6.tar.gz`
- `twine check` passed for both distributions
- `git diff --check`
