### PR TITLE
fix(analyzer): gate AE3 and AE4 on text content

### DIFF
--- a/src/skillspector/nodes/analyzers/artifact_integrity.py
+++ b/src/skillspector/nodes/analyzers/artifact_integrity.py
@@ -9,6 +9,7 @@ import time
 import unicodedata
 from dataclasses import dataclass, field
 
+from skillspector.artifacts import ContentKind
 from skillspector.inspection_ledger import (
     InspectionLedgerEvent,
     LedgerOutcome,
@@ -269,28 +270,32 @@ def node(state: SkillspectorState) -> AnalyzerNodeResponse:
                             confidence=1.0,
                         )
                     )
-                format_density, mixed_script, first_nul_line = _text_signals(content, budget)
-                if artifact.get("contains_nul") and first_nul_line is not None:
-                    budget.emit(
-                        _finding(
-                            "AE3",
-                            "Text artifact contains embedded NUL bytes",
-                            path,
-                            severity="HIGH",
-                            confidence=0.9,
-                            line=first_nul_line,
+                if artifact.get("content_kind") not in {
+                    ContentKind.BINARY,
+                    ContentKind.OPAQUE,
+                }:
+                    format_density, mixed_script, first_nul_line = _text_signals(content, budget)
+                    if artifact.get("contains_nul") and first_nul_line is not None:
+                        budget.emit(
+                            _finding(
+                                "AE3",
+                                "Text artifact contains embedded NUL bytes",
+                                path,
+                                severity="HIGH",
+                                confidence=0.9,
+                                line=first_nul_line,
+                            )
                         )
-                    )
-                if format_density >= 0.01 or mixed_script:
-                    budget.emit(
-                        _finding(
-                            "AE4",
-                            "Suspicious Unicode normalization or mixed-script content",
-                            path,
-                            severity="MEDIUM",
-                            confidence=0.8,
+                    if format_density >= 0.01 or mixed_script:
+                        budget.emit(
+                            _finding(
+                                "AE4",
+                                "Suspicious Unicode normalization or mixed-script content",
+                                path,
+                                severity="MEDIUM",
+                                confidence=0.8,
+                            )
                         )
-                    )
         except _ArtifactIntegrityResourceLimitError as exc:
             resource_limit = exc
 

--- a/tests/nodes/test_security_remediation.py
+++ b/tests/nodes/test_security_remediation.py
@@ -80,7 +80,7 @@ Describe the diagram in assets/diagram.png to the user.
         encoding="utf-8",
     )
     png = base64.b64decode(
-        "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAHElEQVQoz2NgGAWjYBSMglEwCkbBKBgFo2AUAAAHkgABfXRPtQAAAABJRU5ErkJggg=="
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
     )
     assets = tmp_path / "assets"
     assets.mkdir()
@@ -95,9 +95,17 @@ Describe the diagram in assets/diagram.png to the user.
     assert artifact["content_kind"] in {ContentKind.BINARY, ContentKind.OPAQUE}
     assert not {finding.rule_id for finding in findings} & {"AE3", "AE4"}
     assert any(
+        finding.rule_id == "AE1" and finding.file == "SKILL.md" for finding in result["findings"]
+    )
+    assert any(
         event.get("analyzer_id") == "artifact_integrity"
         and event.get("path") == "assets/diagram.png"
         and event.get("outcome") == "completed"
+        for event in result["inspection_ledger"]
+    )
+    assert any(
+        event.get("path") == "assets/diagram.png"
+        and event.get("reason_code") == LedgerReason.OPAQUE_CONTENT
         for event in result["inspection_ledger"]
     )
 

--- a/tests/nodes/test_security_remediation.py
+++ b/tests/nodes/test_security_remediation.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import base64
 import io
 import time
 import tracemalloc
@@ -63,6 +64,54 @@ def test_artifact_integrity_reports_misleading_extension() -> None:
     )
 
     assert any(finding.rule_id == "AE2" for finding in response["findings"])
+
+
+def test_opaque_png_does_not_produce_decoded_text_findings(tmp_path: Path) -> None:
+    (tmp_path / "SKILL.md").write_text(
+        """---
+name: binary-repro
+description: A skill that ships one small PNG as reference material.
+---
+
+# Binary repro
+
+Describe the diagram in assets/diagram.png to the user.
+""",
+        encoding="utf-8",
+    )
+    png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAHElEQVQoz2NgGAWjYBSMglEwCkbBKBgFo2AUAAAHkgABfXRPtQAAAABJRU5ErkJggg=="
+    )
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    (assets / "diagram.png").write_bytes(png)
+
+    result = graph.invoke({"input_path": str(tmp_path), "output_format": "json", "use_llm": False})
+
+    artifact = next(
+        item for item in result["artifact_inventory"] if item["path"] == "assets/diagram.png"
+    )
+    findings = [finding for finding in result["findings"] if finding.file == "assets/diagram.png"]
+    assert artifact["content_kind"] in {ContentKind.BINARY, ContentKind.OPAQUE}
+    assert not {finding.rule_id for finding in findings} & {"AE3", "AE4"}
+    assert any(
+        event.get("path") == "assets/diagram.png" and event.get("reason_code") == "opaque_content"
+        for event in result["inspection_ledger"]
+    )
+
+
+def test_text_artifact_remains_eligible_for_ae4() -> None:
+    response = artifact_integrity(
+        {
+            "components": ["notes"],
+            "local_file_cache": {"notes": "latin-а"},
+            "artifact_inventory": [
+                {"path": "notes", "content_kind": ContentKind.TEXT},
+            ],
+        }
+    )
+
+    assert [finding.rule_id for finding in response["findings"]] == ["AE4"]
 
 
 def test_normalized_view_removes_ignorables_maps_offsets_and_confusables() -> None:

--- a/tests/nodes/test_security_remediation.py
+++ b/tests/nodes/test_security_remediation.py
@@ -95,7 +95,9 @@ Describe the diagram in assets/diagram.png to the user.
     assert artifact["content_kind"] in {ContentKind.BINARY, ContentKind.OPAQUE}
     assert not {finding.rule_id for finding in findings} & {"AE3", "AE4"}
     assert any(
-        event.get("path") == "assets/diagram.png" and event.get("reason_code") == "opaque_content"
+        event.get("analyzer_id") == "artifact_integrity"
+        and event.get("path") == "assets/diagram.png"
+        and event.get("outcome") == "completed"
         for event in result["inspection_ledger"]
     )
 
@@ -112,6 +114,28 @@ def test_text_artifact_remains_eligible_for_ae4() -> None:
     )
 
     assert [finding.rule_id for finding in response["findings"]] == ["AE4"]
+
+
+def test_opaque_misleading_extension_keeps_ae2_without_ae3_or_ae4() -> None:
+    response = artifact_integrity(
+        {
+            "components": ["payload.md"],
+            "file_cache": {"payload.md": "\x00latin-а"},
+            "artifact_inventory": [
+                {
+                    "path": "payload.md",
+                    "content_kind": ContentKind.OPAQUE,
+                    "misleading_extension": True,
+                    "contains_nul": True,
+                }
+            ],
+        }
+    )
+
+    rule_ids = [finding.rule_id for finding in response["findings"]]
+    assert "AE2" in rule_ids
+    assert "AE3" not in rule_ids
+    assert "AE4" not in rule_ids
 
 
 def test_normalized_view_removes_ignorables_maps_offsets_and_confusables() -> None:


### PR DESCRIPTION
## Summary

AE3 and AE4 no longer inspect decoded cache text for artifacts classified as binary or opaque. Inventory, ledger accounting, AE1, AE2, AE5, and report ownership remain unchanged.

## Root cause

Artifact integrity reused decoded cache content without honoring the authoritative raw-byte `content_kind`, so an opaque PNG could be treated as text for mixed-script and instruction checks.

## Diff Notes

- Added an analyzer-local applicability guard for explicit `BINARY` and `OPAQUE` rows.
- Added the exact PNG production regression and text/direct-node negative-space coverage.
- Kept AE1 reference policy and all report/ledger contracts unchanged.

## Scope

This PR references #413 because it fixes the AE3/AE4 slice only. It does not change AE1 policy, artifact classification, static-runner routing, scoring, report schemas, or analyzer registration.

## Verification

- Focused tests: `python -m pytest tests/nodes/test_security_remediation.py tests/nodes/analyzers/test_artifact_integrity_bounds.py` passes, including opaque inventory, AE1, AE2, AE3, and AE4 preservation coverage.
- Ruff check, format check, and `git diff --check` pass.

Refs #413
