### PR TITLE
fix(lp1): tailor remediation to manifest type

### DIFF
--- a/docs/B.3.1-mcp-least-privilege.md
+++ b/docs/B.3.1-mcp-least-privilege.md
@@ -117,10 +117,13 @@ hiding its true behavior. This is the strongest indicator of deceptive intent
 among the LP rules -- the skill is actively performing operations it claims not
 to need.
 
-**Example:** A skill declares `permissions: [read]` but its code contains
-`httpx.post(...)`. LP1 fires for the undeclared `network` capability.
+**Example:** An Agent Skills `SKILL.md` declares `allowed-tools: Read` but its
+code contains `httpx.post(...)`. LP1 fires for the undeclared `network`
+capability.
 
-**Remediation:** Add the missing permission to SKILL.md, or remove the code
+**Remediation:** For Agent Skills `SKILL.md`, add a tool that covers the missing
+capability to the `allowed-tools` frontmatter field. For MCP server manifests,
+add the missing capability to the `permissions` list. Otherwise, remove the code
 that requires it.
 
 ---

--- a/src/skillspector/nodes/analyzers/mcp_least_privilege.py
+++ b/src/skillspector/nodes/analyzers/mcp_least_privilege.py
@@ -364,6 +364,17 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
                 confidence = _clamp(0.55 if is_test_only else 0.75)
                 source_files = [p for p, caps in file_capabilities.items() if cap in caps]
                 primary_file = source_files[0] if source_files else "SKILL.md"
+                if allowed_tools:
+                    remediation = (
+                        f"Add a tool that covers the '{cap}' capability to the "
+                        "'allowed-tools' frontmatter field in SKILL.md, or remove "
+                        "the code that requires it."
+                    )
+                else:
+                    remediation = (
+                        f"Add the '{cap}' capability to the MCP server manifest's "
+                        "'permissions' list, or remove the code that requires it."
+                    )
                 logger.debug(
                     "%s: LP1 underdeclared capability %s in %s", ANALYZER_ID, cap, primary_file
                 )
@@ -383,9 +394,7 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
                             f"The skill uses '{cap}' capability that is not listed in its permissions. "
                             "This may indicate deceptive intent or missing permission declarations."
                         ),
-                        remediation=(
-                            f"Add the '{cap}' permission to SKILL.md, or remove the code that requires it."
-                        ),
+                        remediation=remediation,
                     )
                 )
 

--- a/src/skillspector/nodes/analyzers/pattern_defaults.py
+++ b/src/skillspector/nodes/analyzers/pattern_defaults.py
@@ -402,7 +402,7 @@ DEFAULT_REMEDIATIONS: dict[str, str] = {
     "YR3": "Remove all cryptocurrency mining code, pool references, and miner binaries. Mining in agent skills is unauthorized resource abuse. Report the skill as malicious.",
     "YR4": "Remove offensive tool references and exploit code. Legitimate agent skills should not contain penetration testing tools, exploit frameworks, or reconnaissance utilities.",
     # MCP Least Privilege (B.3.1)
-    "LP1": "Add the missing permission to SKILL.md, or remove the code that requires it.",
+    "LP1": "Declare the missing capability in the manifest type being scanned: for Agent Skills SKILL.md, add a covering tool to the 'allowed-tools' frontmatter field; for MCP server manifests, add the capability to the 'permissions' list. Otherwise, remove the code that requires it.",
     "LP2": "Replace wildcard permissions ('*', 'all', 'full', 'any') with an explicit list of required permissions.",
     "LP3": "Declare the skill's tool scope: for Claude Code / Agent Skills SKILL.md, list the tools the skill may invoke in the 'allowed-tools' frontmatter field; for MCP server manifests, add a 'permissions' list naming the required capabilities.",
     "LP4": "Remove the declared permission if the corresponding capability is no longer used.",

--- a/tests/test_mcp_least_privilege.py
+++ b/tests/test_mcp_least_privilege.py
@@ -242,6 +242,9 @@ class TestLP1UnderdeclaredCapability:
         for lp1 in lp1_findings:
             assert lp1.severity == "HIGH", f"Expected HIGH severity for LP1, got {lp1.severity}"
             assert lp1.confidence >= 0.70
+            assert lp1.remediation is not None
+            assert "'permissions' list" in lp1.remediation
+            assert "SKILL.md" not in lp1.remediation
 
 
 class TestLP3NoPermissions:
@@ -306,6 +309,9 @@ class TestLP3AllowedTools:
         )
         for lp1 in lp1_findings:
             assert lp1.severity == "HIGH", f"Expected HIGH severity for LP1, got {lp1.severity}"
+            assert lp1.remediation is not None
+            assert "'allowed-tools'" in lp1.remediation
+            assert "'permissions'" not in lp1.remediation
 
     def test_allowed_tools_fully_covered_no_lp1(self):
         """allowed-tools: [Bash] + only shell code → no LP1 (capability is covered)."""


### PR DESCRIPTION
Closes #300.

## What changed

- Make LP1 remediation follow the declaration source:
  - Agent Skills using `allowed-tools` are told to add a tool that covers the missing capability.
  - MCP server manifests using `permissions` are told to add the missing capability to that list.
- Align the LP1 fallback remediation and the B.3.1 design documentation.
- Add regression assertions for both manifest shapes.

## Why

LP1 currently tells Agent Skills authors to add a generic permission to `SKILL.md`, but the Agent Skills schema uses `allowed-tools`. Following the existing remediation can therefore produce an unsupported field and leave the finding unresolved.

PR #316 corrected the same guidance gap for LP3. This completes the remaining LP1 path described in #300 without changing detection, scoring, or schema behavior.

## Validation

- `ruff check` on the changed Python and test files
- `ruff format --check` on the changed Python and test files
- Python AST parsing for the changed Python and test files
- `git diff --check`

The focused regression assertions are included; the repository's full dependency-backed test suite is left to GitHub Actions to avoid installing its unrelated AI/AWS runtime stack locally.
