### PR TITLE
fix(scripts): resolve editable file:// URLs with url2pathname

### DIFF
--- a/scripts/compare_scan_accuracy.py
+++ b/scripts/compare_scan_accuracy.py
@@ -61,6 +61,7 @@ import os
 import platform
 import sys
 import urllib.parse
+import urllib.request
 from pathlib import Path
 
 MAX_DEPENDENCY_FILES = 200_000
@@ -178,7 +179,9 @@ for distribution in importlib.metadata.distributions():
             parsed = urllib.parse.urlsplit(raw_url)
             if parsed.scheme != "file" or parsed.netloc not in {"", "localhost"}:
                 raise RuntimeError(f"editable dependency is not a local file target: {normalized_name}")
-            editable_root = Path(urllib.parse.unquote(parsed.path)).resolve(strict=True)
+            # url2pathname, not unquote: a Windows file URL's path is "/C:/..."
+            # and Path() would read the leading slash as a root, producing "C:\C:\...".
+            editable_root = Path(urllib.request.url2pathname(parsed.path)).resolve(strict=True)
             if not editable_root.is_dir():
                 raise RuntimeError(f"editable dependency target is not a directory: {normalized_name}")
             for editable_path in sorted(editable_root.rglob("*")):


### PR DESCRIPTION
Fixes #485.

## Problem

In `_RUNTIME_IDENTITY_PROBE`, an editable dependency's `direct_url.json` `file://` URL is converted to a local path with `Path(urllib.parse.unquote(parsed.path))`.

A Windows file URL is `file:///C:/Users/.../pkg`, so `urlsplit(...).path` is `/C:/Users/.../pkg`. `Path()` reads that leading slash as a root, so the result is `C:\C:\Users\...\pkg` and `resolve(strict=True)` raises:

```
OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect:
'C:\C:\Users\...\editable-dependency'
```

On POSIX both forms give the same string, so CI never sees it.

## Change

One line, plus the import:

```diff
-editable_root = Path(urllib.parse.unquote(parsed.path)).resolve(strict=True)
+editable_root = Path(urllib.request.url2pathname(parsed.path)).resolve(strict=True)
```

`urllib.request.url2pathname` is the stdlib conversion for URL path to local path. It strips the leading slash before a drive letter on Windows and is a no-op relative to the previous behavior on POSIX, where there is no drive letter to double. It also still percent-decodes, so no separate `unquote` is needed.

## Verification

`tests/unit/test_compare_scan_accuracy.py::test_runtime_probe_hashes_installed_and_editable_dependency_bytes` already covers this path — it just never runs on a Windows host in CI. No test changes in this PR.

On Windows 11 (native, not WSL) / Python 3.13.14 / uv 0.12.8, from this branch:

- without the change: `1 failed` with the `WinError 123` above
- with the change: `1 passed`
- `ruff check scripts/compare_scan_accuracy.py` — clean
- `ruff format --check scripts/compare_scan_accuracy.py` — already formatted

I did not add a regression test: on Linux `url2pathname("/C:/x")` and `unquote("/C:/x")` return the same string, so no cross-platform test can distinguish the two implementations. The existing test is the real guard, and it only bites on a Windows runner.

## Notes

Found while getting the suite green on a native Windows host. This is the only product-code bug among the failures there — the other 22 were POSIX assumptions in the tests themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)