### PR TITLE
fix(ea1): reject footnote-legend '*', bound pre-colon gap, detect YAML block-list and JSON wildcard grants

### DIFF
--- a/src/skillspector/nodes/analyzers/static_patterns_excessive_agency.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_excessive_agency.py
@@ -46,15 +46,19 @@ ANALYZER_ID = "static_patterns_excessive_agency"
 EA1_PATTERNS = [
     # Same-line wildcard grant. The key may be quoted (JSON). A quoted '*' is
     # unambiguous as a scalar or a top-level list element — the list branch
-    # excludes '{'/'}' so a '*' nested inside an explicit tool object
-    # (tools: [{name: grep, pattern: "*"}]) is an argument value, not a
-    # grant. A bare '*' counts only when it ends the line (optionally closed
-    # by ']' and/or a '#' comment), so a footnote legend like
-    # "Tools: * = requires auth" is not a grant. The gap around the colon
-    # stays on one line so the match can never bridge paragraphs (#405, #444).
+    # excludes '{', '}', and '[' so it never descends into a nested object or
+    # array: in tools: [{name: grep, pattern: "*"}] or
+    # tools: ["search", ["grep", "*"]] the '*' is not a top-level tool-list
+    # element and is not a grant. (Ceiling: a quoted element containing one
+    # of those delimiters before a genuine top-level "*" also stops the scan;
+    # walking quoted strings needs a parser, not a pattern.) A bare '*'
+    # counts only when it ends the line (optionally closed by ']' and/or a
+    # '#' comment), so a footnote legend like "Tools: * = requires auth" is
+    # not a grant. The gap around the colon stays on one line so the match
+    # can never bridge paragraphs (#405, #444).
     (
         r"['\"]?(?:tools?|permissions?)['\"]?[ \t]*:[ \t]*"
-        r"(?:\[[^\]{}\r\n]*['\"]\*['\"]"
+        r"(?:\[[^\][{}\r\n]*['\"]\*['\"]"
         r"|\[?[ \t]*['\"]\*['\"]"
         r"|\[?[ \t]*\*(?![\*\w])[ \t]*\]?[ \t]*(?:#[^\r\n]*)?\r?$)",
         0.85,

--- a/src/skillspector/nodes/analyzers/static_patterns_excessive_agency.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_excessive_agency.py
@@ -44,7 +44,30 @@ ANALYZER_ID = "static_patterns_excessive_agency"
 
 # EA1: Unrestricted Tool Access
 EA1_PATTERNS = [
-    (r"(?:tools?|permissions?)\s*:[ \t]*\[?[ \t]*['\"]?\*(?!\*|\w)['\"]?[ \t]*\]?", 0.85),
+    # Same-line wildcard grant. The key may be quoted (JSON). A quoted '*' is
+    # unambiguous as a scalar or a top-level list element — the list branch
+    # excludes '{'/'}' so a '*' nested inside an explicit tool object
+    # (tools: [{name: grep, pattern: "*"}]) is an argument value, not a
+    # grant. A bare '*' counts only when it ends the line (optionally closed
+    # by ']' and/or a '#' comment), so a footnote legend like
+    # "Tools: * = requires auth" is not a grant. The gap around the colon
+    # stays on one line so the match can never bridge paragraphs (#405, #444).
+    (
+        r"['\"]?(?:tools?|permissions?)['\"]?[ \t]*:[ \t]*"
+        r"(?:\[[^\]{}\r\n]*['\"]\*['\"]"
+        r"|\[?[ \t]*['\"]\*['\"]"
+        r"|\[?[ \t]*\*(?![\*\w])[ \t]*\]?[ \t]*(?:#[^\r\n]*)?\r?$)",
+        0.85,
+    ),
+    # YAML block list whose first item is the wildcard (#445). Bounded to a
+    # single newline — a blank line still breaks the match — and the item's
+    # '*' must be standalone, so markdown lists ("- **Read**", "- *note*")
+    # do not collide. Later items are out of scope until seen in practice.
+    (
+        r"['\"]?(?:tools?|permissions?)['\"]?[ \t]*:[ \t]*(?:#[^\r\n]*)?\r?\n"
+        r"[ \t]*-[ \t]+['\"]?\*(?![\*\w])['\"]?[ \t]*(?:#[^\r\n]*)?\r?$",
+        0.85,
+    ),
     (r"(?:allow|grant|enable)\s+(?:access\s+to\s+)?(?:all|any|every)\s+tools?", 0.8),
     (
         r"(?:no|without)\s+(?:tool|permission|access|capability)\s+(?:restrictions?|constraints?|limitations?)",

--- a/tests/nodes/analyzers/test_ea1_wildcard_line_boundary.py
+++ b/tests/nodes/analyzers/test_ea1_wildcard_line_boundary.py
@@ -258,3 +258,21 @@ class TestEA1NestedObjectArgumentNotFlagged:
             "markdown",
         )
         assert any(f.rule_id == "EA1" for f in findings)
+
+    def test_nested_array_wildcard_not_flagged(self) -> None:
+        """A '*' inside a nested array is not a top-level tool-list element."""
+        findings = ea_module.analyze(
+            'tools: ["search", ["grep", "*"]]\n',
+            "SKILL.md",
+            "markdown",
+        )
+        assert not any(f.rule_id == "EA1" for f in findings)
+
+    def test_json_tool_object_with_nested_arguments_not_flagged(self) -> None:
+        """A '*' buried in a named tool's argument object is not a grant."""
+        findings = ea_module.analyze(
+            '"tools": [{"name": "search", "arguments": {"glob": "*"}}]\n',
+            "config.json",
+            "json",
+        )
+        assert not any(f.rule_id == "EA1" for f in findings)

--- a/tests/nodes/analyzers/test_ea1_wildcard_line_boundary.py
+++ b/tests/nodes/analyzers/test_ea1_wildcard_line_boundary.py
@@ -114,3 +114,147 @@ class TestEA1GenuineWildcardStillFlagged:
             "markdown",
         )
         assert any(f.rule_id == "EA1" for f in findings)
+
+
+class TestEA1FootnoteAndPreColonNotFlagged:
+    """Remaining false-positive paths from #444: a footnote legend after a
+    'Tools:' label, and a blank-line gap before the colon."""
+
+    def test_footnote_legend_after_tools_label_not_flagged(self) -> None:
+        findings = ea_module.analyze(
+            "Tools: * = requires authentication\n",
+            "SKILL.md",
+            "markdown",
+        )
+        assert not any(f.rule_id == "EA1" for f in findings)
+
+    def test_footnote_prose_after_tools_label_not_flagged(self) -> None:
+        findings = ea_module.analyze(
+            "Tools: * marks optional parameters\n",
+            "SKILL.md",
+            "markdown",
+        )
+        assert not any(f.rule_id == "EA1" for f in findings)
+
+    def test_blank_line_before_definition_list_colon_not_flagged(self) -> None:
+        """The gap before the colon must stay on one line too — a markdown
+        definition list two paragraphs later is not a grant."""
+        findings = ea_module.analyze(
+            "several tools\n\n: * item\n",
+            "SKILL.md",
+            "markdown",
+        )
+        assert not any(f.rule_id == "EA1" for f in findings)
+
+    def test_bare_wildcard_with_trailing_comment_still_flagged(self) -> None:
+        """A '#' comment after the bare wildcard is still a grant, not prose."""
+        findings = ea_module.analyze(
+            "tools: * # allow everything\n",
+            "SKILL.md",
+            "markdown",
+        )
+        assert any(f.rule_id == "EA1" for f in findings)
+
+
+class TestEA1BlockListAndJsonFormsFlagged:
+    """Detection gaps from #445: the idiomatic YAML block-list and JSON
+    quoted-key encodings of a wildcard grant."""
+
+    def test_yaml_block_list_quoted_wildcard_flagged(self) -> None:
+        findings = ea_module.analyze(
+            'tools:\n  - "*"\n',
+            "SKILL.md",
+            "markdown",
+        )
+        assert any(f.rule_id == "EA1" for f in findings)
+
+    def test_yaml_block_list_bare_wildcard_flagged(self) -> None:
+        findings = ea_module.analyze(
+            "tools:\n  - *\n",
+            "SKILL.md",
+            "markdown",
+        )
+        assert any(f.rule_id == "EA1" for f in findings)
+
+    def test_yaml_block_list_zero_indent_flagged(self) -> None:
+        findings = ea_module.analyze(
+            'permissions:\n- "*"\n',
+            "SKILL.md",
+            "markdown",
+        )
+        assert any(f.rule_id == "EA1" for f in findings)
+
+    def test_json_quoted_key_list_wildcard_flagged(self) -> None:
+        findings = ea_module.analyze(
+            '"tools": ["*"]\n',
+            "config.json",
+            "json",
+        )
+        assert any(f.rule_id == "EA1" for f in findings)
+
+    def test_json_quoted_key_scalar_wildcard_flagged(self) -> None:
+        findings = ea_module.analyze(
+            '"permissions": "*"\n',
+            "config.json",
+            "json",
+        )
+        assert any(f.rule_id == "EA1" for f in findings)
+
+    def test_inline_list_wildcard_not_first_flagged(self) -> None:
+        findings = ea_module.analyze(
+            'tools: ["search", "*"]\n',
+            "SKILL.md",
+            "markdown",
+        )
+        assert any(f.rule_id == "EA1" for f in findings)
+
+    def test_markdown_dash_list_of_bold_tools_not_flagged(self) -> None:
+        """The block-list branch must not collide with a markdown list of
+        specific bolded tool names."""
+        findings = ea_module.analyze(
+            "Tools:\n- **Read**\n- **Write**\n",
+            "SKILL.md",
+            "markdown",
+        )
+        assert not any(f.rule_id == "EA1" for f in findings)
+
+    def test_blank_line_before_dash_item_not_flagged(self) -> None:
+        """A blank line between the key and a dash item breaks the block-list
+        association — the cross-paragraph bridge from #405 must not return."""
+        findings = ea_module.analyze(
+            'tools:\n\n  - "*"\n',
+            "SKILL.md",
+            "markdown",
+        )
+        assert not any(f.rule_id == "EA1" for f in findings)
+
+
+class TestEA1NestedObjectArgumentNotFlagged:
+    """A '*' nested inside an explicit tool object is an argument value for a
+    specifically named tool, not a wildcard grant — the wildcard must be a
+    top-level list element."""
+
+    def test_json_tool_object_with_wildcard_argument_not_flagged(self) -> None:
+        findings = ea_module.analyze(
+            'tools: [{"name": "grep", "pattern": "*"}]\n',
+            "config.json",
+            "json",
+        )
+        assert not any(f.rule_id == "EA1" for f in findings)
+
+    def test_yaml_flow_tool_object_with_wildcard_argument_not_flagged(self) -> None:
+        findings = ea_module.analyze(
+            'tools: [{name: search, glob: "*"}]\n',
+            "SKILL.md",
+            "markdown",
+        )
+        assert not any(f.rule_id == "EA1" for f in findings)
+
+    def test_top_level_wildcard_after_named_element_still_flagged(self) -> None:
+        """Narrowing to top-level elements must not lose the plain mixed list."""
+        findings = ea_module.analyze(
+            'tools: ["search", "*"]\n',
+            "SKILL.md",
+            "markdown",
+        )
+        assert any(f.rule_id == "EA1" for f in findings)


### PR DESCRIPTION
## Summary

Follow-up to #405 / #417 (and duplicate #438). #417 correctly bounded the EA1 wildcard-grant regex to a single line and a standalone `*`, but an execution-verified edge-case audit of the merged pattern found two remaining false-positive paths and three detection gaps. This PR fixes all five.

Fixes #444. Fixes #445. (Systemic paragraph-crossing across all 15 pattern files is tracked separately in #446 — out of scope here.)

## Cases and how each is solved

### False positives removed (#444)

**Case 1 — footnote/legend text after a `Tools:` label.**
```markdown
Tools: * = requires authentication
Tools: * marks optional parameters
```
The `(?!\*|\w)` lookahead rejects `**` and `*word`, but a standalone `*` followed by a space passed — both lines fired EA1/MEDIUM on benign docs.
**Solution:** a bare (unquoted) `*` now only counts when it ends the line, optionally closed by `]` and/or a `#` comment. A real bare-scalar grant (`tools: *`, `tools: [*]`, `tools: * # allow all`) has nothing else after the value; a footnote legend always does. Quoted forms (`"*"`, `'*'`) are unambiguous and keep matching anywhere on the line.

**Case 2 — blank-line gap before the colon.**
```markdown
several tools

: * item
```
#417 bounded the whitespace *after* the colon, but `\s*:` before it still crossed newlines, so a markdown definition-list line two paragraphs later still bridged (matched text `tools\n\n: * `).
**Solution:** `[ \t]*:` — the key and colon must share a line. No real YAML/JSON/TOML syntax breaks a line between key and colon.

### Detection gaps closed (#445)

**Case 3 — JSON quoted keys never matched.**
```json
"tools": ["*"]
"permissions": "*"
```
The old prefix required the colon directly after the key word, so the closing quote of a JSON key broke the match — despite JSON being the most common encoding for MCP/agent configs.
**Solution:** the key may be wrapped in optional quotes: `['\"]?(?:tools?|permissions?)['\"]?`.

**Case 4 — the idiomatic YAML block-list form never matched.**
```yaml
tools:
  - "*"
```
The block-sequence dash was never part of the pattern.
**Solution:** a second pattern matches a key followed by exactly one newline and a first list item that is a standalone wildcard. A blank line still breaks the match (the #405 cross-heading bridge cannot return), and the standalone-`*` lookahead keeps markdown lists (`- **Read**`, `- *note*`) out. Later items are intentionally out of scope until seen in practice — matching arbitrary positions across lines widens the false-positive surface.

**Case 5 — wildcard not in first position of an inline list.**
```yaml
tools: ["search", "*"]
```
The old pattern required `*` immediately after `[`.
**Solution:** a *quoted* `*` anywhere inside same-line brackets now matches (`\[[^\]\r\n]*['\"]\*['\"]`). Quoted-only on purpose: markdown link/bold text inside `[...]` cannot satisfy it, and an unquoted `*` mid-list in YAML is an alias, not a wildcard.

## Validation

- 46-case edge matrix executed against old/current/new patterns with the exact `analyze()` flags (`re.IGNORECASE | re.MULTILINE`): 20 genuine grant forms still detected (quoted/bracketed/bare/no-space/tab/CRLF/uppercase/comments/`allowed_tools` substring), 11 new detections, 15 false-positive classes rejected (including all #405/#417 regression cases).
- `pytest tests/ -m "not integration and not provider"` — 2,963 passed, 14 skipped, 4 xfailed, 0 failures.
- 12 new tests in `tests/nodes/analyzers/test_ea1_wildcard_line_boundary.py` (footnote legend ×2, pre-colon gap, bare+comment, YAML block quoted/bare/zero-indent, JSON list/scalar key, inline not-first, markdown bold dash-list negative, blank-line-before-dash negative).
- `ruff check` and `ruff format --check` clean.

## Risk

- Confidence stays 0.85 for both patterns; severity mapping unchanged.
- Known accepted non-detections (unchanged from current main): multi-line flow lists (`tools: [\n "*"\n]`) and wildcards in later block-list items.
