### PR TITLE
Fix false local references from slash-separated prose

### DIFF
--- a/src/skillspector/references.py
+++ b/src/skillspector/references.py
@@ -44,7 +44,8 @@ class ReferenceResolutionResult:
 
 
 _PLAIN_RELATIVE_PATH = re.compile(
-    r"(?<![\w:/.-])((?:\./)?(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+(?:\.[A-Za-z0-9]{1,12})?)(?![\w/.-])"
+    r"(?<![\w:/.-])((?:\./(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+|"
+    r"(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.[A-Za-z0-9]{1,12}))(?![\w/.-])"
 )
 
 

--- a/src/skillspector/references.py
+++ b/src/skillspector/references.py
@@ -44,7 +44,7 @@ class ReferenceResolutionResult:
 
 
 _PLAIN_RELATIVE_PATH = re.compile(
-    r"(?<![\w:/.-])((?:\./(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+|"
+    r"(?<![\w:/.-])((?:\./(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+|"
     r"(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.[A-Za-z0-9]{1,12}))(?![\w/.-])"
 )
 

--- a/tests/nodes/test_security_remediation.py
+++ b/tests/nodes/test_security_remediation.py
@@ -358,7 +358,7 @@ def test_plain_slash_separated_prose_is_not_a_reference(tmp_path: Path) -> None:
         source_path="SKILL.md",
         source_text=(
             "Compare reads/writes, environment/profile settings, operation/node behavior, "
-            "and model/provider options."
+            "and model/provider options. SkillSpector 2.10.0 supports node.js; see example.com."
         ),
         known_paths=["SKILL.md"],
     )

--- a/tests/nodes/test_security_remediation.py
+++ b/tests/nodes/test_security_remediation.py
@@ -352,6 +352,41 @@ def test_full_body_reference_resolver_handles_markdown_and_unique_basename(
     assert all(record["status"] == "resolved" for record in records)
 
 
+def test_plain_slash_separated_prose_is_not_a_reference(tmp_path: Path) -> None:
+    records = resolve_bundle_references(
+        tmp_path,
+        source_path="SKILL.md",
+        source_text=(
+            "Compare reads/writes, environment/profile settings, and operation/node behavior."
+        ),
+        known_paths=["SKILL.md"],
+    )
+
+    assert records == []
+
+
+@pytest.mark.parametrize(
+    ("source_text", "target_path"),
+    [
+        ("Read references/guide.md before continuing.", "references/guide.md"),
+        ("Read ./references/guide before continuing.", "references/guide"),
+    ],
+)
+def test_plain_local_reference_requires_an_explicit_path_signal(
+    tmp_path: Path, source_text: str, target_path: str
+) -> None:
+    records = resolve_bundle_references(
+        tmp_path,
+        source_path="SKILL.md",
+        source_text=source_text,
+        known_paths=["SKILL.md", target_path],
+    )
+
+    assert len(records) == 1
+    assert records[0]["status"] == "resolved"
+    assert records[0]["target_path"] == target_path
+
+
 def test_reference_resolver_rejects_external_and_parent_escape(tmp_path: Path) -> None:
     records = resolve_bundle_references(
         tmp_path,

--- a/tests/nodes/test_security_remediation.py
+++ b/tests/nodes/test_security_remediation.py
@@ -369,6 +369,7 @@ def test_plain_slash_separated_prose_is_not_a_reference(tmp_path: Path) -> None:
     ("source_text", "target_path"),
     [
         ("Read references/guide.md before continuing.", "references/guide.md"),
+        ("Read ./guide before continuing.", "guide"),
         ("Read ./references/guide before continuing.", "references/guide"),
     ],
 )

--- a/tests/nodes/test_security_remediation.py
+++ b/tests/nodes/test_security_remediation.py
@@ -357,7 +357,8 @@ def test_plain_slash_separated_prose_is_not_a_reference(tmp_path: Path) -> None:
         tmp_path,
         source_path="SKILL.md",
         source_text=(
-            "Compare reads/writes, environment/profile settings, and operation/node behavior."
+            "Compare reads/writes, environment/profile settings, operation/node behavior, "
+            "and model/provider options."
         ),
         known_paths=["SKILL.md"],
     )


### PR DESCRIPTION
## Summary

- Ignore ordinary slash-separated prose such as `reads/writes` and `model/provider` during plain-text reference extraction.
- Preserve explicit paths such as `./guide.md` and `./references/guide`.
- Preserve extension-bearing paths with a directory segment, such as `references/guide.md`, and existing quoted, code-span, and Markdown destinations.

Fixes #450.

## Root cause

The plain relative-path pattern accepted a multi-segment token when both the explicit `./` prefix and final file extension were absent. The resolver therefore could not distinguish ordinary prose from an extensionless local path.

Unquoted plain-text references now require an explicit `./` prefix, or both a directory segment and final extension. Bare dotted tokens remain excluded because versions such as `2.10.0`, domains such as `example.com`, and ecosystem names such as `node.js` are indistinguishable from root-level filenames without another path signal.

Root-level files remain expressible through `./guide.md`, quotes or code spans, or Markdown link syntax.

## Verification

- Focused reference cases: `14 passed, 57 deselected`
- Full unit suite: `2956 passed, 14 skipped, 38 deselected, 4 xfailed`
- `ruff check`: passed
- `ruff format --check`: passed
- Source distribution and wheel build: passed
- `git diff --check`: passed

## Tradeoff

An unquoted extensionless token such as `references/guide`, or a bare dotted token such as `guide.md`, is ambiguous with prose. Authors must use an explicit `./` prefix, quotes or a code span, or Markdown link syntax. Nested extension-bearing paths such as `references/guide.md` remain supported.

## AI assistance disclosure

Codex inspected the reference resolver, reproduced the defect, tested version, domain, ecosystem-name, and slash-prose counterexamples, drafted the implementation and tests, and ran the verification commands. I reviewed the root cause, conservative contract, diff, tradeoff, and final pull-request text.
