### PR TITLE
fix(scripts): convert editable file URLs portably

### DIFF
--- a/scripts/compare_scan_accuracy.py
+++ b/scripts/compare_scan_accuracy.py
@@ -61,6 +61,7 @@ import os
 import platform
 import sys
 import urllib.parse
+import urllib.request
 from pathlib import Path
 
 MAX_DEPENDENCY_FILES = 200_000
@@ -178,7 +179,9 @@ for distribution in importlib.metadata.distributions():
             parsed = urllib.parse.urlsplit(raw_url)
             if parsed.scheme != "file" or parsed.netloc not in {"", "localhost"}:
                 raise RuntimeError(f"editable dependency is not a local file target: {normalized_name}")
-            editable_root = Path(urllib.parse.unquote(parsed.path)).resolve(strict=True)
+            # url2pathname, not unquote: a Windows file URL's path is "/C:/..."
+            # and Path() would read the leading slash as a root, producing "C:\C:\...".
+            editable_root = Path(urllib.request.url2pathname(parsed.path)).resolve(strict=True)
             if not editable_root.is_dir():
                 raise RuntimeError(f"editable dependency target is not a directory: {normalized_name}")
             for editable_path in sorted(editable_root.rglob("*")):

--- a/scripts/compare_scan_accuracy.py
+++ b/scripts/compare_scan_accuracy.py
@@ -179,9 +179,11 @@ for distribution in importlib.metadata.distributions():
             parsed = urllib.parse.urlsplit(raw_url)
             if parsed.scheme != "file" or parsed.netloc not in {"", "localhost"}:
                 raise RuntimeError(f"editable dependency is not a local file target: {normalized_name}")
-            # url2pathname, not unquote: a Windows file URL's path is "/C:/..."
-            # and Path() would read the leading slash as a root, producing "C:\C:\...".
-            editable_root = Path(urllib.request.url2pathname(parsed.path)).resolve(strict=True)
+            # Preserve the scheme-less URL rather than passing only parsed.path:
+            # url2pathname needs the empty-authority delimiter for paths beginning
+            # with "//", while still removing a Windows drive path's leading slash.
+            schemeless_url = parsed._replace(scheme="", query="", fragment="").geturl()
+            editable_root = Path(urllib.request.url2pathname(schemeless_url)).resolve(strict=True)
             if not editable_root.is_dir():
                 raise RuntimeError(f"editable dependency target is not a directory: {normalized_name}")
             for editable_path in sorted(editable_root.rglob("*")):

--- a/scripts/compare_scan_accuracy.py
+++ b/scripts/compare_scan_accuracy.py
@@ -179,11 +179,13 @@ for distribution in importlib.metadata.distributions():
             parsed = urllib.parse.urlsplit(raw_url)
             if parsed.scheme != "file" or parsed.netloc not in {"", "localhost"}:
                 raise RuntimeError(f"editable dependency is not a local file target: {normalized_name}")
-            # Preserve the scheme-less URL rather than passing only parsed.path:
             # url2pathname needs the empty-authority delimiter for paths beginning
-            # with "//", while still removing a Windows drive path's leading slash.
-            schemeless_url = parsed._replace(scheme="", query="", fragment="").geturl()
-            editable_root = Path(urllib.request.url2pathname(schemeless_url)).resolve(strict=True)
+            # with "//". Build it explicitly because urlunsplit() normalizes this
+            # form differently across Python patch releases.
+            converter_input = parsed.path
+            if not parsed.netloc and converter_input.startswith("//"):
+                converter_input = f"//{converter_input}"
+            editable_root = Path(urllib.request.url2pathname(converter_input)).resolve(strict=True)
             if not editable_root.is_dir():
                 raise RuntimeError(f"editable dependency target is not a directory: {normalized_name}")
             for editable_path in sorted(editable_root.rglob("*")):

--- a/tests/unit/test_compare_scan_accuracy.py
+++ b/tests/unit/test_compare_scan_accuracy.py
@@ -9,6 +9,7 @@ import json
 import subprocess
 import sys
 import tarfile
+import urllib.request
 from collections.abc import Iterator
 from contextlib import contextmanager, redirect_stdout
 from pathlib import Path
@@ -1114,6 +1115,63 @@ def test_runtime_probe_hashes_installed_and_editable_dependency_bytes(
     editable_file.write_text("VALUE = 'editable-v2'\n", encoding="utf-8")
     editable_changed = probe()
     assert editable_changed["dependencies"] != original["dependencies"]
+
+
+@pytest.mark.parametrize(
+    ("editable_url", "expected_converter_input"),
+    [
+        ("file:///C:/PortableRegressionProbe", "/C:/PortableRegressionProbe"),
+        ("file:////portable-regression-probe", "////portable-regression-probe"),
+    ],
+    ids=["windows_drive", "empty_authority"],
+)
+def test_runtime_probe_preserves_file_url_structure_for_path_conversion(
+    tmp_path: Path,
+    monkeypatch,
+    editable_url: str,
+    expected_converter_input: str,
+) -> None:
+    installed_root = tmp_path / "site-packages"
+    installed_root.mkdir()
+    (installed_root / "dependency.py").write_text("VALUE = 1\n", encoding="utf-8")
+    editable_root = tmp_path / "editable-dependency"
+    editable_root.mkdir()
+    (editable_root / "source.py").write_text("VALUE = 2\n", encoding="utf-8")
+
+    class FakeDistribution:
+        metadata = {"Name": "example-dependency"}
+        version = "1.0"
+        files = ["dependency.py"]
+
+        def read_text(self, name: str) -> str | None:
+            if name == "RECORD":
+                return "dependency.py,,\n"
+            if name == "METADATA":
+                return "Name: example-dependency\nVersion: 1.0\n"
+            if name == "direct_url.json":
+                return json.dumps({"url": editable_url, "dir_info": {"editable": True}})
+            return None
+
+        def locate_file(self, package_path: object) -> Path:
+            return installed_root / str(package_path)
+
+    monkeypatch.setattr(importlib.metadata, "distributions", lambda: [FakeDistribution()])
+    converter_inputs: list[str] = []
+
+    def fake_url2pathname(value: str) -> str:
+        converter_inputs.append(value)
+        return str(editable_root)
+
+    monkeypatch.setattr(urllib.request, "url2pathname", fake_url2pathname)
+    rendered = io.StringIO()
+    with redirect_stdout(rendered):
+        exec(compare_scan_accuracy._RUNTIME_IDENTITY_PROBE, {})
+
+    payload = json.loads(rendered.getvalue())
+    dependency = payload["dependencies"][0]
+    assert converter_inputs == [expected_converter_input]
+    assert dependency["editable"] is True
+    assert dependency["editable_file_count"] == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Convert editable-install file URLs with the standard platform path adapter.
- Preserve the empty-authority delimiter so valid POSIX double-slash paths remain local on Python 3.14 while Windows drive URLs lose their extra leading slash.
- Add portable regression coverage for both URL shapes.

This builds on #486 and preserves the original author attribution while closing the compatibility gap found during validation.

Fixes #485

## Validation

- `make lint`
- `make format-check`
- `ruff check scripts/compare_scan_accuracy.py`
- Targeted path-conversion tests: 3 passed
- Full Python 3.12 suite: 3,980 passed, 14 skipped, 4 xfailed
- Python 3.14 standard-library conversion probe for empty-authority double-slash paths

Submitted by Codex on behalf of Mohit Gupta.
