### PR TITLE
test(build-context): write fixture content with the newlines the assertions pin

### DIFF
--- a/tests/nodes/test_build_context.py
+++ b/tests/nodes/test_build_context.py
@@ -55,7 +55,7 @@ _OMS_FIXTURE = Path(__file__).parents[1] / "fixtures" / "oms" / "mcore-split-pr.
 def _write_real_oms_signature(root: Path, relative_path: str = "skill.oms.sig") -> Path:
     target = root / relative_path
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(_OMS_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+    target.write_bytes(_OMS_FIXTURE.read_bytes())
     return target
 
 
@@ -65,11 +65,14 @@ def _make_skill_spec_dir(root: Path, *, skill_md_name: str = "SKILL.md") -> None
         (root / "SKILL.md").write_text(
             "---\nname: test-skill\ndescription: For tests\ntriggers: [a, b]\npermissions: [read]\n---\n\n# Skill\n",
             encoding="utf-8",
+            newline="\n",
         )
     (root / "references").mkdir(exist_ok=True)
-    (root / "references" / "guide.md").write_text("# Reference guide\n", encoding="utf-8")
+    (root / "references" / "guide.md").write_text(
+        "# Reference guide\n", encoding="utf-8", newline="\n"
+    )
     (root / "scripts").mkdir(exist_ok=True)
-    (root / "scripts" / "run.py").write_text("print(1)\n", encoding="utf-8")
+    (root / "scripts" / "run.py").write_text("print(1)\n", encoding="utf-8", newline="\n")
     (root / "assets").mkdir(exist_ok=True)
     (root / "assets" / "icon.png").write_bytes(b"\x89PNG\r\n\x1a\n")
     if skill_md_name == "skill.md":
@@ -329,8 +332,8 @@ def test_file_cache_stops_at_progressing_shared_deadline_with_affected_suffix(
     """A deadline reached between files marks the deterministic unread suffix partial."""
     import skillspector.nodes.build_context as build_context_module
 
-    (tmp_path / "first.txt").write_text("first\n", encoding="utf-8")
-    (tmp_path / "second.txt").write_text("second\n", encoding="utf-8")
+    (tmp_path / "first.txt").write_text("first\n", encoding="utf-8", newline="\n")
+    (tmp_path / "second.txt").write_text("second\n", encoding="utf-8", newline="\n")
     clock_values = iter((0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.6))
     monkeypatch.setattr(build_context_module, "monotonic", lambda: next(clock_values))
 
@@ -963,7 +966,7 @@ def test_build_context_reports_exclusion_boundary_without_descendants(tmp_path: 
 def test_build_context_inventories_hidden_file_for_local_analysis(tmp_path: Path) -> None:
     """Hidden regular files stay local and never enter the LLM-visible cache."""
     (tmp_path / "SKILL.md").write_text("# Skill\n", encoding="utf-8")
-    (tmp_path / ".env").write_text("TOKEN=not-reported\n", encoding="utf-8")
+    (tmp_path / ".env").write_text("TOKEN=not-reported\n", encoding="utf-8", newline="\n")
 
     result = build_context({"skill_path": str(tmp_path)})
     assert ".env" in result["components"]


### PR DESCRIPTION
## Problem

Five cases in `tests/nodes/test_build_context.py` assert cached content exactly, including the
trailing newline:

```python
assert result["file_cache"].get("references/guide.md") == "# Reference guide\n"
assert result["file_cache"].get("scripts/run.py") == "print(1)\n"
assert result["local_file_cache"][".env"] == "TOKEN=not-reported\n"
assert result["raw_file_cache"][".env"] == b"TOKEN=not-reported\n"
```

but the fixtures are written with `Path.write_text` and no `newline` argument:

```python
(root / "references" / "guide.md").write_text("# Reference guide\n", encoding="utf-8")
```

Text mode translates `"\n"` to `os.linesep`, so on Windows the fixture lands on disk as CRLF.
`build_context` reads it back faithfully and returns CRLF, and the case fails against content
the test itself wrote. The `raw_file_cache` assertion above makes the intent explicit — it pins
the bytes — so the fixture, not the product, is what is wrong here.

`_write_real_oms_signature` has the same problem in both directions:

```python
target.write_text(_OMS_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
```

`read_text` applies universal newlines and `write_text` applies the reverse translation, so the
pinned signature is newline-translated twice on the way to the temporary directory. Its case
then compares the cache against `nested.read_text(...)`, which normalises again, and the two
never line up.

## Fix

- `_write_real_oms_signature` copies bytes. That is what a pinned signature fixture needs
  regardless of platform, and it removes both translations.
- The writes whose content is asserted exactly pass `newline="\n"`, so the fixture matches what
  the assertion pins. (`Path.write_text` has accepted `newline` since 3.10; this project
  requires `>=3.12`.)

Writes whose content is not asserted verbatim are left alone, so the diff stays at the defect.
On a platform where `os.linesep` is already `"\n"` nothing changes, so CI behaviour is
identical.

## Reproduction

Windows 11, Python 3.12.10, against unmodified `main` (`704bc95`):

```
$ python -m pytest -p no:randomly tests/nodes/test_build_context.py \
    -k "real_directory_with_skill_md or reads_directory_with_windows_secure_open or \
        stops_at_progressing_shared_deadline or scans_nested_oms_signature or \
        inventories_hidden_file_for_local_analysis" -q --no-header

E       AssertionError: assert '# Reference guide\r\n' == '# Reference guide\n'
E       AssertionError: assert 'print(1)\r\n' == 'print(1)\n'
E       AssertionError: assert {'first.txt': 'first\r\n'} == {'first.txt': 'first\n'}
E       assert '{"mediaType"...d":""}]}}\r\n' == '{"mediaType"...yid":""}]}}\n'
E       AssertionError: assert 'TOKEN=not-reported\r\n' == 'TOKEN=not-reported\n'
```

With this change, same command:

```
.....                                                                    [100%]
5 passed, 75 deselected in 5.09s
```

## What must still hold

`tests/nodes/test_build_context.py` in full — five cases move from failing to passing and
nothing else changes state:

| | failed | passed | skipped |
| --- | --- | --- | --- |
| before | 12 | 66 | 2 |
| after | 7 | 71 | 2 |

The seven that remain are unrelated to newline handling and are not touched here.

`ruff check tests/` — `All checks passed!`
`ruff format --check tests/` — `126 files already formatted`

Diff is `1 file changed, 9 insertions(+), 6 deletions(-)`.
