### PR TITLE
test(build-context): skip symlink cases where the platform refuses symlinks

### DIFF
--- a/tests/nodes/test_build_context.py
+++ b/tests/nodes/test_build_context.py
@@ -1075,7 +1075,10 @@ def test_build_context_rejects_symlink_to_external_file(tmp_path: Path) -> None:
     skill_dir = tmp_path / "skill"
     skill_dir.mkdir()
     (skill_dir / "SKILL.md").write_text("---\nname: s\ndescription: d\n---\n", encoding="utf-8")
-    (skill_dir / "creds.md").symlink_to(secret)
+    try:
+        (skill_dir / "creds.md").symlink_to(secret)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
 
     result = build_context({"skill_path": str(skill_dir)})
 
@@ -1093,7 +1096,10 @@ def test_build_context_rejects_symlinked_directory(tmp_path: Path) -> None:
     skill_dir = tmp_path / "skill"
     skill_dir.mkdir()
     (skill_dir / "SKILL.md").write_text("---\nname: s\ndescription: d\n---\n", encoding="utf-8")
-    (skill_dir / "linked").symlink_to(external, target_is_directory=True)
+    try:
+        (skill_dir / "linked").symlink_to(external, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
 
     result = build_context({"skill_path": str(skill_dir)})
 
@@ -1128,7 +1134,10 @@ def test_build_context_rejects_in_tree_symlink(tmp_path: Path) -> None:
     skill_dir.mkdir()
     (skill_dir / "real.md").write_text("real content", encoding="utf-8")
     (skill_dir / "SKILL.md").write_text("---\nname: s\ndescription: d\n---\n", encoding="utf-8")
-    (skill_dir / "alias.md").symlink_to(skill_dir / "real.md")
+    try:
+        (skill_dir / "alias.md").symlink_to(skill_dir / "real.md")
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
 
     result = build_context({"skill_path": str(skill_dir)})
 
@@ -1146,6 +1155,12 @@ def test_build_context_rejects_file_swapped_to_symlink_before_read(
     secret.write_text("AWS_SECRET=hunter2", encoding="utf-8")
     target = tmp_path / "payload.md"
     target.write_text("safe", encoding="utf-8")
+    probe = tmp_path / "symlink-probe"
+    try:
+        probe.symlink_to(secret)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
+    probe.unlink()
 
     def replace_target(path: Path) -> BinaryIO:
         if path.name == target.name:
@@ -1173,7 +1188,10 @@ def test_build_context_rejects_symlinked_manifest(tmp_path: Path) -> None:
     )
     skill_dir = tmp_path / "skill"
     skill_dir.mkdir()
-    (skill_dir / "SKILL.md").symlink_to(external)
+    try:
+        (skill_dir / "SKILL.md").symlink_to(external)
+    except OSError:
+        pytest.skip("symlinks are unavailable on this platform")
 
     result = build_context({"skill_path": str(skill_dir)})
 


### PR DESCRIPTION
## Problem

Five symlink-rejection cases in `tests/nodes/test_build_context.py` build their fixture with
`Path.symlink_to` and let any `OSError` escape:

```python
(skill_dir / "creds.md").symlink_to(secret)
```

Creating a symlink is a privileged operation on Windows unless Developer Mode is on or the
process holds `SeCreateSymbolicLinkPrivilege`. Where it is refused, the error is raised during
fixture setup, so the case reports as a failure rather than as a case that could not run. The
assertions it exists to make — that a symlinked component never reaches `components`, never
reaches `file_cache`, and never leaks its target's content — are never evaluated, and the
failure looks identical to a real regression in that rejection logic.

This is a gap against a guard the suite already applies everywhere else. Every other module
that builds a symlink fixture wraps the creation call:

```
tests/nodes/test_resolve_input.py:53      pytest.skip("symlinks are not supported on this filesystem")
tests/test_multi_skill.py:309,325,477     pytest.skip("symlinks are not supported on this filesystem")
tests/unit/test_cli.py:132,3514           pytest.skip("symlinks are not supported on this filesystem")
tests/unit/test_input_handler.py:102,122,142,212
                                          pytest.skip("symlinks are not supported on this filesystem")
```

`tests/nodes/test_build_context.py` applies the same guard to its dangling-symlink case
(`test_build_context_excludes_dangling_symlink_from_scan_scope`) and omits it from the other
five.

## Fix

Wrap the five unguarded `symlink_to` calls in the guard this file already uses, with the same
wording as the existing one. `test_build_context_rejects_file_swapped_to_symlink_before_read`
creates its symlink inside a monkeypatched open, where `build_context` catches `OSError` and
records `read_error` instead of the expected `not_regular_file`; that case gets an equivalent
up-front probe so the reason is "cannot run here" rather than a wrong reason code.

The `except OSError` wraps only the `symlink_to` call, so on any platform that can create
symlinks — including `ubuntu-latest`, which is what CI runs — every assertion executes exactly
as before. Nothing is skipped there.

## Reproduction

Windows 11, Python 3.12.10, symlink creation not permitted for the process. Run against
unmodified `main` (`704bc95`):

```
$ python -m pytest -p no:randomly tests/nodes/test_build_context.py \
    -k "rejects_symlink_to_external_file or rejects_symlinked_directory or \
        rejects_in_tree_symlink or rejects_file_swapped_to_symlink_before_read or \
        rejects_symlinked_manifest" -q --no-header

    def symlink_to(self, target, target_is_directory=False):
        if not hasattr(os, "symlink"):
            raise NotImplementedError("os.symlink() not available on this system")
>       os.symlink(target, self, target_is_directory)
E       OSError: [WinError 1314] <localized ERROR_PRIVILEGE_NOT_HELD text>:
        '...\\external_manifest.md' -> '...\\skill\\SKILL.md'

..\Python312\Lib\pathlib.py:1386: OSError
=========================== short test summary info ===========================
FAILED tests/nodes/test_build_context.py::test_build_context_rejects_symlink_to_external_file
FAILED tests/nodes/test_build_context.py::test_build_context_rejects_symlinked_directory
FAILED tests/nodes/test_build_context.py::test_build_context_rejects_in_tree_symlink
FAILED tests/nodes/test_build_context.py::test_build_context_rejects_file_swapped_to_symlink_before_read
FAILED tests/nodes/test_build_context.py::test_build_context_rejects_symlinked_manifest
5 failed, 75 deselected in 22.91s
```

`WinError 1314` is `ERROR_PRIVILEGE_NOT_HELD`; the message text itself is locale-dependent and
absolute paths are elided above.

With this change, same command:

```
sssss                                                                    [100%]
=========================== short test summary info ===========================
SKIPPED [1] tests\nodes\test_build_context.py:1081: symlinks are unavailable on this platform
SKIPPED [1] tests\nodes\test_build_context.py:1102: symlinks are unavailable on this platform
SKIPPED [1] tests\nodes\test_build_context.py:1140: symlinks are unavailable on this platform
SKIPPED [1] tests\nodes\test_build_context.py:1162: symlinks are unavailable on this platform
SKIPPED [1] tests\nodes\test_build_context.py:1194: symlinks are unavailable on this platform
5 skipped, 75 deselected in 3.81s
```

## What must still hold

`tests/nodes/test_build_context.py` as a whole, before and after — the count moves by exactly
these five and nothing else changes state:

| | failed | passed | skipped |
| --- | --- | --- | --- |
| before | 12 | 66 | 2 |
| after | 7 | 66 | 7 |

The seven that remain are unrelated to symlinks and are not touched here.

`ruff check src/ tests/` — `All checks passed!`
`ruff format --check src/ tests/` — `223 files already formatted`
