### PR TITLE
test(input): inject secure-open failures on the primitive the platform uses

### DIFF
--- a/tests/nodes/test_build_context.py
+++ b/tests/nodes/test_build_context.py
@@ -987,7 +987,13 @@ def test_build_context_reports_read_error_without_fake_empty_content(
     def deny_open(*args: object, **kwargs: object) -> int:
         raise PermissionError("sensitive operating-system detail")
 
+    # The secure open dispatches on the platform: POSIX goes through os.open,
+    # Windows through the handle-based helper. Deny both so the failure is
+    # injected wherever the test happens to run.
     monkeypatch.setattr("skillspector.input_handler.os.open", deny_open)
+    monkeypatch.setattr(
+        "skillspector.input_handler._open_regular_file_from_windows_handle", deny_open
+    )
     result = build_context({"skill_path": str(tmp_path)})
 
     assert "broken.py" in result["components"]

--- a/tests/unit/test_input_handler.py
+++ b/tests/unit/test_input_handler.py
@@ -28,6 +28,7 @@ import pytest
 from skillspector.input_handler import (
     ALLOWED_GIT_HOSTS,
     InputHandler,
+    _FileOpenError,
     _open_regular_file_from_windows_handle,
     _open_regular_file_no_follow,
 )
@@ -225,8 +226,18 @@ def test_resolve_file_open_failure_does_not_create_temp_dir(tmp_path: Path) -> N
     source = tmp_path / "SKILL.md"
     source.write_text("# Skill", encoding="utf-8")
     handler = InputHandler()
+    denied = OSError("denied")
     try:
-        with patch("skillspector.input_handler.os.open", side_effect=OSError("denied")):
+        # The secure open dispatches on the platform: POSIX goes through os.open,
+        # Windows through the handle-based helper. Deny both so the failure is
+        # injected wherever the test happens to run.
+        with (
+            patch("skillspector.input_handler.os.open", side_effect=denied),
+            patch(
+                "skillspector.input_handler._open_regular_file_from_windows_handle",
+                side_effect=_FileOpenError(source, denied),
+            ),
+        ):
             with pytest.raises(ValueError, match="Could not safely open"):
                 handler.resolve(str(source))
         assert handler.temp_dir_for_cleanup() is None


### PR DESCRIPTION
## Problem

Two cases assert what happens when the secure, no-follow open **fails**. Both inject that
failure by patching `os.open`:

- `tests/unit/test_input_handler.py::test_resolve_file_open_failure_does_not_create_temp_dir`
  — "Failed secure opens leave no handler-owned temporary directory behind."
- `tests/nodes/test_build_context.py::test_build_context_reports_read_error_without_fake_empty_content`
  — "Unreadable files remain inventoried but are absent from the content cache."

```python
with patch("skillspector.input_handler.os.open", side_effect=OSError("denied")):
```

`os.open` is only reached on the POSIX branch:

```python
_HAS_SECURE_DIR_FD = os.open in os.supports_dir_fd and hasattr(os, "O_NOFOLLOW")
...
    if _HAS_SECURE_DIR_FD:
        return _open_regular_file_from_trusted_directory(absolute_path)
    if _IS_WINDOWS:
        return _open_regular_file_from_windows_handle(absolute_path)
```

`os.supports_dir_fd` is empty on Windows, so `_HAS_SECURE_DIR_FD` is `False` and the dispatcher
goes to `_open_regular_file_from_windows_handle`, which opens through `CreateFileW` and never
calls `os.open`. The patch therefore injects nothing: the open succeeds, the file is read, and
the assertions about the failure path never get a failure to observe.

The visible effect is that both cases fail. The substantive effect is that the failed-open
contract — no temporary directory left behind, no fabricated empty content in the cache — has
no coverage at all on the platform that uses the handle-based implementation.

## Fix

Deny both primitives, so the failure reaches the dispatcher whichever branch it takes. The
Windows stub raises `_FileOpenError`, which is exactly what `_open_regular_file_from_windows_handle`
raises when `CreateFileW` returns `INVALID_HANDLE_VALUE`:

```python
if handle == invalid_handle_value:
    error = _windows_last_error()
    if error.errno == ENOENT:
        raise FileNotFoundError(f"File not found: {file_path}") from None
    raise _FileOpenError(file_path, error)
```

On POSIX the added patch targets a helper that branch never calls, so behaviour there is
unchanged and the cases keep exercising the real `os.open` path.

## Reproduction

Windows 11, Python 3.12.10, against unmodified `main` (`704bc95`):

```
$ python -m pytest -p no:randomly \
    "tests/unit/test_input_handler.py::test_resolve_file_open_failure_does_not_create_temp_dir" \
    "tests/nodes/test_build_context.py::test_build_context_reports_read_error_without_fake_empty_content" \
    -q --no-header

        with patch("skillspector.input_handler.os.open", side_effect=OSError("denied")):
>           with pytest.raises(ValueError, match="Could not safely open"):
E           Failed: DID NOT RAISE ValueError
tests\unit\test_input_handler.py:230: Failed

        monkeypatch.setattr("skillspector.input_handler.os.open", deny_open)
        result = build_context({"skill_path": str(tmp_path)})
        assert "broken.py" in result["components"]
>       assert "broken.py" not in result["file_cache"]
E       AssertionError: assert 'broken.py' not in {'broken.py': 'print(1)\r\n'}
tests\nodes\test_build_context.py:994: AssertionError
=========================== short test summary info ===========================
FAILED tests/unit/test_input_handler.py::test_resolve_file_open_failure_does_not_create_temp_dir
FAILED tests/nodes/test_build_context.py::test_build_context_reports_read_error_without_fake_empty_content
2 failed in 5.88s
```

`DID NOT RAISE` and the populated `file_cache` are the same symptom: the open was never denied.

With this change, same command:

```
..                                                                       [100%]
2 passed in 4.88s
```

They pass rather than skip, so the contract is now actually asserted on this platform.

## What must still hold

Both files in full, before and after:

| file | before | after |
| --- | --- | --- |
| `tests/unit/test_input_handler.py` | 1 failed, 22 passed, 6 skipped | 23 passed, 6 skipped |
| `tests/nodes/test_build_context.py` | 12 failed, 66 passed, 2 skipped | 11 failed, 67 passed, 2 skipped |

In both files the change converts exactly one case from failing to passing and moves nothing
else. The eleven remaining `test_build_context.py` failures are unrelated to secure-open
dispatch and are not touched here.

`ruff check src/ tests/` — `All checks passed!`
`ruff format --check src/ tests/` — `223 files already formatted`
