### PR TITLE
docs(cli): list all supported LLM providers

### DIFF
--- a/src/skillspector/cli.py
+++ b/src/skillspector/cli.py
@@ -524,7 +524,9 @@ def scan(
 
         SKILLSPECTOR_PROVIDER  Active LLM provider: openai | anthropic |
                                anthropic_proxy | bedrock | nv_build |
-                               nv_inference. Defaults to the NVIDIA path
+                               nv_inference | ollama | azure_openai |
+                               openai_compatible | claude_cli | codex_cli |
+                               gemini_cli. Defaults to the NVIDIA path
                                (nv_inference, falling back to nv_build in
                                OSS builds).
         SKILLSPECTOR_MODEL     Override the active provider's default
@@ -535,10 +537,19 @@ def scan(
 
         OPENAI_API_KEY [+ OPENAI_BASE_URL]   for SKILLSPECTOR_PROVIDER=openai
         ANTHROPIC_API_KEY                    for SKILLSPECTOR_PROVIDER=anthropic
+        ANTHROPIC_PROXY_API_KEY +
+          ANTHROPIC_PROXY_ENDPOINT_URL       for anthropic_proxy
         AWS_PROFILE (optional) + AWS_REGION  for SKILLSPECTOR_PROVIDER=bedrock
                                              (AWS_PROFILE: standard boto3 credential
                                              chain when unset; AWS_REGION default: us-west-2)
         NVIDIA_INFERENCE_KEY                 for the NVIDIA providers
+        AZURE_OPENAI_API_KEY +
+          AZURE_OPENAI_ENDPOINT              for azure_openai
+        SKILLSPECTOR_COMPAT_API_KEY +
+          SKILLSPECTOR_COMPAT_BASE_URL       for openai_compatible
+
+        ollama uses the local Ollama service. claude_cli, codex_cli, and
+        gemini_cli use their CLI's existing local authentication session.
     """
     if mcp_registry:
         if recursive or baseline is not None or show_suppressed or yara_rules_dir is not None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -88,6 +88,28 @@ def test_cli_version() -> None:
     assert "v" in result.output
 
 
+def test_cli_scan_help_lists_every_available_provider() -> None:
+    """Built-in help names every provider accepted by the selector."""
+    result = runner.invoke(app, ["scan", "--help"])
+
+    assert result.exit_code == 0
+    for provider in (
+        "openai",
+        "anthropic",
+        "anthropic_proxy",
+        "bedrock",
+        "nv_build",
+        "nv_inference",
+        "ollama",
+        "azure_openai",
+        "openai_compatible",
+        "claude_cli",
+        "codex_cli",
+        "gemini_cli",
+    ):
+        assert provider in result.output
+
+
 def test_cli_scan_local_directory(tmp_path: Path) -> None:
     """scan with local directory runs graph and prints report."""
     (tmp_path / "SKILL.md").write_text("---\nname: scan-test\n---\n# Safe", encoding="utf-8")


### PR DESCRIPTION
## Summary

- Update `skillspector scan --help` to list every usable LLM provider supported by the selector.
- Document the missing provider credentials and local-auth behavior.
- Add a CLI regression test covering the provider names in rendered help.

## Validation

- `pytest tests/unit/test_cli.py -q` — 102 passed.
- `pytest -m 'not integration and not provider' tests/ -q` — 2,826 passed, 13 skipped, 38 deselected, 4 xfailed.
- `ruff check src tests` — passed.
- `ruff format --check src tests` — 193 files already formatted.
- `git diff --check` — passed.
- Rendered `skillspector scan --help` and inspected the provider and credential sections.

## Risk

- Low: this changes built-in help text and its regression coverage only; provider selection and authentication behavior are unchanged.
- Integration and live-provider lanes were not run because the change does not exercise provider requests.

Fixes #431
