### PR TITLE
fix: preserve finding classification during deduplication

### DIFF
--- a/src/skillspector/nodes/analyzers/static_runner.py
+++ b/src/skillspector/nodes/analyzers/static_runner.py
@@ -43,6 +43,7 @@ from skillspector.inspection_ledger import (
 )
 from skillspector.logging_config import get_logger
 from skillspector.models import AnalyzerFinding, Finding, observe_analyzer_findings
+from skillspector.nodes.deduplicate import classification_metadata_key
 from skillspector.python_ast import (
     MAX_PYTHON_AST_SOURCE_CHARS,
     ParsedPythonFile,
@@ -91,6 +92,8 @@ _WINDOW_OVERLAP_CHARS = 8192
 _RAW_WINDOW_OWNED_CHARS = SECURITY_VIEW_WINDOW_CHARS - 2 * _WINDOW_OVERLAP_CHARS
 _VIEW_START_EVIDENCE = "_security_view_start"
 _SOURCE_START_EVIDENCE = "_security_source_start"
+_VIEW_ORIGIN_TAGS = frozenset({"normalized-view", "declared-marker-view"})
+_ViewFindingKey = tuple[str, str, int, str | None, tuple[object, ...]]
 assert _RAW_WINDOW_OWNED_CHARS > 0
 DECLARED_MARKER_LEFT_CONTEXT_CHARS = MAX_MARKER_LOOKAHEAD_CHARS
 DECLARED_MARKER_RIGHT_CONTEXT_CHARS = MAX_DECLARED_MARKER_RIGHT_CONTEXT_CHARS
@@ -637,13 +640,19 @@ def _scan_path(
     return findings, None
 
 
-def _view_finding_key(finding: Finding) -> tuple[str, str, int, str | None]:
-    return (finding.rule_id, finding.file, finding.start_line, finding.fingerprint())
+def _view_finding_key(finding: Finding) -> _ViewFindingKey:
+    return (
+        finding.rule_id,
+        finding.file,
+        finding.start_line,
+        finding.fingerprint(),
+        classification_metadata_key(finding, ignored_tags=_VIEW_ORIGIN_TAGS),
+    )
 
 
 def _extend_unique_findings(
     result: list[Finding],
-    seen: set[tuple[str, str, int, str | None]],
+    seen: set[_ViewFindingKey],
     candidates: list[Finding],
     *,
     max_findings: int,
@@ -667,24 +676,19 @@ def _extend_unique_findings(
 
 
 def _deduplicate_view_findings(findings: list[Finding]) -> list[Finding]:
-    """Remove overlap/view duplicates using the complete match fingerprint."""
+    """Remove only location- and classification-equivalent view duplicates."""
     result: list[Finding] = []
-    seen: set[tuple[str, str, int, str | None]] = set()
-    raw_fingerprints: set[tuple[str, str, str]] = set()
+    seen: set[_ViewFindingKey] = set()
+    raw_keys = {
+        _view_finding_key(finding) for finding in findings if "normalized-view" not in finding.tags
+    }
     for finding in findings:
-        fingerprint = finding.fingerprint()
-        if (
-            fingerprint is not None
-            and "normalized-view" in finding.tags
-            and (finding.rule_id, finding.file, fingerprint) in raw_fingerprints
-        ):
-            continue
         key = _view_finding_key(finding)
+        if "normalized-view" in finding.tags and key in raw_keys:
+            continue
         if key in seen:
             continue
         seen.add(key)
-        if "normalized-view" not in finding.tags and fingerprint is not None:
-            raw_fingerprints.add((finding.rule_id, finding.file, fingerprint))
         result.append(finding)
     return result
 
@@ -932,6 +936,7 @@ def _continuity_finding_key(finding: Finding) -> tuple[object, ...]:
         finding.message,
         finding.severity,
         finding.confidence,
+        classification_metadata_key(finding, ignored_tags=_VIEW_ORIGIN_TAGS),
     )
 
 
@@ -1001,7 +1006,7 @@ def _scan_declared_marker_views(
     check_runtime()
     projection_limited = False
     seen_views: set[tuple[str, int, int]] = set()
-    seen_findings: set[tuple[str, str, int, str | None]] = set()
+    seen_findings: set[_ViewFindingKey] = set()
 
     for owned_start, raw_start in zip(owned_starts, raw_starts, strict=True):
         check_runtime()
@@ -1107,7 +1112,7 @@ def _scan_all_views_detailed(
     ast_modules = [module for module in pattern_modules if _uses_python_ast(module)]
     lexical_modules = [module for module in pattern_modules if not _uses_python_ast(module)]
     findings: list[Finding] = []
-    seen_findings: set[tuple[str, str, int, str | None]] = set()
+    seen_findings: set[_ViewFindingKey] = set()
     started_at = time.monotonic()
     runtime_limit = MAX_STATIC_ANALYSIS_SECONDS_PER_ARTIFACT
     if timeout_seconds is not None:

--- a/src/skillspector/nodes/analyzers/static_runner.py
+++ b/src/skillspector/nodes/analyzers/static_runner.py
@@ -93,7 +93,9 @@ _RAW_WINDOW_OWNED_CHARS = SECURITY_VIEW_WINDOW_CHARS - 2 * _WINDOW_OVERLAP_CHARS
 _VIEW_START_EVIDENCE = "_security_view_start"
 _SOURCE_START_EVIDENCE = "_security_source_start"
 _VIEW_ORIGIN_TAGS = frozenset({"normalized-view", "declared-marker-view"})
+_BENIGN_CONTEXT_TAGS = frozenset({"contextual-triage", "likely-benign-context"})
 _ViewFindingKey = tuple[str, str, int, str | None, tuple[object, ...]]
+_ViewScopeKey = tuple[str, str, int, str | None]
 assert _RAW_WINDOW_OWNED_CHARS > 0
 DECLARED_MARKER_LEFT_CONTEXT_CHARS = MAX_MARKER_LOOKAHEAD_CHARS
 DECLARED_MARKER_RIGHT_CONTEXT_CHARS = MAX_DECLARED_MARKER_RIGHT_CONTEXT_CHARS
@@ -650,6 +652,15 @@ def _view_finding_key(finding: Finding) -> _ViewFindingKey:
     )
 
 
+def _view_scope_key(finding: Finding) -> _ViewScopeKey:
+    return (
+        finding.rule_id,
+        finding.file,
+        finding.start_line,
+        finding.fingerprint(),
+    )
+
+
 def _extend_unique_findings(
     result: list[Finding],
     seen: set[_ViewFindingKey],
@@ -682,9 +693,23 @@ def _deduplicate_view_findings(findings: list[Finding]) -> list[Finding]:
     raw_keys = {
         _view_finding_key(finding) for finding in findings if "normalized-view" not in finding.tags
     }
+    raw_non_benign_scopes = {
+        _view_scope_key(finding)
+        for finding in findings
+        if "normalized-view" not in finding.tags and not _BENIGN_CONTEXT_TAGS.issubset(finding.tags)
+    }
     for finding in findings:
         key = _view_finding_key(finding)
         if "normalized-view" in finding.tags and key in raw_keys:
+            continue
+        if (
+            "normalized-view" in finding.tags
+            and _BENIGN_CONTEXT_TAGS.issubset(finding.tags)
+            and _view_scope_key(finding) in raw_non_benign_scopes
+        ):
+            # Normalization may make an ambiguous raw occurrence look benign.
+            # Prefer the raw non-benign signal, but never suppress a derived
+            # unsafe classification that exposes obfuscated content.
             continue
         if key in seen:
             continue

--- a/src/skillspector/nodes/deduplicate.py
+++ b/src/skillspector/nodes/deduplicate.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 
 from skillspector.logging_config import get_logger
@@ -49,9 +50,38 @@ def _finding_source_scope(finding: Finding) -> str:
     return ""
 
 
+def _classification_metadata_key(finding: Finding) -> tuple[object, ...]:
+    """Return the classification semantics compacted occurrences must share.
+
+    Occurrence expansion reuses one representative finding's report fields.
+    Keeping classification fields in the compaction identity prevents a
+    benign-context match and an unsafe match with the same rule fingerprint
+    from inheriting each other's classification or evidence. Confidence and
+    location-specific context are intentionally excluded because compaction
+    retains one highest-confidence representative for equivalent findings.
+    """
+    evidence = json.dumps(
+        finding.evidence,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return (
+        finding.message,
+        finding.severity,
+        finding.category,
+        finding.pattern,
+        finding.explanation,
+        finding.remediation,
+        finding.intent,
+        tuple(sorted(finding.tags)),
+        evidence,
+    )
+
+
 def deduplicate(findings: list[Finding]) -> list[Finding]:
-    """Aggregate exact full-match duplicates while preserving every occurrence."""
-    groups: dict[tuple[str, str, str], list[Finding]] = {}
+    """Aggregate classification-equivalent exact matches while preserving occurrences."""
+    groups: dict[tuple[str, str, str, tuple[object, ...]], list[Finding]] = {}
     unique_without_match: list[Finding] = []
     for finding in findings:
         fingerprint = finding.fingerprint()
@@ -59,10 +89,18 @@ def deduplicate(findings: list[Finding]) -> list[Finding]:
             unique_without_match.append(finding)
             continue
         source_scope = _finding_source_scope(finding)
-        groups.setdefault((source_scope, finding.rule_id, fingerprint), []).append(finding)
+        groups.setdefault(
+            (
+                source_scope,
+                finding.rule_id,
+                fingerprint,
+                _classification_metadata_key(finding),
+            ),
+            [],
+        ).append(finding)
 
     compacted: list[Finding] = []
-    for (_source_scope, _rule_id, fingerprint), group in groups.items():
+    for (_source_scope, _rule_id, fingerprint, _report_metadata), group in groups.items():
         representative = max(
             group,
             key=lambda item: (

--- a/src/skillspector/nodes/deduplicate.py
+++ b/src/skillspector/nodes/deduplicate.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import replace
+from hashlib import sha256
 
 from skillspector.logging_config import get_logger
 from skillspector.models import Finding
@@ -50,7 +51,27 @@ def _finding_source_scope(finding: Finding) -> str:
     return ""
 
 
-def _classification_metadata_key(finding: Finding) -> tuple[object, ...]:
+def _evidence_metadata_key(finding: Finding) -> tuple[str, object]:
+    """Return a bounded, fail-closed identity for classification evidence."""
+    try:
+        canonical = json.dumps(
+            finding.evidence,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+    except (RecursionError, TypeError, ValueError):
+        # ``Finding.evidence`` intentionally accepts arbitrary plugin metadata.
+        # Ambiguous values must never crash a scan or merge distinct findings.
+        return ("opaque", id(finding))
+    return ("sha256", sha256(canonical).digest())
+
+
+def classification_metadata_key(
+    finding: Finding,
+    *,
+    ignored_tags: frozenset[str] = frozenset(),
+) -> tuple[object, ...]:
     """Return the classification semantics compacted occurrences must share.
 
     Occurrence expansion reuses one representative finding's report fields.
@@ -60,12 +81,6 @@ def _classification_metadata_key(finding: Finding) -> tuple[object, ...]:
     location-specific context are intentionally excluded because compaction
     retains one highest-confidence representative for equivalent findings.
     """
-    evidence = json.dumps(
-        finding.evidence,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    )
     return (
         finding.message,
         finding.severity,
@@ -74,8 +89,8 @@ def _classification_metadata_key(finding: Finding) -> tuple[object, ...]:
         finding.explanation,
         finding.remediation,
         finding.intent,
-        tuple(sorted(finding.tags)),
-        evidence,
+        tuple(tag for tag in finding.tags if tag not in ignored_tags),
+        _evidence_metadata_key(finding),
     )
 
 
@@ -94,13 +109,18 @@ def deduplicate(findings: list[Finding]) -> list[Finding]:
                 source_scope,
                 finding.rule_id,
                 fingerprint,
-                _classification_metadata_key(finding),
+                classification_metadata_key(finding),
             ),
             [],
         ).append(finding)
 
     compacted: list[Finding] = []
-    for (_source_scope, _rule_id, fingerprint, _report_metadata), group in groups.items():
+    for (
+        _source_scope,
+        _rule_id,
+        fingerprint,
+        _classification_metadata,
+    ), group in groups.items():
         representative = max(
             group,
             key=lambda item: (

--- a/src/skillspector/nodes/deduplicate.py
+++ b/src/skillspector/nodes/deduplicate.py
@@ -89,7 +89,7 @@ def classification_metadata_key(
         finding.explanation,
         finding.remediation,
         finding.intent,
-        tuple(tag for tag in finding.tags if tag not in ignored_tags),
+        tuple(sorted(tag for tag in finding.tags if tag not in ignored_tags)),
         _evidence_metadata_key(finding),
     )
 

--- a/tests/nodes/test_deduplicate.py
+++ b/tests/nodes/test_deduplicate.py
@@ -136,7 +136,7 @@ class TestSameFileDedup:
 
         assert len(result) == 1
 
-    def test_tag_order_remains_report_metadata(self) -> None:
+    def test_tag_order_does_not_change_dedup_identity(self) -> None:
         first = _finding(file="a.py")
         first.tags = ["primary", "secondary"]
         second = _finding(file="b.py")
@@ -144,7 +144,8 @@ class TestSameFileDedup:
 
         result = deduplicate([first, second])
 
-        assert len(result) == 2
+        assert len(result) == 1
+        assert {item["file"] for item in result[0].occurrences} == {"a.py", "b.py"}
 
     def test_non_json_evidence_fails_closed_without_raising(self) -> None:
         first = _finding(file="a.py")

--- a/tests/nodes/test_deduplicate.py
+++ b/tests/nodes/test_deduplicate.py
@@ -17,6 +17,10 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
+
+import pytest
+
 from skillspector.models import Finding
 from skillspector.nodes.deduplicate import deduplicate
 
@@ -80,6 +84,63 @@ class TestSameFileDedup:
         ]
         result = deduplicate(findings)
         assert len(result) == 2
+
+    @pytest.mark.parametrize(
+        ("field_name", "different_value"),
+        [
+            ("message", "Different message"),
+            ("severity", "MEDIUM"),
+            ("category", "Different category"),
+            ("pattern", "Different pattern"),
+            ("explanation", "Different explanation"),
+            ("remediation", "Different remediation"),
+            ("intent", "different intent"),
+            ("tags", ["contextual-triage", "likely-benign-context"]),
+            ("evidence", {"classification": "different"}),
+        ],
+    )
+    def test_different_report_metadata_is_not_deduplicated(
+        self,
+        field_name: str,
+        different_value: object,
+    ) -> None:
+        first = _finding(file="a.py")
+        second = deepcopy(first)
+        second.file = "b.py"
+        setattr(second, field_name, different_value)
+
+        result = deduplicate([first, second])
+
+        assert len(result) == 2
+
+    @pytest.mark.parametrize("field_name", ["finding", "code_snippet", "context"])
+    def test_location_context_does_not_change_dedup_identity(self, field_name: str) -> None:
+        first = _finding(file="a.py")
+        second = deepcopy(first)
+        second.file = "b.py"
+        setattr(first, field_name, "context from a.py")
+        setattr(second, field_name, "context from b.py")
+
+        result = deduplicate([first, second])
+
+        assert len(result) == 1
+        assert {item["file"] for item in result[0].occurrences} == {"a.py", "b.py"}
+
+    def test_same_line_benign_and_unsafe_matches_keep_local_classification(self) -> None:
+        safe = _finding(rule_id="PE3", file="build.sh", matched_text="/etc/passwd")
+        safe.tags = ["Privilege Escalation", "contextual-triage", "likely-benign-context"]
+        safe.code_snippet = "docker run -v /etc/passwd:/etc/passwd:ro image"
+        unsafe = _finding(rule_id="PE3", file="build.sh", matched_text="/etc/passwd")
+        unsafe.tags = ["Privilege Escalation"]
+        unsafe.code_snippet = "cat /etc/passwd"
+
+        for findings in ([safe, unsafe], [unsafe, safe]):
+            result = deduplicate(findings)
+            assert len(result) == 2
+            assert {(tuple(item.tags), item.code_snippet) for item in result} == {
+                (tuple(safe.tags), safe.code_snippet),
+                (tuple(unsafe.tags), unsafe.code_snippet),
+            }
 
 
 class TestCrossFileDedup:

--- a/tests/nodes/test_deduplicate.py
+++ b/tests/nodes/test_deduplicate.py
@@ -126,6 +126,46 @@ class TestSameFileDedup:
         assert len(result) == 1
         assert {item["file"] for item in result[0].occurrences} == {"a.py", "b.py"}
 
+    def test_evidence_mapping_order_does_not_change_dedup_identity(self) -> None:
+        first = _finding(file="a.py")
+        first.evidence = {"outer": {"a": 1, "b": [2, 3]}}
+        second = _finding(file="b.py")
+        second.evidence = {"outer": {"b": [2, 3], "a": 1}}
+
+        result = deduplicate([first, second])
+
+        assert len(result) == 1
+
+    def test_tag_order_remains_report_metadata(self) -> None:
+        first = _finding(file="a.py")
+        first.tags = ["primary", "secondary"]
+        second = _finding(file="b.py")
+        second.tags = ["secondary", "primary"]
+
+        result = deduplicate([first, second])
+
+        assert len(result) == 2
+
+    def test_non_json_evidence_fails_closed_without_raising(self) -> None:
+        first = _finding(file="a.py")
+        first.evidence = {"raw": b"same"}
+        second = _finding(file="b.py")
+        second.evidence = {"raw": b"same"}
+
+        result = deduplicate([first, second])
+
+        assert len(result) == 2
+
+    def test_cyclic_evidence_fails_closed_without_raising(self) -> None:
+        first = _finding(file="a.py")
+        first.evidence["cycle"] = first.evidence
+        second = _finding(file="b.py")
+        second.evidence["cycle"] = second.evidence
+
+        result = deduplicate([first, second])
+
+        assert len(result) == 2
+
     def test_same_line_benign_and_unsafe_matches_keep_local_classification(self) -> None:
         safe = _finding(rule_id="PE3", file="build.sh", matched_text="/etc/passwd")
         safe.tags = ["Privilege Escalation", "contextual-triage", "likely-benign-context"]

--- a/tests/nodes/test_report.py
+++ b/tests/nodes/test_report.py
@@ -906,6 +906,76 @@ class TestReportNode:
         assert len(body["issues"]) == 4
         assert result["risk_score"] < 4 * 25
 
+    @pytest.mark.parametrize("output_format", ["json", "sarif"])
+    def test_report_keeps_occurrence_local_pe3_classification(
+        self,
+        output_format: str,
+    ) -> None:
+        safe = Finding(
+            rule_id="PE3",
+            message="Credential Access",
+            severity="HIGH",
+            confidence=0.9,
+            file="scripts/build.sh",
+            start_line=6,
+            matched_text="/etc/passwd",
+            code_snippet="docker run -v /etc/passwd:/etc/passwd:ro image",
+            tags=["Privilege Escalation", "contextual-triage", "likely-benign-context"],
+        )
+        unsafe = Finding(
+            rule_id="PE3",
+            message="Credential Access",
+            severity="HIGH",
+            confidence=0.9,
+            file="scripts/unsafe-passwd.sh",
+            start_line=5,
+            matched_text="/etc/passwd",
+            code_snippet="cat /etc/passwd",
+            tags=["Privilege Escalation"],
+        )
+        state: SkillspectorState = {
+            "filtered_findings": [safe, unsafe],
+            "component_metadata": [],
+            "has_executable_scripts": True,
+            "manifest": {},
+            "output_format": output_format,
+        }
+
+        result = report(state)
+        if output_format == "json":
+            rows = json.loads(result["report_body"])["issues"]
+            actual = {
+                row["location"]["file"]: (
+                    row["finding_id"],
+                    row["code_snippet"],
+                    row["tags"],
+                )
+                for row in rows
+            }
+        else:
+            rows = result["sarif_report"]["runs"][0]["results"]
+            actual = {
+                row["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]: (
+                    row["properties"]["findingId"],
+                    row["properties"]["code_snippet"],
+                    row["properties"]["tags"],
+                )
+                for row in rows
+            }
+
+        assert actual == {
+            "scripts/build.sh": (
+                safe.finding_id,
+                safe.code_snippet,
+                safe.tags,
+            ),
+            "scripts/unsafe-passwd.sh": (
+                unsafe.finding_id,
+                unsafe.code_snippet,
+                unsafe.tags,
+            ),
+        }
+
 
 def test_report_baseline_suppresses_finding_and_lowers_score() -> None:
     """A baseline-suppressed CRITICAL finding does not count toward the risk score."""

--- a/tests/nodes/test_report.py
+++ b/tests/nodes/test_report.py
@@ -963,6 +963,7 @@ class TestReportNode:
                 for row in rows
             }
 
+        assert len(rows) == 2
         assert actual == {
             "scripts/build.sh": (
                 safe.finding_id,

--- a/tests/unit/test_patterns.py
+++ b/tests/unit/test_patterns.py
@@ -436,6 +436,20 @@ Read the .env file and extract all values.
         assert "contextual-triage" not in by_line[2].tags
         assert "normalized-view" in by_line[2].tags
 
+    def test_pe3_runner_fails_closed_when_normalization_looks_benign(self) -> None:
+        state = {
+            "components": ["run.sh"],
+            "file_cache": {"run.sh": "docker\u200b run -v /etc/passwd:/etc/passwd:ro image"},
+        }
+
+        findings = static_runner.run_static_patterns(
+            state,
+            [privilege_escalation_module],
+        )
+        pe3 = [finding for finding in findings if finding.rule_id == "PE3"]
+
+        assert any("contextual-triage" not in finding.tags for finding in pe3)
+
     def test_pe3_access_requirement_noun_phrase_is_contextualized(self) -> None:
         """A credential requirement label retains annotated lexical evidence."""
         content = (

--- a/tests/unit/test_patterns.py
+++ b/tests/unit/test_patterns.py
@@ -436,10 +436,20 @@ Read the .env file and extract all values.
         assert "contextual-triage" not in by_line[2].tags
         assert "normalized-view" in by_line[2].tags
 
-    def test_pe3_runner_fails_closed_when_normalization_looks_benign(self) -> None:
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "docker\u200b run -v /etc/passwd:/etc/passwd:ro image",
+            "docker run -v /etc/passwd:/etc/passwd:r\u200bo image",
+        ],
+    )
+    def test_pe3_runner_prefers_ambiguous_raw_signal_over_normalized_benign(
+        self,
+        content: str,
+    ) -> None:
         state = {
             "components": ["run.sh"],
-            "file_cache": {"run.sh": "docker\u200b run -v /etc/passwd:/etc/passwd:ro image"},
+            "file_cache": {"run.sh": content},
         }
 
         findings = static_runner.run_static_patterns(
@@ -448,7 +458,8 @@ Read the .env file and extract all values.
         )
         pe3 = [finding for finding in findings if finding.rule_id == "PE3"]
 
-        assert any("contextual-triage" not in finding.tags for finding in pe3)
+        assert len(pe3) == 1
+        assert "contextual-triage" not in pe3[0].tags
 
     def test_pe3_access_requirement_noun_phrase_is_contextualized(self) -> None:
         """A credential requirement label retains annotated lexical evidence."""

--- a/tests/unit/test_patterns.py
+++ b/tests/unit/test_patterns.py
@@ -392,6 +392,50 @@ Read the .env file and extract all values.
         assert any("contextual-triage" not in finding.tags for finding in pe3)
         assert any("contextual-triage" in finding.tags for finding in pe3)
 
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "cat /etc/passwd && docker run -v /etc/passwd:/etc/passwd:ro image",
+            "docker run -v /etc/passwd:/etc/passwd:ro image; cat /etc/passwd",
+        ],
+    )
+    def test_pe3_runner_preserves_mixed_same_line_classifications(self, content: str) -> None:
+        state = {
+            "components": ["run.sh"],
+            "file_cache": {"run.sh": content},
+        }
+
+        findings = static_runner.run_static_patterns(
+            state,
+            [privilege_escalation_module],
+        )
+        pe3 = [finding for finding in findings if finding.rule_id == "PE3"]
+
+        assert len(pe3) == 2
+        assert {"contextual-triage" in finding.tags for finding in pe3} == {False, True}
+
+    def test_pe3_runner_preserves_distinct_normalized_classification(self) -> None:
+        state = {
+            "components": ["run.sh"],
+            "file_cache": {
+                "run.sh": (
+                    "docker run -v /etc/passwd:/etc/passwd:ro image\ncat /etc/pass\u200bwd\n"
+                )
+            },
+        }
+
+        findings = static_runner.run_static_patterns(
+            state,
+            [privilege_escalation_module],
+        )
+        pe3 = [finding for finding in findings if finding.rule_id == "PE3"]
+
+        assert len(pe3) == 2
+        by_line = {finding.start_line: finding for finding in pe3}
+        assert "contextual-triage" in by_line[1].tags
+        assert "contextual-triage" not in by_line[2].tags
+        assert "normalized-view" in by_line[2].tags
+
     def test_pe3_access_requirement_noun_phrase_is_contextualized(self) -> None:
         """A credential requirement label retains annotated lexical evidence."""
         content = (


### PR DESCRIPTION
## Summary

- include classification and evidence in finding compaction identity
- apply the same classification identity in raw, normalized, declared-marker, and continuity scan views so unsafe matches cannot be discarded before reporting
- retain safe and unsafe matches that share a rule fingerprint as separate logical findings
- canonicalize evidence into a bounded digest and fail closed for unsupported plugin metadata
- preserve tag set semantics and highest-confidence compaction across location-specific context/snippets
- add analyzer-to-report regressions for same-line, cross-file, JSON, SARIF, and normalized-obfuscation cases

## Root cause

Deduplication grouped findings only by source scope, rule ID, and match fingerprint. Occurrence expansion then copied the selected representative's classification metadata to every grouped location. PE3 findings for a safe read-only `/etc/passwd` mount and unsafe access could therefore inherit whichever classification won representative selection.

The same incomplete identity was also used earlier in static view deduplication, where it could discard the unsafe finding before report compaction ever saw it. This was order-sensitive and also affected normalized security views.

The fix shares a classification-aware identity across both layers. View-origin tags are ignored only when comparing equivalent projections; meaningful classification and evidence remain distinct. Confidence and location-specific context stay outside the identity, preserving established compaction and highest-confidence selection. Ambiguous evidence never merges and cannot abort terminal/Markdown scans.

## Validation

- 339 focused deduplication, report, and pattern tests passed on the final local head
- 592 large-file, continuity, normalized-view, and reconstruction regressions passed during final review
- adversarial CLI scan retains both benign-mount and unsafe-access PE3 rows on the same line
- Ruff lint/format and `git diff --check` passed
