### PR TITLE
fix(analyzer): project manifest version for RP3

### DIFF
--- a/src/skillspector/nodes/build_context.py
+++ b/src/skillspector/nodes/build_context.py
@@ -1455,6 +1455,9 @@ def _project_manifest(
             raise _ManifestSchemaError(type(description).__name__)
         _consume(description)
         manifest["description"] = description
+    version = data.get("version")
+    if version is not None:
+        manifest["version"] = _scalar_text(version)
 
     manifest["triggers"] = _string_list(data.get("triggers", []))
     manifest["permissions"] = _string_list(data.get("permissions", []))
@@ -1515,8 +1518,9 @@ def _parse_manifest(
 ) -> dict[str, object]:
     """Parse SKILL.md or skill.md YAML frontmatter into a manifest dict.
 
-    Returns dict with name, description, triggers (list), permissions (list),
-    allowed-tools (list), parameters (list). Returns {} if no file or parse fails.
+    Returns dict with name, description, version, triggers (list), permissions
+    (list), allowed-tools (list), parameters (list). Returns {} if no file or
+    parse fails.
     Parsing is restricted to a bounded byte prefix, including for direct helper
     callers that do not provide the bundle's already-bounded raw cache.
     """

--- a/tests/test_mcp_rug_pull.py
+++ b/tests/test_mcp_rug_pull.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from skillspector.nodes.analyzers.mcp_rug_pull import node
+from skillspector.nodes.build_context import build_context
 from skillspector.state import SkillspectorState
 
 
@@ -133,6 +134,20 @@ def test_rp3_version_wildcard():
     )
     rp3 = [f for f in result["findings"] if f.rule_id == "RP3"]
     assert len(rp3) >= 1
+
+
+def test_rp3_version_wildcard_from_skill_frontmatter(tmp_path):
+    """RP3 receives the version projected from real skill frontmatter."""
+    (tmp_path / "SKILL.md").write_text(
+        '---\nname: test-skill\ndescription: For tests\nversion: "*"\n---\n',
+        encoding="utf-8",
+    )
+
+    result = node(build_context({"skill_path": str(tmp_path)}))
+
+    rp3 = [finding for finding in result["findings"] if finding.rule_id == "RP3"]
+    assert len(rp3) == 1
+    assert rp3[0].matched_text == "*"
 
 
 def test_rp3_version_ok_no_finding():


### PR DESCRIPTION
## Summary

- project the `version` field from `SKILL.md` frontmatter into the bounded manifest
- add a regression test that exercises real frontmatter through `build_context` before running the RP3 analyzer
- update the manifest parser docstring to include the projected field

Before this change, RP3 ran successfully but could not observe `version`, so values such as `"*"` produced no finding.

Fixes #472.

## Testing

- `PATH="$PWD/.venv/bin:$PATH" make test-unit` (`3979 passed, 14 skipped, 38 deselected, 4 xfailed`)
- `PATH="$PWD/.venv/bin:$PATH" make lint format-check`
- manual no-LLM CLI repro: `version: "*"` now emits `RP3`