### PR TITLE
feat(report): expose max_issue_severity so a normalized verdict cannot hide a HIGH finding

### DIFF
--- a/src/skillspector/nodes/report.py
+++ b/src/skillspector/nodes/report.py
@@ -153,6 +153,31 @@ _SEVERITY_POINTS: dict[str, int] = {
     "LOW": 5,
 }
 
+# Ranking used only to report the worst finding alongside the normalized verdict.
+# Deliberately separate from _SEVERITY_POINTS: those are scoring weights and may be
+# retuned, while this is an ordering and must stay stable for consumers.
+_SEVERITY_RANK: dict[str, int] = {"LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
+
+
+def _max_issue_severity(findings: Sequence[Finding]) -> str:
+    """Highest severity present in the reported issues, or NONE when there are none.
+
+    risk_assessment.severity is a normalized, confidence-weighted verdict: it can read
+    LOW while issues[] contains a HIGH finding. That smoothing is intentional, but until
+    now it was invisible, so every consumer that wanted to gate on the worst finding had
+    to walk issues[] and re-implement this ranking. Reporting it here makes the two
+    numbers comparable without changing either.
+    """
+    worst = 0
+    label = "NONE"
+    for finding in findings:
+        rank = _SEVERITY_RANK.get(str(finding.severity).upper(), 0)
+        if rank > worst:
+            worst = rank
+            label = str(finding.severity).upper()
+    return label
+
+
 _MAX_OCCURRENCES_PER_RULE = 3
 _DIMINISHING_WEIGHTS = (1.0, 0.5, 0.25)
 
@@ -689,6 +714,7 @@ def _format_json(
             "score": risk_score,
             "severity": risk_severity,
             "recommendation": risk_recommendation,
+            "max_issue_severity": _max_issue_severity(findings),
         },
         "components": [
             {

--- a/tests/nodes/analyzers/test_sc8_shipped_bytecode.py
+++ b/tests/nodes/analyzers/test_sc8_shipped_bytecode.py
@@ -62,5 +62,6 @@ def test_sc8_single_pyc_blocks_install_and_cli_exit(tmp_path: Path) -> None:
         "score": 51,
         "severity": "HIGH",
         "recommendation": "DO_NOT_INSTALL",
+        "max_issue_severity": "HIGH",
     }
     assert any(issue["id"] == "SC8" for issue in report["issues"])

--- a/tests/nodes/test_report.py
+++ b/tests/nodes/test_report.py
@@ -696,6 +696,56 @@ def test_report_baseline_keeps_unmatched_finding() -> None:
     assert len(result["suppressed_findings"]) == 1
 
 
+def test_report_json_reports_worst_issue_severity() -> None:
+    """max_issue_severity names the worst finding even when the verdict normalizes it away.
+
+    A single HIGH finding scores below the HIGH band, so risk_assessment.severity reads
+    LOW. Before this field, a consumer reading the verdict got the opposite of what the
+    findings said, with nothing in the report flagging the disagreement.
+    """
+    state: SkillspectorState = {
+        "filtered_findings": [_finding("PE3", "HIGH")],
+        "component_metadata": [],
+        "has_executable_scripts": False,
+        "manifest": {},
+        "skill_path": None,
+        "output_format": "json",
+    }
+    data = json.loads(report(state)["report_body"])
+    assert data["risk_assessment"]["max_issue_severity"] == "HIGH"
+    assert data["issues"][0]["severity"] == "HIGH"
+
+
+def test_report_json_worst_issue_severity_is_none_without_findings() -> None:
+    """With no issues the field says NONE, not the empty string or a bare LOW."""
+    state: SkillspectorState = {
+        "filtered_findings": [],
+        "component_metadata": [],
+        "has_executable_scripts": False,
+        "manifest": {},
+        "skill_path": None,
+        "output_format": "json",
+    }
+    data = json.loads(report(state)["report_body"])
+    assert data["risk_assessment"]["max_issue_severity"] == "NONE"
+
+
+def test_report_json_worst_issue_severity_ignores_suppressed() -> None:
+    """A suppressed finding is not a reported issue, so it must not set the maximum."""
+    baseline = Baseline(rules=[SuppressionRule(rule_id="P5", reason="fp")])
+    state: SkillspectorState = {
+        "filtered_findings": [_finding("P5", "CRITICAL"), _finding("PE3", "MEDIUM")],
+        "component_metadata": [],
+        "has_executable_scripts": False,
+        "manifest": {},
+        "skill_path": None,
+        "output_format": "json",
+        "baseline": baseline,
+    }
+    data = json.loads(report(state)["report_body"])
+    assert data["risk_assessment"]["max_issue_severity"] == "MEDIUM"
+
+
 def test_report_json_includes_suppressed_section() -> None:
     """JSON output reports suppressed_count and a suppressed array."""
     baseline = Baseline(rules=[SuppressionRule(rule_id="P5", reason="fp")])


### PR DESCRIPTION
Closes #397.

## What

Adds `risk_assessment.max_issue_severity` to the JSON report: the highest severity present in
`issues[]`, or `"NONE"` when there are none.

Additive only. No existing field changes value, no scoring is touched, no behaviour changes.

## Why

`risk_assessment.severity` is a normalised, confidence-weighted verdict, and it can read **LOW /
SAFE** on a report whose `issues[]` contains a **HIGH** finding. A single HIGH scores below the
HIGH band, so the summary and the findings disagree — and nothing in the report says so.

I am not asking for the normalisation to go away. With rules that fire on documentation prose (see
#396), a max-severity verdict would read HIGH on almost everything, which is its own kind of
useless. The problem is that the smoothing is **silent**: every consumer that wants to gate on the
worst finding has to walk `issues[]` and re-implement the severity ranking, and each one does it
slightly differently.

This is not hypothetical for me. I run SkillSpector as a pre-install gate. The gate keyed on
`risk_assessment.severity`, and on a corpus of deliberately malicious fixtures it stopped **0 of
5** — every one reported LOW/SAFE with HIGH findings listed underneath. Keying on the worst
finding took it to 2 of 5 with static analysis alone. The remaining gap is detection, which is
fair. The first gap was the report telling me SAFE.

## Design notes

- `_SEVERITY_RANK` is deliberately separate from `_SEVERITY_POINTS`. The latter are scoring
  weights and may be retuned; this is an ordering that consumers will depend on, so it should not
  move when scoring does.
- The value is computed from the same `findings` list the `issues[]` array is built from, so
  **suppressed findings do not raise it**. A finding excluded by a baseline is not a reported
  issue, and a field that counted it would make baselines useless for exactly the consumers this
  field is for. There is a test for this.
- `"NONE"` rather than `null` or `"LOW"` for the empty case: `null` invites `.get(...)` returning
  a falsy value that compares oddly, and `"LOW"` would be indistinguishable from a report that
  really does have a LOW finding.

## Tests

Three, in `tests/nodes/test_report.py`:

- a single HIGH finding → `max_issue_severity == "HIGH"` while the verdict normalises to LOW
- no findings → `"NONE"`
- a CRITICAL finding suppressed by baseline plus a reported MEDIUM → `"MEDIUM"`

All three fail without the source change and pass with it (verified by reverting the one-line
addition and re-running: 3 failed → 3 passed).

One existing test needed updating: `tests/nodes/analyzers/test_sc8_shipped_bytecode.py:61`
compares `risk_assessment` against an **exact** dict, so any added key fails it. I only found
this by running the full suite — worth knowing if other PRs add fields there.

`ruff check`, `ruff format --check` and `mypy` are clean on the touched files.

Full suite on this branch: **2107 passed, 14 skipped, 4 xfailed, 1 failed** in 26m22s. The one
failure is `tests/unit/test_mcp_server.py::test_mcp_stdio_initialize_registers_scan_skill`, and
it is **not** from this change: it fails identically with the change reverted on the same
machine (45.02s with, 47.86s without, load average 31-33). Its
`asyncio.wait_for(session.initialize(), timeout=15)` is a hardcoded budget smaller than the work
under load — the MCP subprocess does not finish the handshake in 15 s on a busy machine. Happy to
open that separately if it is not already known.

## Not in this PR

The human-readable output still prints `SAFE` and then lists a `[HIGH]` line below it with
nothing connecting the two. A one-line note there would help, but it is a presentation change with
its own review surface, so I left it out rather than bundle it.
