### PR TITLE
test(build-context): guard the second FIFO case on mkfifo availability

### DIFF
--- a/tests/nodes/test_build_context.py
+++ b/tests/nodes/test_build_context.py
@@ -1054,6 +1054,8 @@ def test_build_context_records_stat_errors_in_the_ledger(
 
 def test_build_context_records_non_regular_entries_in_the_ledger(tmp_path: Path) -> None:
     """A discovered FIFO is retained as failed ledger evidence, never silently skipped."""
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("named pipes are unavailable on this platform")
     fifo = tmp_path / "inspection.pipe"
     os.mkfifo(fifo)
 


### PR DESCRIPTION
## Problem

`tests/nodes/test_build_context.py` has two adjacent cases that build a named pipe to prove the
ledger keeps non-regular entries. One guards the primitive, the other does not:

```python
def test_build_context_records_non_regular_files_in_the_ledger(tmp_path: Path) -> None:
    """Named pipes are inventoried so the cache phase can report their failure."""
    if not hasattr(os, "mkfifo"):
        pytest.skip("named pipes are unavailable on this platform")
    pipe = tmp_path / "events.pipe"
    os.mkfifo(pipe)
```

```python
def test_build_context_records_non_regular_entries_in_the_ledger(tmp_path: Path) -> None:
    """A discovered FIFO is retained as failed ledger evidence, never silently skipped."""
    fifo = tmp_path / "inspection.pipe"
    os.mkfifo(fifo)          # no guard
```

`os.mkfifo` does not exist on Windows, so the second case raises `AttributeError` during setup.
Its assertion — that a discovered FIFO is retained as failed ledger evidence rather than
silently dropped — is never evaluated, and the result is indistinguishable from a real
regression in that ledger behaviour.

## Fix

Apply the guard the sibling case already uses, with the same wording. Two lines; no change on
any platform that has `os.mkfifo`, so CI (`ubuntu-latest`) continues to execute the case
exactly as before.

## Reproduction

Windows 11, Python 3.12.10, against unmodified `main` (`704bc95`). Both cases selected together
so the asymmetry is visible in one run:

```
$ python -m pytest -p no:randomly tests/nodes/test_build_context.py -k "records_non_regular" \
    -q --no-header -rs
sF                                                                       [100%]
================================== FAILURES ===================================
________ test_build_context_records_non_regular_entries_in_the_ledger _________

    def test_build_context_records_non_regular_entries_in_the_ledger(tmp_path: Path) -> None:
        """A discovered FIFO is retained as failed ledger evidence, never silently skipped."""
        fifo = tmp_path / "inspection.pipe"
>       os.mkfifo(fifo)
        ^^^^^^^^^
E       AttributeError: module 'os' has no attribute 'mkfifo'

tests\nodes\test_build_context.py:1058: AttributeError
=========================== short test summary info ===========================
SKIPPED [1] tests\nodes\test_build_context.py:1004: named pipes are unavailable on this platform
1 failed, 1 skipped, 78 deselected in 4.57s
```

With this change, same command:

```
ss                                                                       [100%]
=========================== short test summary info ===========================
SKIPPED [1] tests\nodes\test_build_context.py:1004: named pipes are unavailable on this platform
SKIPPED [1] tests\nodes\test_build_context.py:1058: named pipes are unavailable on this platform
2 skipped, 78 deselected in 3.06s
```

## What must still hold

`tests/nodes/test_build_context.py` as a whole — exactly one case changes state, and the passing
set is untouched:

| | failed | passed | skipped |
| --- | --- | --- | --- |
| before | 12 | 66 | 2 |
| after | 11 | 66 | 3 |

The eleven that remain are unrelated to named pipes and are not touched here.

`ruff check tests/` — `All checks passed!`
`ruff format --check tests/` — `126 files already formatted`

Diff is `1 file changed, 2 insertions(+)`.
