### PR TITLE
fix: avoid false parser limits and reference accounting failures

### DIFF
--- a/src/skillspector/nodes/analyzers/static_patterns_tool_misuse.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_tool_misuse.py
@@ -53,6 +53,8 @@ _PRINTF_STATIC_WORD_RE = re.compile(r"[-A-Za-z0-9_./*?%]{0,64}")
 _DESTRUCTIVE_COMMAND_BASENAMES = frozenset({"rm", "del", "erase"})
 _QUOTED_GLOB_SENTINEL = "\ue000"
 _DYNAMIC_SHELL_WORD_SENTINEL = "\ue001"
+_RUNTIME_SHELL_PARAMETER_SENTINEL = "\ue002"
+_SIMPLE_BRACED_PARAMETER_RE = re.compile(r"\$\{(?:[A-Za-z_][A-Za-z0-9_]*|[0-9]+|[@*#?$!-])\}")
 _ROOT_GLOB_DOCUMENTATION_LINE_RE = re.compile(
     r"[ \t]*(?:(?:[-*+]|#{1,6})[ \t]+)?"
     r"(?:(?:(?:documentation|note|example)[ \t]*:[ \t]*)"
@@ -702,8 +704,8 @@ def _consume_printf_invocation(
         if word is None:
             return False, False
         if _DYNAMIC_SHELL_WORD_SENTINEL in word:
-            # A runtime expansion participates in the invocation or wrapper
-            # command word. Its executable basename is not deterministic.
+            # A command substitution or complex expansion participates in the
+            # invocation or wrapper word. Its basename is not deterministic.
             return True, False
         command = word.casefold().rsplit("/", 1)[-1]
         if command == "printf":
@@ -789,6 +791,17 @@ def _printf_invocation_arguments(inner: str) -> tuple[bool, list[str]]:
     return True, arguments
 
 
+def _invocation_expansion_marker(content: str, start: int, end: int) -> str:
+    """Distinguish runtime-only parameters from possible command reconstruction."""
+    if content.startswith("$(", start) or (
+        content.startswith("${", start)
+        and _SIMPLE_BRACED_PARAMETER_RE.fullmatch(content, start, end) is None
+    ):
+        # Complex parameter expansions may contain nested command substitutions.
+        return _DYNAMIC_SHELL_WORD_SENTINEL
+    return _RUNTIME_SHELL_PARAMETER_SENTINEL
+
+
 def _next_shell_invocation_word(
     content: str,
     start: int,
@@ -820,6 +833,7 @@ def _next_shell_invocation_word(
     quote: str | None = None
     ansi_c_quote = False
     word_started = False
+    unquoted_characters = 0
     while cursor < limit:
         if cursor % 4096 == 0:
             check_runtime()
@@ -884,7 +898,7 @@ def _next_shell_invocation_word(
                     word_started = True
                     cursor += 1
                     continue
-                output.append(_DYNAMIC_SHELL_WORD_SENTINEL)
+                output.append(_invocation_expansion_marker(content, cursor, parameter_end))
                 word_started = True
                 cursor = parameter_end
                 if inherited_quote_closed[0]:
@@ -959,7 +973,8 @@ def _next_shell_invocation_word(
                 word_started = True
                 cursor += 1
                 continue
-            output.append(_DYNAMIC_SHELL_WORD_SENTINEL)
+            # A simple runtime parameter does not invoke the printf evaluator.
+            output.append(_invocation_expansion_marker(content, cursor, parameter_end))
             word_started = True
             cursor = parameter_end
             continue
@@ -1002,7 +1017,8 @@ def _next_shell_invocation_word(
         else:
             output.append(character)
             word_started = True
-            if len(output) > _SHELL_COMMAND_WORD_CHARS:
+            unquoted_characters += 1
+            if unquoted_characters > _SHELL_COMMAND_WORD_CHARS:
                 return None, cursor, True
         cursor += 1
     if quote is not None:
@@ -1151,6 +1167,7 @@ def _parse_shell_command_word(
     ansi_c_quote = False
     dynamic = False
     limited = False
+    unquoted_characters = 0
     cursor = start
     limit = len(content)
     while cursor < limit:
@@ -1354,7 +1371,11 @@ def _parse_shell_command_word(
             break
         else:
             output.append(character)
-            if len(output) > _SHELL_COMMAND_WORD_CHARS:
+            # Quoted spans have already been consumed in full. Their decoded
+            # length must not exhaust the budget for the following literal
+            # suffix, which can resolve the candidate as an ordinary word.
+            unquoted_characters += 1
+            if unquoted_characters > _SHELL_COMMAND_WORD_CHARS:
                 return _ShellCommandWord("".join(output), cursor, dynamic, limited=True)
         cursor += 1
     if quote is not None:

--- a/src/skillspector/nodes/analyzers/static_patterns_tool_misuse.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_tool_misuse.py
@@ -708,6 +708,14 @@ def _consume_printf_invocation(
             # invocation or wrapper word. Its basename is not deterministic.
             return True, False
         command = word.casefold().rsplit("/", 1)[-1]
+        if _RUNTIME_SHELL_PARAMETER_SENTINEL in word and command in {
+            "printf",
+            "command",
+            "builtin",
+            "env",
+        }:
+            # A known basename does not make a runtime-selected executable exact.
+            return True, False
         if command == "printf":
             return True, True
         if command == "command":

--- a/src/skillspector/nodes/finalize_inspection_ledger.py
+++ b/src/skillspector/nodes/finalize_inspection_ledger.py
@@ -39,6 +39,7 @@ def _reference_coverage_findings(
         if outcome in {"partial", "failed", "out_of_scope"}:
             exceptional_outcomes.setdefault(str(event.get("path", "")), set()).add(outcome)
     findings: list[Finding] = []
+    seen_locations: set[tuple[str, int, str]] = set()
     for reference in raw_references:
         if not isinstance(reference, dict):
             continue
@@ -62,6 +63,14 @@ def _reference_coverage_findings(
         if final_disposition not in {"partial", "failed", "out_of_scope"}:
             continue
         line_value = reference.get("line", 1)
+        source_path = str(reference.get("source_path", "SKILL.md"))
+        line = line_value if isinstance(line_value, int) else 1
+        # A Markdown label and destination may resolve to the same artifact.
+        # Findings identify source lines, so emit that coverage gap only once.
+        location = (source_path, line, target_path)
+        if location in seen_locations:
+            continue
+        seen_locations.add(location)
         evidence = str(reference.get("evidence", ""))[:160]
         findings.append(
             Finding(
@@ -69,8 +78,8 @@ def _reference_coverage_findings(
                 message="Referenced artifact was not completely inspected",
                 severity="HIGH",
                 confidence=1.0,
-                file=str(reference.get("source_path", "SKILL.md")),
-                start_line=line_value if isinstance(line_value, int) else 1,
+                file=source_path,
+                start_line=line,
                 category="analysis-evasion",
                 tags=["coverage", "reference", f"target-disposition:{final_disposition}"],
                 finding=f"{target_path} ({final_disposition})"[:200],
@@ -88,17 +97,24 @@ def _reference_coverage_findings(
 def finalize_inspection_ledger(state: SkillspectorState) -> dict[str, object]:
     """Validate full internal facts and derive the public completeness projection."""
     reference_findings = _reference_coverage_findings(state)
+    # Work IDs are scoped to analyzer, source file and line range. Distinct
+    # targets on one line must share a terminal row with all emitted findings.
+    reference_ids_by_line: dict[tuple[str, int | None], list[str]] = {}
+    for finding in reference_findings:
+        reference_ids_by_line.setdefault((finding.file, finding.start_line), []).append(
+            finding.finding_id
+        )
     reference_events: list[InspectionLedgerEvent] = [
         ledger_event(
             outcome=LedgerOutcome.COMPLETED,
             phase="reference",
             analyzer_id="reference_coverage",
-            path=finding.file,
-            start_line=finding.start_line,
-            end_line=finding.start_line,
-            emitted_finding_ids=[finding.finding_id],
+            path=path,
+            start_line=line,
+            end_line=line,
+            emitted_finding_ids=finding_ids,
         )
-        for finding in reference_findings
+        for (path, line), finding_ids in reference_ids_by_line.items()
     ]
     merged_state = dict(state)
     all_findings = [*(state.get("findings") or []), *reference_findings]

--- a/tests/nodes/analyzers/test_security_reconstruction.py
+++ b/tests/nodes/analyzers/test_security_reconstruction.py
@@ -1664,15 +1664,32 @@ def test_long_quoted_command_path_still_detects_destructive_basename() -> None:
     [
         "$(printf $FORMAT) -rf /",
         "$(printf ${FORMAT}) -rf /",
+        "$($BIN/printf echo) -rf /",
+        "$(${BIN}/printf echo) -rf /",
+        '$("$BIN/printf" echo) -rf /',
+        "$($BIN/env printf echo) -rf /",
+        "$($BIN/command printf echo) -rf /",
+        "$($BIN/builtin printf echo) -rf /",
         '`"${TOOL:-$(printf rm ' + " " * 300 + ')}"` -rf /',
     ],
-    ids=["runtime-format", "braced-runtime-format", "nested-parameter-reconstruction"],
+    ids=[
+        "runtime-format",
+        "braced-runtime-format",
+        "runtime-path",
+        "braced-runtime-path",
+        "quoted-runtime-path",
+        "runtime-env-path",
+        "runtime-command-path",
+        "runtime-builtin-path",
+        "nested-parameter-reconstruction",
+    ],
 )
 def test_runtime_printf_arguments_and_nested_reconstruction_stay_partial(content: str) -> None:
     result = static_runner.run_static_patterns_with_ledger(
         {"components": ["SKILL.md"], "file_cache": {"SKILL.md": content}}, [tm_module]
     )
 
+    assert result["inspection_ledger"][0]["outcome"] is LedgerOutcome.PARTIAL
     assert result["inspection_ledger"][0]["reason_code"] is LedgerReason.STATIC_PARSE_LIMIT
 
 

--- a/tests/nodes/analyzers/test_security_reconstruction.py
+++ b/tests/nodes/analyzers/test_security_reconstruction.py
@@ -1619,6 +1619,64 @@ def test_shell_command_word_cap_exhaustion_is_partial() -> None:
 
 
 @pytest.mark.parametrize(
+    "content",
+    [
+        "Interpret `$ARGUMENTS` as the user's input.",
+        "Interpret `${ARGUMENTS}` as the user's input.",
+        "Use `$example:task FILE_PATH|--all` to invoke the skill.",
+        "Read the token from `$SERVICE_TOKEN` or a configured file.",
+        'Test-Path "$($_.FullName)\\cli-path"',
+        r"Render `$$\int_0^1 x \, dx$$` as math.",
+        "The reader's " + "ordinary documentation\n" * 220 + " author's guide.\n",
+        '"""Reader documentation.\n' + "ordinary documentation\n" * 220 + '"""\nreturn None\n',
+    ],
+    ids=[
+        "parameter",
+        "braced-parameter",
+        "skill-invocation",
+        "token",
+        "powershell",
+        "math",
+        "apostrophe",
+        "docstring",
+    ],
+)
+def test_documentation_is_not_a_bounded_shell_reconstruction(content: str) -> None:
+    result = static_runner.run_static_patterns_with_ledger(
+        {"components": ["SKILL.md"], "file_cache": {"SKILL.md": content}}, [tm_module]
+    )
+
+    assert result["inspection_ledger"][0]["outcome"] is LedgerOutcome.COMPLETED
+    assert not any(finding.rule_id == "TM1" for finding in result["findings"])
+
+
+def test_long_quoted_command_path_still_detects_destructive_basename() -> None:
+    content = 'r"' + "directory/" * 500 + '"rm -rf /'
+    result = static_runner.run_static_patterns_with_ledger(
+        {"components": ["SKILL.md"], "file_cache": {"SKILL.md": content}}, [tm_module]
+    )
+
+    assert any(finding.rule_id == "TM1" for finding in result["findings"])
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "$(printf $FORMAT) -rf /",
+        "$(printf ${FORMAT}) -rf /",
+        '`"${TOOL:-$(printf rm ' + " " * 300 + ')}"` -rf /',
+    ],
+    ids=["runtime-format", "braced-runtime-format", "nested-parameter-reconstruction"],
+)
+def test_runtime_printf_arguments_and_nested_reconstruction_stay_partial(content: str) -> None:
+    result = static_runner.run_static_patterns_with_ledger(
+        {"components": ["SKILL.md"], "file_cache": {"SKILL.md": content}}, [tm_module]
+    )
+
+    assert result["inspection_ledger"][0]["reason_code"] is LedgerReason.STATIC_PARSE_LIMIT
+
+
+@pytest.mark.parametrize(
     "printf_command",
     ["printf", 'p"rintf"', "p'rintf'", '"pri"ntf', r"p\rintf", "env printf"],
 )

--- a/tests/nodes/test_finalize_inspection_ledger.py
+++ b/tests/nodes/test_finalize_inspection_ledger.py
@@ -610,6 +610,76 @@ def test_resolved_partial_reference_produces_one_canonically_counted_ae1() -> No
     assert completeness["is_complete"] is False
 
 
+@pytest.mark.parametrize("failed", [False, True])
+@pytest.mark.parametrize(
+    "locations",
+    [
+        [("a.md", 4, 8), ("a.md", 4, 24)],
+        [("a.md", 4, 8), ("b.md", 4, 24)],
+        [("a.md", 4, 8), ("a.md", 7, 8)],
+        [("a.md", 4, 8), ("a.md", 4, 24), ("b.md", 4, 40), ("a.md", 7, 8)],
+    ],
+)
+def test_reference_findings_share_one_terminal_event_per_source_line(
+    locations: list[tuple[str, int, int]], failed: bool
+) -> None:
+    paths = sorted({path for path, _, _ in locations})
+    result = finalize_inspection_ledger(
+        {
+            "components": ["SKILL.md", *paths],
+            "findings": [],
+            "effective_finding_ids": [],
+            "artifact_inventory": [
+                {"path": path, "disposition": "analyzed", "content_kind": "text"} for path in paths
+            ],
+            "artifact_references": [
+                {
+                    "source_path": "SKILL.md",
+                    "line": line,
+                    "column": column,
+                    "evidence": f"Read [{path}]({path}).",
+                    "target_path": path,
+                    "status": "resolved",
+                    "disposition": "analyzed",
+                }
+                for path, line, column in locations
+            ],
+            "inspection_ledger": [
+                ledger_event(
+                    outcome=LedgerOutcome.FAILED if failed else LedgerOutcome.PARTIAL,
+                    record_type=LedgerRecordType.SYSTEM,
+                    phase="static",
+                    path=path,
+                    reason=LedgerReason.READ_ERROR if failed else LedgerReason.STATIC_PARSE_LIMIT,
+                )
+                for path in paths
+            ],
+            "analyzer_status_events": [],
+        }
+    )
+
+    findings = result["findings"]
+    expected_locations = {(line, path) for path, line, _ in locations}
+    assert len(findings) == len(expected_locations)
+    assert {
+        (finding.start_line, finding.matched_text) for finding in findings
+    } == expected_locations
+    events = result["inspection_ledger"]
+    assert len(events) == len({line for _, line, _ in locations})
+    for event in events:
+        assert set(event["emitted_finding_ids"]) == {
+            finding.finding_id for finding in findings if finding.start_line == event["start_line"]
+        }
+    completeness = result["analysis_completeness"]
+    assert completeness["status"] == ("failed" if failed else "partial")
+    assert result["execution_successful"] is (not failed)
+    assert len(result["effective_finding_ids"]) == len(expected_locations)
+    assert not any(
+        row["reason_code"] in {"unaccounted_work", "finding_accounting_error"}
+        for row in completeness["ledger_exceptions"]
+    )
+
+
 @pytest.mark.parametrize("use_llm", [False, True])
 @pytest.mark.parametrize(
     ("disposition", "outcome", "reason", "expected_ae1"),

--- a/tests/nodes/test_security_end_to_end.py
+++ b/tests/nodes/test_security_end_to_end.py
@@ -1005,6 +1005,36 @@ async def test_printf_wrapper_depth_limit_fails_closed_across_public_surfaces(
     await _assert_incomplete_across_public_surfaces(tmp_path, result)
 
 
+def test_markdown_reference_to_parser_limited_target_keeps_cli_execution_successful(
+    tmp_path: Path,
+) -> None:
+    _write_bundle(
+        tmp_path,
+        {
+            "SKILL.md": (
+                "---\nname: reference-coverage\ndescription: Reference coverage regression\n---\n"
+                "Read [references/commands.md](references/commands.md).\n"
+            ),
+            "references/commands.md": "$(env env env env printf rm) -rf /\n",
+        },
+    )
+
+    report = _scan_cli(tmp_path)
+
+    assert report["execution_successful"] is True
+    completeness = report["analysis_completeness"]
+    assert completeness["status"] == "partial"
+    assert completeness["is_complete"] is False
+    assert any(
+        row["reason_code"] == "static_parse_limit" for row in completeness["ledger_exceptions"]
+    )
+    assert not any(row["fatal"] for row in completeness["ledger_exceptions"])
+    ae1 = [issue for issue in report["issues"] if issue["id"] == "AE1"]
+    assert len(ae1) == 1
+    assert ae1[0]["location"]["file"] == "SKILL.md"
+    assert ae1[0]["location"]["start_line"] == 5
+
+
 @pytest.mark.asyncio
 async def test_changed_rule_family_negative_controls(tmp_path: Path) -> None:
     _write_bundle(

--- a/tests/nodes/test_security_end_to_end.py
+++ b/tests/nodes/test_security_end_to_end.py
@@ -1035,6 +1035,29 @@ def test_markdown_reference_to_parser_limited_target_keeps_cli_execution_success
     assert ae1[0]["location"]["start_line"] == 5
 
 
+def test_referenced_variable_documentation_does_not_create_coverage_gaps(tmp_path: Path) -> None:
+    _write_bundle(
+        tmp_path,
+        {
+            "SKILL.md": (
+                "---\nname: reference-variables\ndescription: Variable documentation\n---\n"
+                "Read [references/usage.md](references/usage.md).\n"
+            ),
+            "references/usage.md": (
+                "Interpret `$ARGUMENTS` as the requested input.\n"
+                'In PowerShell, use `Test-Path "$($_.FullName)\\cli-path"`.\n'
+            ),
+        },
+    )
+
+    report = _scan_cli(tmp_path)
+
+    assert report["execution_successful"] is True
+    assert report["analysis_completeness"]["status"] == "complete"
+    assert report["analysis_completeness"]["ledger_exceptions"] == []
+    assert not any(issue["id"] == "AE1" for issue in report["issues"])
+
+
 @pytest.mark.asyncio
 async def test_changed_rule_family_negative_controls(tmp_path: Path) -> None:
     _write_bundle(


### PR DESCRIPTION
Ordinary skill documentation can trigger false `static_parse_limit` warnings and fatal reference-accounting errors, producing CLI exit code 2. This PR fixes those failures while preserving partial coverage for commands that cannot be reconstructed safely.

- Distinguish simple runtime parameters from command substitutions and complex expansions. Inline `$ARGUMENTS`, skill invocation syntax, and PowerShell member access no longer produce false parser-limit errors.
- Count directly scanned literal characters separately from already-consumed quoted spans, so long quoted documentation does not exhaust the wrong parser budget.
- Deduplicate coverage findings by source file, line, and target, and emit one completion event per source line containing all finding IDs. Markdown label/destination duplicates and distinct targets on one line no longer cause fatal `unaccounted_work` errors.
- Preserve partial coverage for runtime-selected `printf`, `env`, `command`, and `builtin` executable paths. A familiar basename does not make a runtime-selected executable deterministic.

Includes #508, merged into this PR's source branch as `f5bb619`. Fixes #464.

Validation:

- **629 tests passed** across security reconstruction, reference finalization, and security end-to-end suites on the combined implementation. The current branch has the same file tree as that tested implementation; the subsequent CI-refresh commit changes no files.
- Six focused runtime-path probes change from incorrect completed coverage before #508 to partial coverage with #508. Markdown runtime-parameter controls remain complete, and the literal destructive-command control remains detected.
- Fresh `ruff check src tests` and `ruff format --check src tests` passed after the merge.
- The earlier #507 revision was replayed against **31 affected skill inputs with `--no-llm`**: all had successful scanner execution and no fatal accounting errors. Some retained blocking findings. This corpus replay predates #508 and is not claimed as a fresh combined-corpus or full LLM/CI rerun.

Unresolved references and other analysis limitations remain visible. Downstream validation with LLM analyzers must be rerun after release adoption.

Prepared and updated by Codex on behalf of Mohit Gupta. The runtime-path follow-up in #508 was contributed by Yashraj.
