### PR TITLE
fix(as3): ignore current-skill self references

### DIFF
--- a/src/skillspector/nodes/analyzers/static_patterns_agent_snooping.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_agent_snooping.py
@@ -28,8 +28,10 @@ Framework: OWASP LLMT09 (Misinformation), ASI-SR-003 (Least Knowledge).
 
 from __future__ import annotations
 
+import os
 import re
-import sys
+from collections.abc import Mapping
+from contextvars import ContextVar
 
 from skillspector.logging_config import get_logger
 from skillspector.models import AnalyzerFinding, Location, Severity
@@ -42,6 +44,12 @@ from .pattern_defaults import PatternCategory
 logger = get_logger(__name__)
 
 ANALYZER_ID = "static_patterns_agent_snooping"
+
+_AS3_SKILL_PATH_PATTERN = r"skills?/(?P<skill_name>(?!CURRENT)[A-Z][A-Za-z0-9_-]+)/SKILL\.md"
+_AS3_SKILL_PATH_FULLMATCH = re.compile(_AS3_SKILL_PATH_PATTERN, re.IGNORECASE)
+_CURRENT_SKILL_IDENTIFIERS: ContextVar[frozenset[str]] = ContextVar(
+    "agent_snooping_current_skill_identifiers", default=frozenset()
+)
 
 # AS1: Agent Config Directory Access
 # Matches code/instructions that read from well-known agent config directories.
@@ -111,7 +119,7 @@ AS3_PATTERNS = [
         0.85,
     ),
     # Accessing skills/CURRENT or adjacent skill directories
-    (r"skills?/(?:(?!CURRENT)[A-Z][A-Za-z0-9_-]+)/SKILL\.md", 0.8),
+    (_AS3_SKILL_PATH_PATTERN, 0.8),
     # Reading tool manifests of other agents
     (
         r"(?:read|access|load)\s+(?:the\s+)?(?:SKILL|skill)\.md\s+(?:file\s+)?(?:of|from|for)\s+(?:another|other|different|all)\s+(?:skill|agent|tool)",
@@ -166,6 +174,9 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
 
     for pattern, confidence in AS3_PATTERNS:
         for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
+            matched_text = match.group(0)[:200]
+            if _is_current_skill_path_reference(matched_text, _CURRENT_SKILL_IDENTIFIERS.get()):
+                continue
             line_num = get_line_number(content, match.start())
             findings.append(
                 AnalyzerFinding(
@@ -176,15 +187,81 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
                     confidence=confidence,
                     tags=tag,
                     context=ctx(match.start()),
-                    matched_text=match.group(0)[:200],
+                    matched_text=matched_text,
                 )
             )
 
     return findings
 
 
+def _normalize_skill_identifier(value: object) -> str | None:
+    """Return the comparison form for a usable skill identifier."""
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().casefold().replace("_", "-")
+    return normalized or None
+
+
+def _current_skill_identifiers(state: SkillspectorState) -> frozenset[str]:
+    """Derive fail-closed identities for the skill currently being inspected."""
+    identifiers: set[str] = set()
+
+    skill_path: object = state.get("skill_path")
+    path_text: str | bytes | None = None
+    if isinstance(skill_path, str):
+        path_text = skill_path
+    elif isinstance(skill_path, os.PathLike):
+        try:
+            path_text = os.fspath(skill_path)
+        except Exception:
+            path_text = None
+    if isinstance(path_text, str):
+        normalized_path = path_text.replace("\\", "/").rstrip("/")
+        path_identifier = _normalize_skill_identifier(normalized_path.rsplit("/", 1)[-1])
+        if path_identifier is not None:
+            identifiers.add(path_identifier)
+
+    manifest = state.get("manifest")
+    if isinstance(manifest, Mapping):
+        manifest_identifier = _normalize_skill_identifier(manifest.get("name"))
+        if manifest_identifier is not None:
+            identifiers.add(manifest_identifier)
+
+    return frozenset(identifiers)
+
+
+def _is_current_skill_path_reference(
+    matched_text: object, current_skill_identifiers: frozenset[str]
+) -> bool:
+    """Return whether an exact AS3 path match names the current skill."""
+    if not current_skill_identifiers or not isinstance(matched_text, str):
+        return False
+    match = _AS3_SKILL_PATH_FULLMATCH.fullmatch(matched_text)
+    if match is None:
+        return False
+    matched_identifier = _normalize_skill_identifier(match.group("skill_name"))
+    return matched_identifier in current_skill_identifiers
+
+
+class _CurrentSkillScopedAnalyzer:
+    """Delegate AS checks while excluding exact current-skill path references."""
+
+    ANALYZER_ID = ANALYZER_ID
+
+    def __init__(self, current_skill_identifiers: frozenset[str]) -> None:
+        self._current_skill_identifiers = current_skill_identifiers
+
+    def analyze(self, content: str, file_path: str, file_type: str) -> list[AnalyzerFinding]:
+        token = _CURRENT_SKILL_IDENTIFIERS.set(self._current_skill_identifiers)
+        try:
+            return analyze(content, file_path, file_type)
+        finally:
+            _CURRENT_SKILL_IDENTIFIERS.reset(token)
+
+
 def node(state: SkillspectorState) -> AnalyzerNodeResponse:
     """Run agent_snooping patterns and return findings."""
-    response = static_runner.run_static_patterns_with_ledger(state, [sys.modules[__name__]])
+    analyzer = _CurrentSkillScopedAnalyzer(_current_skill_identifiers(state))
+    response = static_runner.run_static_patterns_with_ledger(state, [analyzer])
     logger.info("%s: %d findings", ANALYZER_ID, len(response["findings"]))
     return response

--- a/src/skillspector/nodes/analyzers/static_patterns_agent_snooping.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_agent_snooping.py
@@ -175,7 +175,9 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
     for pattern, confidence in AS3_PATTERNS:
         for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
             full_match = match.group(0)
-            if _is_current_skill_path_reference(full_match, _CURRENT_SKILL_IDENTIFIERS.get()):
+            if _is_current_skill_path_reference(
+                full_match, _CURRENT_SKILL_IDENTIFIERS.get()
+            ) and static_runner.security_view_match_is_literal(content, match.start(), match.end()):
                 continue
             matched_text = full_match[:200]
             line_num = get_line_number(content, match.start())

--- a/src/skillspector/nodes/analyzers/static_patterns_agent_snooping.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_agent_snooping.py
@@ -174,9 +174,10 @@ def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFindin
 
     for pattern, confidence in AS3_PATTERNS:
         for match in re.finditer(pattern, content, re.IGNORECASE | re.MULTILINE):
-            matched_text = match.group(0)[:200]
-            if _is_current_skill_path_reference(matched_text, _CURRENT_SKILL_IDENTIFIERS.get()):
+            full_match = match.group(0)
+            if _is_current_skill_path_reference(full_match, _CURRENT_SKILL_IDENTIFIERS.get()):
                 continue
+            matched_text = full_match[:200]
             line_num = get_line_number(content, match.start())
             findings.append(
                 AnalyzerFinding(

--- a/src/skillspector/nodes/analyzers/static_runner.py
+++ b/src/skillspector/nodes/analyzers/static_runner.py
@@ -23,6 +23,7 @@ import unicodedata
 from array import array
 from bisect import bisect_right
 from collections.abc import Callable, Iterator, Mapping
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import cast
 
@@ -94,6 +95,10 @@ _VIEW_START_EVIDENCE = "_security_view_start"
 _SOURCE_START_EVIDENCE = "_security_source_start"
 _VIEW_ORIGIN_TAGS = frozenset({"normalized-view", "declared-marker-view"})
 _BENIGN_CONTEXT_TAGS = frozenset({"contextual-triage", "likely-benign-context"})
+_ActiveSecurityView = tuple[SecurityTextView, str]
+_ACTIVE_SECURITY_VIEW: ContextVar[_ActiveSecurityView | None] = ContextVar(
+    "static_runner_active_security_view", default=None
+)
 _ViewFindingKey = tuple[str, str, int, str | None, tuple[object, ...]]
 _ViewScopeKey = tuple[str, str, int, str | None]
 assert _RAW_WINDOW_OWNED_CHARS > 0
@@ -122,6 +127,31 @@ _LICENSE_BASENAME = re.compile(r"^(?:license|licenses|copying|notice|notices)(?:
 _LICENSE_OTHER_SUFFIXES = frozenset({".lesser"})
 _ASCII_CONTINUITY_SEPARATOR_RUN = re.compile(r"[\s\x00-\x08\x0b\x0c\x0e-\x1f\x7f]+")
 _ASCII_NON_NEWLINE_WHITESPACE = re.compile(r"[ \t\r\f\v]")
+
+
+def security_view_match_is_literal(content: str, start: int, end: int) -> bool:
+    """Return whether an active-view span is unchanged from its source text."""
+    active_view = _ACTIVE_SECURITY_VIEW.get()
+    if active_view is None or not 0 <= start < end <= len(content):
+        return False
+    view, source_text = active_view
+    if view.text is not content:
+        return False
+    if view.source_offsets is None:
+        return view.text is source_text
+    if end > len(view.source_offsets):
+        return False
+
+    source_start = view.source_offsets[start]
+    match_length = end - start
+    source_end = source_start + match_length
+    if source_end > len(source_text):
+        return False
+    if any(
+        view.source_offsets[index] != source_start + index - start for index in range(start, end)
+    ):
+        return False
+    return source_text[source_start:source_end] == content[start:end]
 
 
 def _advance_markdown_fence(active: tuple[str, int] | None, line: str) -> tuple[str, int] | None:
@@ -724,15 +754,21 @@ def _scan_view_windows(
     pattern_modules: list,
     finding_budget: _FindingBudget,
     python_ast_cache_key: str | None,
+    *,
+    source_text: str,
 ) -> tuple[list[Finding], _StaticResourceLimitError | None]:
     """Scan one already-bounded view."""
-    findings, resource_limit = _scan_path(
-        path,
-        view.text,
-        pattern_modules,
-        finding_budget,
-        python_ast_cache_key,
-    )
+    view_token = _ACTIVE_SECURITY_VIEW.set((view, source_text))
+    try:
+        findings, resource_limit = _scan_path(
+            path,
+            view.text,
+            pattern_modules,
+            finding_budget,
+            python_ast_cache_key,
+        )
+    finally:
+        _ACTIVE_SECURITY_VIEW.reset(view_token)
     for finding in findings:
         local_start = finding.evidence.pop(_VIEW_START_EVIDENCE, None)
         if isinstance(local_start, int) and 0 <= local_start < len(view.text):
@@ -1088,6 +1124,7 @@ def _scan_declared_marker_views(
                         pattern_modules,
                         view_budget,
                         None,
+                        source_text=raw_window,
                     )
                     _restore_source_lines(
                         view_findings,
@@ -1325,6 +1362,7 @@ def _scan_all_views_detailed(
                             modules_for_windows,
                             view_budget,
                             None,
+                            source_text=raw_window,
                         )
                     except _StaticResourceLimitError as exc:
                         return (
@@ -1395,6 +1433,7 @@ def _scan_all_views_detailed(
                             modules_for_windows,
                             view_budget,
                             None,
+                            source_text=continuity.view.text,
                         )
                         _restore_source_lines(
                             view_findings,

--- a/tests/fixtures/as3_self_reference/README.md
+++ b/tests/fixtures/as3_self_reference/README.md
@@ -1,0 +1,5 @@
+# Manifest Index
+
+Current manifest: `skills/example-skill/SKILL.md`
+
+Peer manifest: `skills/peer-skill/SKILL.md`

--- a/tests/fixtures/as3_self_reference/SKILL.md
+++ b/tests/fixtures/as3_self_reference/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: example-skill
+description: Documents manifest locations for an example skill.
+---
+
+# Example Skill
+
+Use the manifest index in `README.md` when locating related documentation.

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -712,13 +712,15 @@ class TestRunStaticPatternsAgentSnoopingAdditional:
     def test_as3_skill_enumeration(self):
         """Listing installed skills from skill directories yields AS3."""
         state = {
+            "skill_path": "/tmp/checkout-root/example-skill",
+            "manifest": {"name": "example-skill"},
             "components": ["SKILL.md"],
             "file_cache": {
                 "SKILL.md": "Enumerate all installed skills by listing files in the .claude/skills/ directory.",
             },
         }
-        findings = static_runner.run_static_patterns(state, [agent_snooping_module])
-        assert any(f.rule_id == "AS3" for f in findings)
+        result = agent_snooping_module.node(state)
+        assert any(f.rule_id == "AS3" for f in result["findings"])
 
     def test_safe_content_no_agent_snooping(self):
         """Legitimate skill content produces no agent snooping findings."""
@@ -780,11 +782,61 @@ class TestRunStaticPatternsAgentSnooping:
     def test_as3_other_skill_produces_finding(self):
         """Reading another skill's manifest yields AS3."""
         state = {
+            "skill_path": "/tmp/checkout-root/example-skill",
+            "manifest": {"name": "example-skill"},
             "components": ["s.py"],
             "file_cache": {"s.py": 'open("skills/other-skill/SKILL.md").read()\n'},
         }
-        findings = static_runner.run_static_patterns(state, [agent_snooping_module])
-        assert any(f.rule_id == "AS3" for f in findings)
+        result = agent_snooping_module.node(state)
+        assert any(f.rule_id == "AS3" for f in result["findings"])
+
+    def test_as3_ownership_table_current_skill_is_not_snooping(self):
+        """An ownership table may name the skill currently being inspected."""
+        state = {
+            "skill_path": "/tmp/checkout-root/example-skill",
+            "manifest": {"name": "example-skill"},
+            "components": ["README.md"],
+            "file_cache": {"README.md": "Root skill: skills/example-skill/SKILL.md"},
+        }
+
+        result = agent_snooping_module.node(state)
+
+        readme_event = next(
+            event for event in result["inspection_ledger"] if event["path"] == "README.md"
+        )
+        assert readme_event["outcome"] == "completed"
+        assert readme_event["emitted_finding_ids"] == []
+        assert not any(f.rule_id == "AS3" for f in result["findings"])
+
+    def test_as3_scan_root_identity_marks_self_reference_when_manifest_is_absent(self):
+        """The scan-root basename identifies the current skill without a manifest."""
+        state = {
+            "skill_path": "/tmp/checkout-root/example-skill",
+            "components": ["README.md"],
+            "file_cache": {"README.md": "Root skill: skills/example-skill/SKILL.md"},
+        }
+
+        result = agent_snooping_module.node(state)
+
+        readme_event = next(
+            event for event in result["inspection_ledger"] if event["path"] == "README.md"
+        )
+        assert readme_event["outcome"] == "completed"
+        assert readme_event["emitted_finding_ids"] == []
+        assert not any(f.rule_id == "AS3" for f in result["findings"])
+
+    def test_as3_manifest_identity_marks_self_reference_when_path_is_unrelated(self):
+        """Manifest identity is authoritative when the checkout basename is unrelated."""
+        state = {
+            "skill_path": "/tmp/checkout-root",
+            "manifest": {"name": "example-skill"},
+            "components": ["README.md"],
+            "file_cache": {"README.md": "Root skill: skills/example-skill/SKILL.md"},
+        }
+
+        result = agent_snooping_module.node(state)
+
+        assert not any(f.rule_id == "AS3" for f in result["findings"])
 
     def test_same_line_distinct_matches_preserved(self):
         """Distinct same-line config reads are preserved as separate findings."""

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -901,6 +901,44 @@ class TestRunStaticPatternsAgentSnooping:
         assert readme_event["emitted_finding_ids"] == []
         assert not any(f.rule_id == "AS3" for f in result["findings"])
 
+    def test_as3_fullwidth_peer_path_from_normalized_view_remains_suspicious(self):
+        """A compatibility-normalized peer path remains an AS3 finding."""
+        state = {
+            "skill_path": "/tmp/checkout-root/example-skill",
+            "manifest": {"name": "example-skill"},
+            "components": ["README.md"],
+            "file_cache": {"README.md": "Peer skill: skills/ｅxample-skill/SKILL.md"},
+        }
+
+        result = agent_snooping_module.node(state)
+
+        as3_findings = [finding for finding in result["findings"] if finding.rule_id == "AS3"]
+        assert len(as3_findings) == 1
+        assert "normalized-view" in as3_findings[0].tags
+        readme_event = next(
+            event for event in result["inspection_ledger"] if event["path"] == "README.md"
+        )
+        assert readme_event["emitted_finding_ids"] == [as3_findings[0].finding_id]
+
+    def test_as3_hidden_separator_peer_path_from_compact_view_remains_suspicious(self):
+        """A peer path reconstructed across hidden text remains an AS3 finding."""
+        state = {
+            "skill_path": "/tmp/checkout-root/example-skill",
+            "manifest": {"name": "example-skill"},
+            "components": ["README.md"],
+            "file_cache": {"README.md": "Peer skill: skills/exam\u200bple-skill/SKILL.md"},
+        }
+
+        result = agent_snooping_module.node(state)
+
+        as3_findings = [finding for finding in result["findings"] if finding.rule_id == "AS3"]
+        assert len(as3_findings) == 1
+        assert "normalized-view" in as3_findings[0].tags
+        readme_event = next(
+            event for event in result["inspection_ledger"] if event["path"] == "README.md"
+        )
+        assert readme_event["emitted_finding_ids"] == [as3_findings[0].finding_id]
+
     def test_as3_missing_current_identity_fails_closed(self):
         """Without a path or manifest identity, a skill path remains suspicious."""
         state = {

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -838,6 +838,86 @@ class TestRunStaticPatternsAgentSnooping:
 
         assert not any(f.rule_id == "AS3" for f in result["findings"])
 
+    def test_as3_long_current_skill_path_is_not_snooping(self):
+        """Self-reference comparison uses the full path before evidence truncation."""
+        skill_name = f"example-{'a' * 190}"
+        path_reference = f"skills/{skill_name}/SKILL.md"
+        assert len(path_reference) > 200
+        state = {
+            "skill_path": f"/tmp/checkout-root/{skill_name}",
+            "manifest": {"name": skill_name},
+            "components": ["README.md"],
+            "file_cache": {"README.md": f"Root skill: {path_reference}"},
+        }
+
+        result = agent_snooping_module.node(state)
+
+        readme_event = next(
+            event for event in result["inspection_ledger"] if event["path"] == "README.md"
+        )
+        assert readme_event["outcome"] == "completed"
+        assert readme_event["emitted_finding_ids"] == []
+        assert not any(f.rule_id == "AS3" for f in result["findings"])
+
+    def test_as3_filtered_self_references_do_not_consume_output_limit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Filtered self paths neither consume output budget nor enter the ledger."""
+        monkeypatch.setattr(static_runner, "MAX_FINDINGS_PER_ARTIFACT", 2)
+        peer_reference = "skills/other-skill/SKILL.md"
+        state = {
+            "skill_path": "/tmp/checkout-root/example-skill",
+            "manifest": {"name": "example-skill"},
+            "components": ["README.md"],
+            "file_cache": {
+                "README.md": "\n".join(["skills/example-skill/SKILL.md"] * 3 + [peer_reference])
+            },
+        }
+
+        result = agent_snooping_module.node(state)
+
+        as3_findings = [finding for finding in result["findings"] if finding.rule_id == "AS3"]
+        assert [finding.matched_text for finding in as3_findings] == [peer_reference]
+        readme_event = next(
+            event for event in result["inspection_ledger"] if event["path"] == "README.md"
+        )
+        assert readme_event["outcome"] == "completed"
+        assert readme_event["emitted_finding_ids"] == [as3_findings[0].finding_id]
+
+    def test_as3_current_identity_normalizes_case_hyphens_and_underscores(self):
+        """Manifest and path identifiers compare across supported spelling variants."""
+        state = {
+            "skill_path": "/tmp/checkout-root",
+            "manifest": {"name": "Example_Skill"},
+            "components": ["README.md"],
+            "file_cache": {"README.md": "Root skill: skills/eXaMpLe-SkIlL/SKILL.md"},
+        }
+
+        result = agent_snooping_module.node(state)
+
+        readme_event = next(
+            event for event in result["inspection_ledger"] if event["path"] == "README.md"
+        )
+        assert readme_event["emitted_finding_ids"] == []
+        assert not any(f.rule_id == "AS3" for f in result["findings"])
+
+    def test_as3_missing_current_identity_fails_closed(self):
+        """Without a path or manifest identity, a skill path remains suspicious."""
+        state = {
+            "components": ["README.md"],
+            "file_cache": {"README.md": "Root skill: skills/example-skill/SKILL.md"},
+        }
+
+        result = agent_snooping_module.node(state)
+
+        as3_findings = [finding for finding in result["findings"] if finding.rule_id == "AS3"]
+        assert len(as3_findings) == 1
+        readme_event = next(
+            event for event in result["inspection_ledger"] if event["path"] == "README.md"
+        )
+        assert readme_event["outcome"] == "completed"
+        assert readme_event["emitted_finding_ids"] == [as3_findings[0].finding_id]
+
     def test_same_line_distinct_matches_preserved(self):
         """Distinct same-line config reads are preserved as separate findings."""
         state = {

--- a/tests/nodes/analyzers/test_static_patterns.py
+++ b/tests/nodes/analyzers/test_static_patterns.py
@@ -939,6 +939,55 @@ class TestRunStaticPatternsAgentSnooping:
         )
         assert readme_event["emitted_finding_ids"] == [as3_findings[0].finding_id]
 
+    def test_as3_literal_self_path_stays_suppressed_when_other_text_is_normalized(self):
+        """Unrelated normalization does not turn a literal self path into snooping."""
+        state = {
+            "skill_path": "/tmp/checkout-root/example-skill",
+            "manifest": {"name": "example-skill"},
+            "components": ["README.md"],
+            "file_cache": {
+                "README.md": (
+                    "Root skill: skills/example-skill/SKILL.md\nUnrelated compatibility text: ｘ"
+                )
+            },
+        }
+
+        result = agent_snooping_module.node(state)
+
+        readme_event = next(
+            event for event in result["inspection_ledger"] if event["path"] == "README.md"
+        )
+        assert readme_event["emitted_finding_ids"] == []
+        assert not any(finding.rule_id == "AS3" for finding in result["findings"])
+
+    def test_as3_raw_view_scope_does_not_extend_to_transformed_content(self):
+        """Raw-view authorization is bound to the runner-provided text object."""
+
+        class TransformedAnalyzer:
+            ANALYZER_ID = agent_snooping_module.ANALYZER_ID
+
+            @staticmethod
+            def analyze(content: str, file_path: str, file_type: str) -> list[AnalyzerFinding]:
+                assert content == "placeholder"
+                transformed = "skills/example-skill/SKILL.md"
+                analyzer = agent_snooping_module._CurrentSkillScopedAnalyzer(
+                    frozenset({"example-skill"})
+                )
+                return analyzer.analyze(transformed, file_path, file_type)
+
+        result = static_runner.run_static_patterns_with_ledger(
+            {
+                "components": ["README.md"],
+                "file_cache": {"README.md": "placeholder"},
+            },
+            [TransformedAnalyzer()],
+        )
+
+        as3_findings = [finding for finding in result["findings"] if finding.rule_id == "AS3"]
+        assert len(as3_findings) == 1
+        readme_event = result["inspection_ledger"][0]
+        assert readme_event["emitted_finding_ids"] == [as3_findings[0].finding_id]
+
     def test_as3_missing_current_identity_fails_closed(self):
         """Without a path or manifest identity, a skill path remains suspicious."""
         state = {

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -445,6 +445,20 @@ def test_cli_keyring_fixture_reproduction_is_clean() -> None:
     assert not any(issue["id"] == "PE3" for issue in payload["issues"])
 
 
+def test_cli_as3_self_reference_fixture_preserves_only_peer_path() -> None:
+    fixture = Path(__file__).parents[1] / "fixtures" / "as3_self_reference"
+    result = runner.invoke(app, ["scan", str(fixture), "--format", "json", "--no-llm"])
+
+    assert result.exit_code in {0, 1}, result.output
+    payload = json.loads(result.output)
+    assert payload["execution_successful"] is True
+    assert [
+        (issue["location"]["file"], issue["finding"])
+        for issue in payload["issues"]
+        if issue["id"] == "AS3"
+    ] == [("README.md", "skills/peer-skill/SKILL.md")]
+
+
 def test_cli_scan_nonexistent_exits_2() -> None:
     """scan with nonexistent path exits with code 2."""
     result = runner.invoke(app, ["scan", "/nonexistent/path/xyz"])


### PR DESCRIPTION
## Summary

- suppress AS3 only when a literal `skills/<name>/SKILL.md` path identifies the skill currently being scanned
- derive current-skill identity from the scan-root basename and manifest name
- preserve peer-skill, transformed/obfuscated path, explicit enumeration, AS1, and AS2 findings
- exclude suppressed findings before finding-budget and inspection-ledger accounting
- add unit and real no-LLM CLI regression coverage

## Validation

- `uv run --no-sync pytest -q tests/nodes/analyzers/test_static_patterns.py -k AgentSnooping` — 22 passed
- `uv run --no-sync pytest -q tests/unit/test_cli.py -k as3_self_reference` — 1 passed
- real no-LLM CLI fixture — current-skill reference suppressed; peer-skill reference retained
- local `uv run --no-sync make test-ci` — 3,997 passed, 14 skipped, 38 deselected, 4 xfailed
- [GitHub Actions CI](https://github.com/NVIDIA/SkillSpector/actions/runs/34323974670) — all 5 jobs passed; `test-unit` reported the same counts
- `uv run --no-sync make lint` — passed
- `uv run --no-sync make format-check` — passed
- targeted mypy for changed production modules — passed
- Docker build and `tests/docker/smoke.sh` — passed, including local and public-repository scans
- `git diff --check origin/main...HEAD` — passed

## Security behavior

Suppression is restricted to unchanged literal source spans naming the current skill. References reconstructed through normalized or compact security views remain findings, as do references to peer skills.

Refs #500

AI assistance disclosure: Codex assisted with source inspection, regression tests, implementation, and review. I reviewed and verified the change.
