### PR TITLE
fix(providers): honor model registry overrides for CLI providers

### DIFF
--- a/src/skillspector/providers/_agent_cli_base.py
+++ b/src/skillspector/providers/_agent_cli_base.py
@@ -39,7 +39,7 @@ class AgentCLIProviderBase:
     #: ``_provider.DEFAULT_MODEL`` lookup has an attribute; never pins a version.
     DEFAULT_MODEL: str = ""
     #: Optional path to a bundled ``model_registry.yaml`` for token budgets. CLI
-    #: providers leave this empty and fall back to package-wide default budgets.
+    #: providers leave this empty, but users can supply a global registry override.
     REGISTRY_PATH: str = ""
 
     # -- Credentials ---------------------------------------------------------
@@ -81,13 +81,9 @@ class AgentCLIProviderBase:
     # -- Metadata ------------------------------------------------------------
 
     def get_context_length(self, model: str) -> int | None:
-        if not self.REGISTRY_PATH:
-            return None  # no registry -> caller uses the package-wide default budget
         return registry.lookup_context_length(self.REGISTRY_PATH, model)
 
     def get_max_output_tokens(self, model: str) -> int | None:
-        if not self.REGISTRY_PATH:
-            return None
         return registry.lookup_max_output_tokens(self.REGISTRY_PATH, model)
 
     def resolve_model(self, slot: str = "default") -> str:

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -23,6 +23,7 @@ NVIDIA catalog API) is covered by the layered tests in
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 import pytest
 from langchain_anthropic import ChatAnthropic
@@ -828,6 +829,62 @@ class TestAntigravityCLIProvider:
         available, reason = AntigravityCLIProvider().is_available()
         assert available is False
         assert reason
+
+
+class TestAgentCLIProviderMetadata:
+    """Shared model-registry behavior for supported agent CLI providers."""
+
+    @pytest.mark.parametrize(
+        "provider_type",
+        [ClaudeCLIProvider, CodexCLIProvider, GeminiCLIProvider],
+    )
+    def test_honors_model_registry_override(
+        self,
+        provider_type: type[ClaudeCLIProvider | CodexCLIProvider | GeminiCLIProvider],
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        registry_path = tmp_path / "model_registry.yaml"
+        registry_path.write_text(
+            "models:\n  test-model:\n    context_length: 200000\n    max_output_tokens: 32000\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("SKILLSPECTOR_MODEL_REGISTRY", str(registry_path))
+
+        provider = provider_type()
+        assert provider.get_context_length("test-model") == 200_000
+        assert provider.get_max_output_tokens("test-model") == 32_000
+
+    @pytest.mark.parametrize("registry_value", [None, "   "])
+    def test_returns_none_without_registry(
+        self,
+        registry_value: str | None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        if registry_value is None:
+            monkeypatch.delenv("SKILLSPECTOR_MODEL_REGISTRY", raising=False)
+        else:
+            monkeypatch.setenv("SKILLSPECTOR_MODEL_REGISTRY", registry_value)
+
+        provider = ClaudeCLIProvider()
+        assert provider.get_context_length("test-model") is None
+        assert provider.get_max_output_tokens("test-model") is None
+
+    def test_unknown_model_returns_none(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        registry_path = tmp_path / "model_registry.yaml"
+        registry_path.write_text(
+            "models:\n  known-model:\n    context_length: 200000\n    max_output_tokens: 32000\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("SKILLSPECTOR_MODEL_REGISTRY", str(registry_path))
+
+        provider = ClaudeCLIProvider()
+        assert provider.get_context_length("unknown-model") is None
+        assert provider.get_max_output_tokens("unknown-model") is None
 
 
 class TestClaudeCLIProvider:


### PR DESCRIPTION
## Summary

- Let CLI providers use `SKILLSPECTOR_MODEL_REGISTRY` even though they have no bundled registry.
- Keep the `None` fallback for missing models or unset/blank overrides, and warn rather than crash on malformed registry entries or invalid/non-positive budgets.
- Cover Claude, Codex, and Gemini, including preserving a valid budget when the other field is invalid.

Closes #459.

## Testing

On Linux / Python 3.12 with `uv sync --all-extras --locked`:

- `uv run --locked pytest -q tests/unit/test_providers.py tests/unit/test_model_info.py`
- `uv run --locked make test-ci`
- `uv run --locked make lint`
- `uv run --locked make format-check`
- `uv run --locked python -m build`
- `uv run --locked twine check dist/*`
- CLI startup with a scalar model entry for each of the three providers, with strict model validation disabled. No model calls were made.

The new malformed-registry regressions were run before and after the fix. Optional live-provider tests and Docker smoke were not run locally; hosted CI is reported separately.
