### PR TITLE
docs(readme): add HVTrust badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/NVIDIA/SkillSpector/badge)](https://scorecard.dev/viewer/?uri=github.com/NVIDIA/SkillSpector)
+[![HVTrust](https://hvtracker.net/badge/skillspector.svg)](https://hvtracker.net/agents/skillspector/)
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- add the requested auto-updating HVTrust badge beside the existing README trust badges
- link the badge to SkillSpector's public HVTracker evidence page

## Validation

- `git diff --check`  - clean
- verified the badge endpoint returns HTTP 200 with `image/svg+xml`
- verified the destination page returns HTTP 200 and identifies SkillSpector
- rendered the live SVG locally and confirmed the badge is legible

## Risk

- documentation-only change; no scanner or package behavior changes
- the score is served dynamically by the third-party badge endpoint

Fixes #277
