### PR TITLE
fix(analyzer): stop EA1 from matching multiline gaps and markdown bold spans

### DIFF
--- a/src/skillspector/nodes/analyzers/static_patterns_excessive_agency.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_excessive_agency.py
@@ -42,7 +42,7 @@ ANALYZER_ID = "static_patterns_excessive_agency"
 
 # EA1: Unrestricted Tool Access
 EA1_PATTERNS = [
-    (r"(?:tools?|permissions?)\s*:\s*\[?\s*['\"]?\*['\"]?\s*\]?", 0.85),
+    (r"(?:tools?|permissions?)\s*:[ \t]*\[?[ \t]*['\"]?\*(?!\*|\w)['\"]?[ \t]*\]?", 0.85),
     (r"(?:allow|grant|enable)\s+(?:access\s+to\s+)?(?:all|any|every)\s+tools?", 0.8),
     (
         r"(?:no|without)\s+(?:tool|permission|access|capability)\s+(?:restrictions?|constraints?|limitations?)",

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -309,6 +309,48 @@ class TestP9PatternDefaults:
         assert pattern_defaults.get_remediation("P9").strip()
 
 
+class TestRunStaticPatternsExcessiveAgencyEA1:
+    """EA1_PATTERNS[0] must not match a blank-line gap or a markdown bold span."""
+
+    def test_ea1_multiline_gap_not_flagged(self):
+        """A blank-line gap between the colon and a bold heading is not a wildcard grant."""
+        state = {
+            "components": ["skill.md"],
+            "file_cache": {
+                "skill.md": "tool:\n\n**Input Schema:**",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [excessive_agency_module])
+        assert not any(f.rule_id == "EA1" for f in findings)
+
+    def test_ea1_bold_span_not_flagged(self):
+        """The first '*' of a '**bold**' heading is not a wildcard grant."""
+        state = {
+            "components": ["skill.md"],
+            "file_cache": {
+                "skill.md": "**API Coverage vs. Workflow Tools:**",
+            },
+        }
+        findings = static_runner.run_static_patterns(state, [excessive_agency_module])
+        assert not any(f.rule_id == "EA1" for f in findings)
+
+    @pytest.mark.parametrize(
+        "content",
+        ['tools: "*"', "tools: [*]", "permissions: '*'"],
+        ids=["quoted_star", "bracket_star", "single_quoted_star"],
+    )
+    def test_ea1_real_wildcard_still_flagged(self, content: str):
+        """The three real wildcard-grant shapes still produce EA1, MEDIUM severity."""
+        state = {
+            "components": ["skill.md"],
+            "file_cache": {"skill.md": content},
+        }
+        findings = static_runner.run_static_patterns(state, [excessive_agency_module])
+        ea1 = [f for f in findings if f.rule_id == "EA1"]
+        assert len(ea1) >= 1
+        assert ea1[0].severity == "MEDIUM"
+
+
 class TestRunStaticPatternsDataExfiltration:
     """run_static_patterns with data_exfiltration: E1, E2, E5."""
 


### PR DESCRIPTION
Fixes #405.

## Root cause

`EA1_PATTERNS[0]` in `static_patterns_excessive_agency.py` is
`(?:tools?|permissions?)\s*:\s*\[?\s*['"]?\*['"]?\s*\]?`. Python's `\s` matches
newlines regardless of `re.MULTILINE`, so the gap the pattern allows between the
colon and the wildcard value is unbounded across blank lines and paragraphs, and
the pattern has no check that the matched `*` is a standalone token rather than the
first `*` of a `**bold**` span. Two shapes both produce a false-positive EA1
finding on prose that grants no tool access: a blank-line gap (`tool:\n\n**Input
Schema:**`) and a markdown bold heading (`**API Coverage vs. Workflow Tools:**`).

## Fix

Replace the pattern with `(?:tools?|permissions?)\s*:[ \t]*\[?[ \t]*['"]?\*(?!\*|\w)['"]?[ \t]*\]?`:
restricts the gap to spaces/tabs (no longer crosses a blank line) and adds a
negative lookahead so the matched `*` cannot be followed by another `*` or a word
character, so it can no longer be the first character of a bold span or an
identifier. The three real wildcard-grant shapes (`tools: "*"`, `tools: [*]`,
`permissions: '*'`) still match.

## Verification

- New regression tests in `tests/nodes/analyzers/test_static_patterns.py`: the two
  false-positive shapes from the issue no longer produce an EA1 finding, and the
  three real wildcard shapes still produce EA1 at MEDIUM severity.
- `make lint` and `make format-check` clean.
- Full unit suite in a clean `python:3.12-slim` container: 2800 passed (2795
  existing + 5 new), 14 skipped, 4 xfailed, matching the repo's `test-unit` gate.
  Under `--cov` (the `test-ci` recipe), two unrelated tests in
  `test_security_end_to_end.py` fail; reproduced the same two failures 3/3 runs
  against unmodified `main` under the same `--cov` flag, so this is a pre-existing
  flake independent of this change, not a regression it introduces.
- `docker-smoke` (image build plus `tests/docker/smoke.sh`) passes.
