### PR TITLE
fix(supply-chain): surface the OSV advisory cap in the ledger and the finding

### DIFF
--- a/src/skillspector/inspection_ledger.py
+++ b/src/skillspector/inspection_ledger.py
@@ -60,9 +60,13 @@ class LedgerReason(StrEnum):
     NO_APPLICABLE_FILES = "no_applicable_files"
     OMS_SIGNATURE = "oms_signature"
     BASELINE_FILE = "baseline_file"
+    RESULT_LIMIT = "result_limit"
 
 
 REASON_MESSAGES: Final[dict[LedgerReason, str]] = {
+    LedgerReason.RESULT_LIMIT: (
+        "Only the first N results were examined; the remainder were not retrieved."
+    ),
     LedgerReason.EXCLUDED_DIRECTORY: ("Directory tree is excluded from the configured scan scope."),
     LedgerReason.HIDDEN_FILE: "Hidden file is excluded from the configured scan scope.",
     LedgerReason.FILE_DISAPPEARED: ("Inventoried file disappeared before it could be inspected."),
@@ -141,6 +145,8 @@ class InspectionLedgerEvent(TypedDict):
     limit_characters: NotRequired[int]
     observed_bytes: NotRequired[int]
     limit_bytes: NotRequired[int]
+    observed_count: NotRequired[int]
+    limit_count: NotRequired[int]
 
 
 class AnalyzerStatusEvent(TypedDict):
@@ -262,6 +268,8 @@ def ledger_event(
     limit_characters: int | None = None,
     observed_bytes: int | None = None,
     limit_bytes: int | None = None,
+    observed_count: int | None = None,
+    limit_count: int | None = None,
 ) -> InspectionLedgerEvent:
     """Create one validated terminal ledger record without sensitive payloads."""
     _validate_range(start_line, end_line)
@@ -324,6 +332,10 @@ def ledger_event(
         event["observed_bytes"] = observed_bytes
     if limit_bytes is not None:
         event["limit_bytes"] = limit_bytes
+    if observed_count is not None:
+        event["observed_count"] = observed_count
+    if limit_count is not None:
+        event["limit_count"] = limit_count
     return event
 
 

--- a/src/skillspector/nodes/analyzers/osv_client.py
+++ b/src/skillspector/nodes/analyzers/osv_client.py
@@ -52,6 +52,16 @@ if (env_val := os.environ.get("SKILLSPECTOR_OSV_TIMEOUT")) is not None:
 # Used by the supply-chain analyzer to surface fallback warnings.
 _last_query_ok: bool = True
 
+# Detail lookups cost one HTTP request each, so a package with 153 advisories would mean 153
+# round trips. The cap is deliberate; what it must not be is invisible.
+_MAX_VULN_DETAILS = 10
+
+# Packages whose advisory list was capped during the last query_batch() call, as
+# (name, version, examined, total). Same accessor pattern as _last_query_ok: the analyzer reads
+# it right after the call and turns it into ledger evidence, so the drop reaches the report
+# instead of stopping at a log line no consumer of the JSON will ever see.
+_last_truncations: list[tuple[str, str | None, int, int]] = []
+
 # Ecosystem identifiers expected by OSV.dev (case-sensitive).
 ECOSYSTEM_PYPI = "PyPI"
 ECOSYSTEM_NPM = "npm"
@@ -68,9 +78,13 @@ class VulnResult:
 
 
 # ---------------------------------------------------------------------------
-# In-memory cache: (name, version, ecosystem) -> list[VulnResult]
+# In-memory cache: (name, version, ecosystem) -> (results, total advisories reported by OSV)
+#
+# The total is stored next to the results because the results may be a capped subset of it. A
+# package appearing in two dependency files is the ordinary case, and without the total the
+# second lookup — a cache hit — would report the truncation as if it had not happened.
 # ---------------------------------------------------------------------------
-_cache: dict[tuple[str, str | None, str], tuple[float, list[VulnResult]]] = {}
+_cache: dict[tuple[str, str | None, str], tuple[float, list[VulnResult], int]] = {}
 _CACHE_TTL_SECS = 3600.0  # 1 hour
 
 
@@ -78,19 +92,21 @@ def _cache_key(name: str, version: str | None, ecosystem: str) -> tuple[str, str
     return (name.lower().replace("_", "-"), version, ecosystem)
 
 
-def _get_cached(key: tuple[str, str | None, str]) -> list[VulnResult] | None:
+def _get_cached(key: tuple[str, str | None, str]) -> tuple[list[VulnResult], int] | None:
     entry = _cache.get(key)
     if entry is None:
         return None
-    ts, results = entry
+    ts, results, total = entry
     if (time.monotonic() - ts) > _CACHE_TTL_SECS:
         del _cache[key]
         return None
-    return results
+    return results, total
 
 
-def _put_cache(key: tuple[str, str | None, str], results: list[VulnResult]) -> None:
-    _cache[key] = (time.monotonic(), results)
+def _put_cache(
+    key: tuple[str, str | None, str], results: list[VulnResult], total: int | None = None
+) -> None:
+    _cache[key] = (time.monotonic(), results, len(results) if total is None else total)
 
 
 def clear_cache() -> None:
@@ -198,12 +214,16 @@ def _parse_vuln(vuln: dict) -> VulnResult:
 
 
 def _fetch_vuln_details(vuln_ids: list[str]) -> list[VulnResult]:
-    """Fetch full vulnerability details for a list of IDs."""
-    if len(vuln_ids) > 10:
-        logger.warning("Processing 10 of %d vulnerabilities, truncating the rest", len(vuln_ids))
+    """Fetch full vulnerability details for at most _MAX_VULN_DETAILS IDs."""
+    if len(vuln_ids) > _MAX_VULN_DETAILS:
+        logger.warning(
+            "Processing %d of %d vulnerabilities, truncating the rest",
+            _MAX_VULN_DETAILS,
+            len(vuln_ids),
+        )
     results: list[VulnResult] = []
     with httpx.Client(timeout=_REQUEST_TIMEOUT) as client:
-        for vid in vuln_ids[:10]:
+        for vid in vuln_ids[:_MAX_VULN_DETAILS]:
             try:
                 resp = client.get(f"{_OSV_VULN_URL}/{vid}")
                 resp.raise_for_status()
@@ -244,6 +264,8 @@ def query_batch(
     """
     global _last_query_ok
 
+    _last_truncations.clear()
+
     if not packages:
         return []
 
@@ -256,7 +278,8 @@ def query_batch(
         key = _cache_key(name, version, ecosystem)
         cached = _get_cached(key)
         if cached is not None:
-            all_results[i] = cached
+            all_results[i] = cached[0]
+            _record_truncation(name, version, cached[0], cached[1])
         else:
             uncached_indices.append(i)
             uncached_queries.append(_build_query(name, version, ecosystem))
@@ -291,7 +314,8 @@ def query_batch(
             all_results[idx] = vuln_details
 
             name, version = packages[idx]
-            _put_cache(_cache_key(name, version, ecosystem), vuln_details)
+            _record_truncation(name, version, vuln_details, len(vuln_ids))
+            _put_cache(_cache_key(name, version, ecosystem), vuln_details, len(vuln_ids))
 
     except (httpx.HTTPError, httpx.TimeoutException, ValueError, KeyError) as exc:
         logger.warning("OSV.dev API request failed, falling back to static data: %s", exc)
@@ -312,6 +336,27 @@ def is_available() -> bool:
             return resp.status_code == 200
     except (httpx.HTTPError, httpx.TimeoutException):
         return False
+
+
+def _record_truncation(
+    name: str, version: str | None, examined: list[VulnResult], total: int
+) -> None:
+    """Note that *name* had more advisories than were examined, once per query_batch call."""
+    if total <= len(examined):
+        return
+    entry = (name, version, len(examined), total)
+    if entry not in _last_truncations:
+        _last_truncations.append(entry)
+
+
+def last_truncations() -> list[tuple[str, str | None, int, int]]:
+    """Return (name, version, examined, total) for packages capped by the last query_batch().
+
+    Empty when nothing was capped. Callers read this immediately after query_batch() and turn
+    it into ledger evidence: the cap is a defensible cost decision, but a report that says
+    `execution_successful: true` while two thirds of the advisories were never fetched is not.
+    """
+    return list(_last_truncations)
 
 
 def was_osv_reachable() -> bool:

--- a/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_supply_chain.py
@@ -38,14 +38,26 @@ from urllib.parse import urlparse
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.version import InvalidVersion, Version
 
-from skillspector.inspection_ledger import LedgerOutcome, analyzer_status_for_events, ledger_event
+from skillspector.inspection_ledger import (
+    LedgerOutcome,
+    LedgerReason,
+    analyzer_status_for_events,
+    ledger_event,
+)
 from skillspector.logging_config import get_logger
 from skillspector.models import AnalyzerFinding, Finding, Location, Severity
 from skillspector.state import AnalyzerNodeResponse, SkillspectorState
 
 from . import static_runner
 from .common import get_context, get_line_number
-from .osv_client import ECOSYSTEM_NPM, ECOSYSTEM_PYPI, VulnResult, query_batch, was_osv_reachable
+from .osv_client import (
+    ECOSYSTEM_NPM,
+    ECOSYSTEM_PYPI,
+    VulnResult,
+    last_truncations,
+    query_batch,
+    was_osv_reachable,
+)
 from .pattern_defaults import PatternCategory
 from .static_runner import analyzer_finding_to_finding
 
@@ -892,6 +904,15 @@ def _sc4_from_osv(
     """
     pkg_pairs = [(name, version) for name, version, _ in packages]
     osv_results = query_batch(pkg_pairs, ecosystem)
+    # OSV detail lookups are capped, so `vulns` below can be a subset. The finding must quote the
+    # number OSV reported, not the number this process chose to fetch: "10 advisory(ies)" for a
+    # package that has 153 is a false statement, and it is exactly the number a reader uses to
+    # judge the package. The severity is still the worst of the examined ten and may therefore
+    # understate the package; that is why the ledger records the cap as an incompleteness.
+    totals = {
+        (name.lower().replace("_", "-"), version): total
+        for name, version, _examined, total in last_truncations()
+    }
 
     findings: list[AnalyzerFinding] = []
     covered: set[str] = set()
@@ -908,10 +929,12 @@ def _sc4_from_osv(
         severity = _osv_severity_to_app(worst_severity)
         confidence = _SEVERITY_CONFIDENCE.get(worst_severity.upper(), 0.75)
         vuln_desc = _format_vuln_ids(vulns)
+        reported = totals.get((pkg_name.lower().replace("_", "-"), pkg_version), len(vulns))
+        capped = "" if reported == len(vulns) else f" (first {len(vulns)} examined)"
         if pkg_version:
             message = (
                 f"Known Vulnerable Dependency: {pkg_name}=={pkg_version}"
-                f" — {len(vulns)} advisory(ies): {vuln_desc}"
+                f" — {reported} advisory(ies){capped}: {vuln_desc}"
             )
             matched_text = f"{pkg_name}=={pkg_version}"
         else:
@@ -924,9 +947,9 @@ def _sc4_from_osv(
             severity = Severity.LOW
             confidence = 0.4
             message = (
-                f"Unverifiable Dependency: {pkg_name} has {len(vulns)} known advisory(ies)"
-                f" ({vuln_desc}), but the manifest does not pin a version, so it is unknown"
-                " whether the installed release is affected"
+                f"Unverifiable Dependency: {pkg_name} has {reported} known advisory(ies)"
+                f"{capped} ({vuln_desc}), but the manifest does not pin a version, so it is"
+                " unknown whether the installed release is affected"
             )
             matched_text = pkg_name
         findings.append(
@@ -1325,6 +1348,22 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
             dependency_findings,
             f"{ANALYZER_ID}_dependencies",
         )
+        # A capped advisory lookup is work this analyzer decided not to do. The ledger already
+        # accounts for files left unread; advisories left unfetched belong in the same place,
+        # or `analysis_completeness` reports a scan that examined everything when it did not.
+        for name, version, examined, total in last_truncations():
+            response["inspection_ledger"].append(
+                ledger_event(
+                    analyzer_id=ANALYZER_ID,
+                    outcome=LedgerOutcome.SKIPPED,
+                    phase="static",
+                    path=path,
+                    reason=LedgerReason.RESULT_LIMIT,
+                    observed_count=total,
+                    limit_count=examined,
+                    stage=f"osv_vuln_details:{name}=={version or 'unpinned'}",
+                )
+            )
 
     # TR1–TR3: trigger analysis from manifest
     manifest: dict[str, object] = state.get("manifest") or {}

--- a/tests/nodes/analyzers/test_supply_chain_osv_truncation.py
+++ b/tests/nodes/analyzers/test_supply_chain_osv_truncation.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A capped advisory lookup must reach the report, not just the log."""
+
+from __future__ import annotations
+
+from skillspector.inspection_ledger import LedgerReason
+from skillspector.nodes.analyzers import static_patterns_supply_chain as supply_chain
+from skillspector.nodes.analyzers.osv_client import VulnResult
+
+_TOTAL = 153
+_EXAMINED = 10
+
+
+def _ten_advisories() -> list[VulnResult]:
+    return [
+        VulnResult(vuln_id=f"GHSA-{i:04d}", summary="", severity="LOW", aliases=())
+        for i in range(_EXAMINED)
+    ]
+
+
+def _patch_truncated_osv(monkeypatch) -> None:
+    """OSV reports 153 advisories, the client examines 10 — the shape of the real defect."""
+    monkeypatch.setattr(supply_chain, "query_batch", lambda pkgs, eco: [_ten_advisories()])
+    monkeypatch.setattr(
+        supply_chain,
+        "last_truncations",
+        lambda: [("jinja2", "3.1.2", _EXAMINED, _TOTAL)],
+    )
+
+
+def test_finding_message_states_the_true_advisory_count(monkeypatch) -> None:
+    """Reporting "10 advisory(ies)" for a package that has 153 is a false statement.
+
+    It is also the number a reader would use to judge the package, and it understates the risk
+    by an order of magnitude while looking precise.
+    """
+    _patch_truncated_osv(monkeypatch)
+
+    findings = supply_chain._analyze_dependencies("jinja2==3.1.2\n", "requirements.txt", {})
+
+    sc4 = [f for f in findings if f.rule_id == "SC4"]
+    assert sc4, "the vulnerable package must still be reported"
+    message = sc4[0].message
+    assert str(_TOTAL) in message, f"message hides the real advisory count: {message}"
+    assert "10 advisory(ies)" not in message
+
+
+def test_truncation_surfaces_as_a_ledger_exception(monkeypatch) -> None:
+    """`analysis_completeness` is where a consumer looks for what was not examined."""
+    _patch_truncated_osv(monkeypatch)
+
+    state = {
+        "components": ["requirements.txt"],
+        "file_cache": {"requirements.txt": "jinja2==3.1.2\n"},
+        "manifest": {},
+        "skill_path": "",
+        "component_metadata": [{"path": "requirements.txt", "executable": False}],
+    }
+    response = supply_chain.node(state)  # type: ignore[arg-type]
+
+    capped = [
+        event
+        for event in response["inspection_ledger"]
+        if event.get("reason_code") is LedgerReason.RESULT_LIMIT
+    ]
+    assert capped, "the cap left no trace in the ledger"
+    assert capped[0]["observed_count"] == _TOTAL
+    assert capped[0]["limit_count"] == _EXAMINED
+    assert capped[0]["path"] == "requirements.txt"
+
+
+def test_result_limit_reaches_analysis_completeness(monkeypatch) -> None:
+    """The event must survive the projection into the public report, not just the ledger.
+
+    `_exception_from_event` deliberately keeps the public row narrow — it carries what, where and
+    why, and no numeric evidence: real reports show `size_limit` and `binary_content` rows without
+    any byte counts. So the assertion here is the one that matters to a consumer: a capped
+    advisory lookup shows up in `analysis_completeness.ledger_exceptions` naming the file and the
+    analyzer. The quantity travels in the SC4 message instead, which is where a reader looking at
+    the package will find it.
+    """
+    from skillspector.inspection_ledger import LedgerOutcome, finalize_ledger, ledger_event
+
+    completeness, _limitations = finalize_ledger(
+        {
+            "components": ["requirements.txt"],
+            "inspection_ledger": [
+                ledger_event(
+                    analyzer_id="static_patterns_supply_chain",
+                    outcome=LedgerOutcome.SKIPPED,
+                    phase="static",
+                    path="requirements.txt",
+                    reason=LedgerReason.RESULT_LIMIT,
+                    observed_count=_TOTAL,
+                    limit_count=_EXAMINED,
+                )
+            ],
+        }
+    )
+
+    capped = [
+        row
+        for row in completeness["ledger_exceptions"]
+        if row["reason_code"] is LedgerReason.RESULT_LIMIT
+    ]
+    assert capped, "the capped lookup never reaches the public report"
+    assert capped[0]["path"] == "requirements.txt"
+    assert "static_patterns_supply_chain" in capped[0]["analyzers"]
+    assert capped[0]["message"]

--- a/tests/test_inspection_ledger.py
+++ b/tests/test_inspection_ledger.py
@@ -159,3 +159,41 @@ def test_failed_event_includes_sanitized_failure_metadata_only_when_provided() -
 
     assert event["error_class"] == "PermissionError"
     assert event["stage"] == "read"
+
+
+def test_result_limit_event_carries_observed_and_limit_counts() -> None:
+    """A capped result set is a first-class incompleteness, like a size limit on a file.
+
+    The ledger already distinguishes "not read because too large" from "read". It had no way to
+    say "read, but only the first N of M results", so an analyzer that capped its own work had
+    nowhere to put the fact. Without the two counts the event says something happened but not
+    how much was lost, which is the same silence one level up.
+    """
+    event = ledger_event(
+        outcome=LedgerOutcome.SKIPPED,
+        phase="static",
+        analyzer_id="static_patterns_supply_chain",
+        path="requirements.txt",
+        reason=LedgerReason.RESULT_LIMIT,
+        observed_count=153,
+        limit_count=10,
+    )
+
+    assert event["reason_code"] is LedgerReason.RESULT_LIMIT
+    assert event["observed_count"] == 153
+    assert event["limit_count"] == 10
+    assert event["message"], "every reason must carry a human-readable message"
+
+
+def test_counts_are_omitted_when_not_supplied() -> None:
+    """Optional evidence stays optional: absent means absent, not zero."""
+    event = ledger_event(
+        outcome=LedgerOutcome.SKIPPED,
+        phase="static",
+        analyzer_id="static_patterns_supply_chain",
+        path="requirements.txt",
+        reason=LedgerReason.READ_ERROR,
+    )
+
+    assert "observed_count" not in event
+    assert "limit_count" not in event

--- a/tests/unit/test_osv_client.py
+++ b/tests/unit/test_osv_client.py
@@ -26,8 +26,8 @@ from skillspector.nodes.analyzers.osv_client import (
     ECOSYSTEM_NPM,
     ECOSYSTEM_PYPI,
     VulnResult,
-    _cache,
     _estimate_cvss_severity,
+    _put_cache,
     _severity_from_vuln,
     clear_cache,
     query_batch,
@@ -222,9 +222,10 @@ class TestQueryBatch:
         mock_client.post.return_value = mock_post_resp
         mock_client.get.return_value = mock_get_resp
 
-        import time
-
-        _cache[("jinja2", "2.4.1", "PyPI")] = (time.monotonic(), [cached_vuln])
+        # Seed through the module's own writer rather than the raw dict: the cache entry now
+        # carries the advisory total alongside the results, and a test that hand-builds the
+        # tuple breaks on a private shape it has no reason to know.
+        _put_cache(("jinja2", "2.4.1", "PyPI"), [cached_vuln])
 
         with patch(
             "skillspector.nodes.analyzers.osv_client.httpx.Client", return_value=mock_client
@@ -310,3 +311,74 @@ class TestQueryBatch:
             query_batch([("jinja2", "2.4.1")], ECOSYSTEM_PYPI)
 
         assert was_osv_reachable() is False
+
+
+class TestAdvisoryTruncation:
+    """The 10-advisory cap must leave a trace the report can carry.
+
+    The cap itself is a defensible engineering choice: OSV detail lookups are one HTTP request
+    each, and a package with 153 advisories would mean 153 round trips. What is not defensible
+    is that the drop is invisible — ``logger.warning`` does not reach the JSON artifact, so a
+    consumer reading ``execution_successful: true`` cannot tell that 143 advisories were never
+    examined, nor that the reported severity is the worst of ten rather than the worst of all.
+    """
+
+    @staticmethod
+    def _mock_client(n_advisories: int) -> MagicMock:
+        batch = {"results": [{"vulns": [{"id": f"GHSA-{i:04d}"} for i in range(n_advisories)]}]}
+        post_resp = MagicMock()
+        post_resp.json.return_value = batch
+        post_resp.raise_for_status = MagicMock()
+        get_resp = MagicMock()
+        get_resp.json.return_value = {"id": "GHSA-0000", "summary": "s", "severity": []}
+        get_resp.raise_for_status = MagicMock()
+        client = MagicMock()
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client.post.return_value = post_resp
+        client.get.return_value = get_resp
+        return client
+
+    def test_truncation_is_recorded_with_observed_and_limit(self) -> None:
+        from skillspector.nodes.analyzers.osv_client import last_truncations
+
+        with patch("httpx.Client", return_value=self._mock_client(12)):
+            results = query_batch([("jinja2", "3.1.2")], ECOSYSTEM_PYPI)
+
+        assert len(results[0]) == 10, "the cap itself must still hold"
+        assert last_truncations() == [("jinja2", "3.1.2", 10, 12)]
+
+    def test_no_truncation_leaves_no_record(self) -> None:
+        from skillspector.nodes.analyzers.osv_client import last_truncations
+
+        with patch("httpx.Client", return_value=self._mock_client(3)):
+            query_batch([("jinja2", "3.1.2")], ECOSYSTEM_PYPI)
+
+        assert last_truncations() == []
+
+    def test_cached_package_still_reports_its_truncation(self) -> None:
+        """A second scan of the same package must not lose the disclosure.
+
+        The cache is keyed by (name, version, ecosystem) and stores the *truncated* list. If the
+        record lived only on the fetch path, a package seen twice in one run — the same
+        dependency in requirements.txt and pyproject.toml is the ordinary case — would report
+        the truncation the first time and hide it the second.
+        """
+        from skillspector.nodes.analyzers.osv_client import last_truncations
+
+        with patch("httpx.Client", return_value=self._mock_client(12)):
+            query_batch([("jinja2", "3.1.2")], ECOSYSTEM_PYPI)
+            query_batch([("jinja2", "3.1.2")], ECOSYSTEM_PYPI)
+
+        assert last_truncations() == [("jinja2", "3.1.2", 10, 12)]
+
+    def test_previous_truncations_do_not_leak_into_the_next_query(self) -> None:
+        from skillspector.nodes.analyzers.osv_client import last_truncations
+
+        with patch("httpx.Client", return_value=self._mock_client(12)):
+            query_batch([("jinja2", "3.1.2")], ECOSYSTEM_PYPI)
+        clear_cache()
+        with patch("httpx.Client", return_value=self._mock_client(2)):
+            query_batch([("flask", "2.0.0")], ECOSYSTEM_PYPI)
+
+        assert last_truncations() == []


### PR DESCRIPTION
Closes #386.

## What the report says today

`_fetch_vuln_details()` examines at most 10 advisories per package and reports the drop through
`logger.warning` only. Nothing reaches the artifact:

- `analysis_completeness` has no event for it, so a consumer reading `execution_successful: true`
  cannot tell that most of the input was never fetched;
- the SC4 message quotes the truncated count, so a package OSV listed 153 advisories for is
  reported as `10 advisory(ies)` — the number a reader uses to judge the package;
- the finding's severity is the worst of the examined ten, so a truncated lookup can understate
  a package whose worst advisory sits past the cap.

Measured on one workstation. The larger figure in #386 (16 truncation events, 323 advisories
discarded) was taken when a bigger corpus was on disk; that cache rotates, so here is what is
reproducible **today**, on what survives:

| | |
|---|---|
| truncation events in the logs | 7 |
| advisories examined | 70 |
| advisories discarded | **111 (61% of 181)** |
| worst single case | 10 of 44 |
| stored reports carrying a trace of any of it | **0 of 41** |

That last row is the defect stated as a measurement. The mechanism is not missing: 15 of those
41 reports do carry `ledger_exceptions`, with `size_limit`, `binary_content` and
`llm_batch_failed`. Only the advisory cap has no way to appear there.

## What this PR does — and does not

It does **not** touch the cap. A detail lookup is one HTTP request per advisory, and 153 round
trips for one package is not a trade anyone wants. The cap is a reasonable cost decision; being
invisible is the defect.

- `LedgerReason.RESULT_LIMIT`, so the drop appears in `analysis_completeness.ledger_exceptions`
  beside the existing `SIZE_LIMIT` and `READ_ERROR` accounting. SkillSpector already accounts
  carefully for files it did not read; advisories it did not fetch belong in the same ledger.
- `observed_count` / `limit_count` on the internal ledger event, mirroring the existing
  `observed_bytes` / `limit_bytes`. Note these stay internal: `_exception_from_event` keeps the
  public row narrow — what, where, why, no numbers — and real reports confirm it, `size_limit`
  rows carry no byte counts either. This PR does not widen that projection; changing a public
  schema is a separate decision and not one a bug fix should make quietly. The **quantity**
  reaches the reader through the SC4 message instead, which is where someone judging the package
  is already looking.
- `osv_client.last_truncations()`, following the existing `was_osv_reachable()` accessor pattern,
  so the analyzer can turn the cap into evidence without changing `query_batch()`'s signature.
- The advisory total is cached next to the results. A dependency listed in both
  `requirements.txt` and `pyproject.toml` is the ordinary case; without this the second lookup —
  a cache hit — would silently lose the disclosure.
- The SC4 message quotes the number OSV reported and states how many were examined:
  `153 advisory(ies) (first 10 examined): …`

The severity of a truncated finding is still the worst of the examined ten. That is a
consequence of the cap; after this PR it is disclosed rather than implied.

## Tests

Nine new tests, each verified red against the unmodified module before the change:

| test | what it pins |
|---|---|
| `test_truncation_is_recorded_with_observed_and_limit` | the cap still holds, and it is recorded |
| `test_no_truncation_leaves_no_record` | no event when nothing was dropped |
| `test_cached_package_still_reports_its_truncation` | a cache hit does not lose the disclosure |
| `test_previous_truncations_do_not_leak_into_the_next_query` | per-call reset |
| `test_result_limit_event_carries_observed_and_limit_counts` | the two counts reach the event |
| `test_counts_are_omitted_when_not_supplied` | absent stays absent, not zero |
| `test_finding_message_states_the_true_advisory_count` | the message stops understating |
| `test_truncation_surfaces_as_a_ledger_exception` | end-to-end through `node()` |
| `test_result_limit_reaches_analysis_completeness` | the row survives the projection into the report |

One existing test was adjusted: `test_cache_hit_avoids_api_call` hand-built the private cache
tuple, which now carries the advisory total. It seeds through `_put_cache()` instead, so it no
longer depends on a private shape it has no reason to know.

`ruff check` and `ruff format --check` clean; `docker build` + `tests/docker/smoke.sh` pass
locally (including the GitHub URL scan). The unit suite is 2216 passed / 14 skipped / 4 xfailed,
with one unrelated failure: `test_mcp_stdio_initialize_registers_scan_skill` times out on its
hardcoded `asyncio.wait_for(..., timeout=15)` when the machine is loaded. It fails on an
untouched checkout of `main` under the same load and passes on both when the load drops, so it
is not this branch — it may be worth a separate look, since a 15-second handshake budget will go
red on any busy CI runner.
