### PR TITLE
fix(ea1): bound wildcard-grant pattern to a single line and a standalone '*'

### DIFF
--- a/src/skillspector/nodes/analyzers/static_patterns_excessive_agency.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_excessive_agency.py
@@ -42,7 +42,11 @@ ANALYZER_ID = "static_patterns_excessive_agency"
 
 # EA1: Unrestricted Tool Access
 EA1_PATTERNS = [
-    (r"(?:tools?|permissions?)\s*:\s*\[?\s*['\"]?\*['\"]?\s*\]?", 0.85),
+    # EA1 wildcard grant: keep the value on the same line as the colon (the
+    # previous \s* spanned blank lines and bridged unrelated headings) and
+    # require the '*' to be a standalone token so markdown bold (**) or a
+    # word-adjacent '*' (e.g. a YAML anchor) is not treated as a wildcard.
+    (r"(?:tools?|permissions?)\s*:[ \t]*\[?[ \t]*['\"]?\*(?!\*|\w)['\"]?[ \t]*\]?", 0.85),
     (r"(?:allow|grant|enable)\s+(?:access\s+to\s+)?(?:all|any|every)\s+tools?", 0.8),
     (
         r"(?:no|without)\s+(?:tool|permission|access|capability)\s+(?:restrictions?|constraints?|limitations?)",

--- a/tests/unit/test_patterns_new.py
+++ b/tests/unit/test_patterns_new.py
@@ -88,6 +88,8 @@ class TestExcessiveAgency:
         "content",
         [
             pytest.param('tools: ["*"]', id="wildcard_tools"),
+            pytest.param("tools: *", id="wildcard_tools_bare"),
+            pytest.param("permissions: '*'", id="wildcard_permissions"),
             pytest.param("Allow access to all tools without restriction.", id="grant_all_tools"),
             pytest.param("This skill can execute arbitrary commands.", id="arbitrary_commands"),
             pytest.param(
@@ -102,6 +104,21 @@ class TestExcessiveAgency:
         findings = ea_mod.analyze(
             "This API has no restrictions on read-only access.", "docs.md", "markdown"
         )
+        assert not any(f.rule_id == "EA1" for f in findings)
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            pytest.param(
+                "For each tool:\n\n**Input Schema:**",
+                id="no_cross_heading_bridge",
+            ),
+            pytest.param("**API Coverage vs. Workflow Tools:**", id="no_bold_markdown_collision"),
+            pytest.param("Tools: **Read**, **Write**", id="no_bolded_named_tool_list"),
+        ],
+    )
+    def test_ea1_no_false_positive_on_markdown_bold_or_heading(self, content: str) -> None:
+        findings = ea_mod.analyze(content, "SKILL.md", "markdown")
         assert not any(f.rule_id == "EA1" for f in findings)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Fixes #405. The EA1 wildcard-tool-access pattern

```python
r"(?:tools?|permissions?)\s*:\s*\[?\s*['\"]?\*['\"]?\s*\]?"
```

used `\s*` between the colon and the expected `*` value. Python's `\s` matches newlines regardless of `re.MULTILINE`, so the pattern could span a blank line and bridge two unrelated headings (`For each tool:\n\n**Input Schema:**` -> matched text `tool:\n\n*`), and it treated the first `*` of a markdown bold span (`**API Coverage vs. Workflow Tools:**` -> `Tools:*`) as a wildcard grant. Both surfaced as EA1/MEDIUM false positives on benign skills.

## Fix

- Constrain the gap between the colon and the value to the same line (`[ \t]*` instead of `\s*`).
- Require the matched `*` to be a standalone token: add `(?!\*|\w)` so markdown bold (`**`) and word-adjacent `*` (e.g. a YAML anchor like `*ref`) no longer match.

```python
r"(?:tools?|permissions?)\s*:[ \t]*\[?[ \t]*['\"]?\*(?!\*|\w)['\"]?[ \t]*\]?"
```

Genuine single-line wildcard grants still match: `tools: "*"`, `tools: [*]`, `permissions: '*'`, `tool:*`.

## Tests

- Added `tools: *` and `permissions: '*'` to the existing EA1-positive parametrization in `tests/unit/test_patterns_new.py`.
- Added `TestExcessiveAgency::test_ea1_no_false_positive_on_markdown_bold_or_heading` covering the cross-heading bridge, bold-markdown collision, and a bolded list of specific named tools.

Verified: `pytest tests/unit/test_patterns_new.py` (368 passed) and `pytest tests/nodes/analyzers/test_static_patterns.py` (151 passed); `ruff check` and `ruff format --check` clean.