### PR TITLE
fix(input): expand 8.3 short DOS names before the opened-handle check

### DIFF
--- a/src/skillspector/input_handler.py
+++ b/src/skillspector/input_handler.py
@@ -443,6 +443,41 @@ def _windows_last_error() -> OSError:
     return cast(OSError, ctypes.WinError(ctypes.get_last_error()))  # type: ignore[attr-defined]
 
 
+def _windows_long_path_name(path: str) -> str:
+    """Expand any 8.3 short components of a Windows path to their long form.
+
+    ``GetFinalPathNameByHandleW`` always answers with long components, while the
+    requested path may carry short ones: Windows keeps an 8.3 alias for a
+    directory whose name holds a space, so a profile directory such as
+    ``C:\\Users\\Hoang Pham`` reaches the scanner as ``C:\\Users\\HOANGP~1`` by way
+    of ``%TEMP%``. Comparing the two spellings without expanding them first
+    rejects every file below such a path.
+
+    The short name is an alias the filesystem keeps for one directory entry, so
+    expanding it names that same entry and does not resolve symlinks or
+    junctions; the reparse-point checks around the caller keep their meaning. A
+    path that no longer resolves comes back unchanged, which leaves that caller
+    fail-closed.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+    get_long_path_name = kernel32.GetLongPathNameW
+    get_long_path_name.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.DWORD]
+    get_long_path_name.restype = wintypes.DWORD
+
+    buffer_size = 260
+    while True:
+        buffer = ctypes.create_unicode_buffer(buffer_size)
+        result = cast(int, get_long_path_name(path, buffer, buffer_size))
+        if result == 0:
+            return path
+        if result < buffer_size:
+            return buffer.value
+        buffer_size = result + 1
+
+
 def _windows_normalized_path(path: str) -> str:
     """Normalize a Windows DOS path for an exact opened-handle comparison."""
     long_path_prefix = "\\\\?\\"
@@ -451,7 +486,8 @@ def _windows_normalized_path(path: str) -> str:
         path = "\\\\" + path[len(long_unc_prefix) :]
     elif path.startswith(long_path_prefix):
         path = path[len(long_path_prefix) :]
-    return os.path.normcase(os.path.normpath(os.path.abspath(path)))
+    absolute = os.path.normpath(os.path.abspath(path))
+    return os.path.normcase(_windows_long_path_name(absolute))
 
 
 def _close_fd_safely(fd: int) -> None:

--- a/tests/unit/test_input_handler.py
+++ b/tests/unit/test_input_handler.py
@@ -40,8 +40,13 @@ def _mock_windows_secure_open(
     handle: int = 1,
     attributes: int = 0,
     final_path: str | None = None,
+    long_names: dict[str, str] | None = None,
 ) -> None:
-    """Install a handle-level Windows open simulation on any platform."""
+    """Install a handle-level Windows open simulation on any platform.
+
+    ``long_names`` stands in for ``GetLongPathNameW``: it maps a path spelled
+    with an 8.3 short component to the long spelling the filesystem aliases.
+    """
 
     def get_file_information(_handle: int, information: object) -> bool:
         information._obj.dwFileAttributes = attributes  # type: ignore[attr-defined]
@@ -52,10 +57,16 @@ def _mock_windows_secure_open(
         buffer.value = opened_path  # type: ignore[attr-defined]
         return len(opened_path)
 
+    def get_long_path_name(path: str, buffer: object, _size: int) -> int:
+        expanded = (long_names or {}).get(path, path)
+        buffer.value = expanded  # type: ignore[attr-defined]
+        return len(expanded)
+
     kernel32 = SimpleNamespace(
         CreateFileW=lambda *_args: handle,
         GetFileInformationByHandle=get_file_information,
         GetFinalPathNameByHandleW=get_final_path,
+        GetLongPathNameW=get_long_path_name,
         CloseHandle=lambda _handle: True,
     )
     msvcrt = SimpleNamespace(open_osfhandle=lambda _handle, _flags: os.open(source, os.O_RDONLY))
@@ -305,6 +316,37 @@ def test_windows_no_follow_open_rejects_reparse_point(
 
     with pytest.raises(ValueError, match="Could not safely open"):
         _open_regular_file_from_windows_handle(source)
+
+
+def test_windows_no_follow_open_accepts_a_short_dos_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A path spelled with an 8.3 short component opens the entry it aliases."""
+    source = tmp_path / "SKILL.md"
+    source.write_text("# Skill", encoding="utf-8")
+    short = tmp_path / "SHORTN~1.MD"
+    _mock_windows_secure_open(
+        monkeypatch,
+        source,
+        final_path=str(source),
+        long_names={str(short): str(source)},
+    )
+
+    with _open_regular_file_from_windows_handle(short) as opened:
+        assert opened.read() == b"# Skill"
+
+
+def test_windows_no_follow_open_rejects_an_unresolvable_short_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A short name that no longer expands leaves the comparison fail-closed."""
+    source = tmp_path / "SKILL.md"
+    source.write_text("# Skill", encoding="utf-8")
+    short = tmp_path / "SHORTN~1.MD"
+    _mock_windows_secure_open(monkeypatch, source, final_path=str(source))
+
+    with pytest.raises(ValueError, match="Could not safely open"):
+        _open_regular_file_from_windows_handle(short)
 
 
 def test_windows_no_follow_open_rejects_canonical_path_mismatch(


### PR DESCRIPTION
Fixes #481.

## Problem

On Windows, every file in a scan is rejected when the scanned path is spelled with an 8.3 short
component, so `execution_successful` is `false`, the ledger fills with `missing_file_cache`, and the
risk score means nothing regardless of what the skill contains.

`_open_regular_file_from_windows_handle` guards against a reparse-point swap by comparing the
canonical path of the handle it opened against the path it was asked to open.
`GetFinalPathNameByHandleW` always answers with long components, while the requested path can carry
short ones, and `_windows_normalized_path` only stripped the `\\?\` prefix and normcased. The two
spellings never matched, so the guard rejected the file it had just safely opened.

This is not an unusual setup. Windows keeps an 8.3 alias for any directory whose name holds a space,
so a profile directory like `C:\Users\Hoang Pham` reaches the scanner as `C:\Users\HOANGP~1` through
`%TEMP%`. Because `skillspector scan <url>` clones into a temp directory, URL scans are broken by
default on any machine with a spaced account name.

## Fix

`_windows_long_path_name` expands short components through `GetLongPathNameW`, and
`_windows_normalized_path` runs the path through it before comparing.

The guard keeps its meaning. An 8.3 name is an alias the filesystem holds for one directory entry,
so expanding it names that same entry; `GetLongPathNameW` does not resolve symlinks or junctions, so
a reparse point that appeared mid-open still shows up as a different final path and is still
rejected. A path that no longer resolves comes back unchanged, which leaves the comparison
fail-closed.

## Tests

Two tests in `tests/unit/test_input_handler.py`, using the existing `_mock_windows_secure_open`
harness so they run on any platform. The mock gains a `GetLongPathNameW` stub driven by a
`long_names` mapping.

- `test_windows_no_follow_open_accepts_a_short_dos_name` — a requested short spelling and a long
  final path open the same entry. Before the fix:

  ```
  _UnsafeFileError: Could not safely open file: ...\test_windows_no_follow_open_ac0\SHORTN~1.MD
  src\skillspector\input_handler.py:414: _UnsafeFileError
  ```

- `test_windows_no_follow_open_rejects_an_unresolvable_short_name` — a short name that does not
  expand is still refused, so the fail-closed half is pinned rather than assumed.

## How I tested

Windows 11, Python 3.12.10, 8.3 name creation enabled on the volume. Built a two-file skill under
`C:\Users\swsz9\claudeworkspace\Skill Space Test`, whose short name is `SKILLS~3`, and scanned both
spellings with `--no-llm --format json`:

| scan target | `execution_successful` | status | components scanned | ledger exceptions |
| --- | --- | --- | --- | --- |
| `SKILLS~3` before the fix | `false` | `failed` | 0 / 0 | 5 |
| `SKILLS~3` after the fix | `true` | `complete` | 2 / 2 | 0 |
| `Skill Space Test` (control) | `true` | `complete` | 2 / 2 | 0 |

The first ledger exception in the failing run is the one from the report:

```json
{"outcome": "failed", "phase": "static", "reason_code": "missing_file_cache",
 "message": "Applicable analyzer could not obtain file content.", "path": "SKILL.md",
 "fatal": true, "analyzers": ["static_yara"]}
```

`ruff check src/ tests/` and `ruff format --check src/ tests/` are clean.

`pytest -m "not integration and not provider" tests/` adds no failures: 23 failed / 3943 passed
before, 23 failed / 3945 passed after, the two extra passes being the tests above.

That suite is not green on Windows to begin with, and none of the 23 involve this code path:
12 in `tests/nodes/test_build_context.py` (symlink fixtures, which need elevation or developer mode
on Windows), 5 in `test_create_github_release.py`, 4 in `test_compare_scan_accuracy.py`, 1 in
`test_static_yara.py`, and `test_input_handler.py::test_resolve_file_open_failure_does_not_create_temp_dir`.
I ran `tests/nodes/test_build_context.py` on its own with and without this change to be sure: 12
failed either way. Happy to file those separately if they are not already known.
