### PR TITLE
fix: preserve partial coverage for runtime printf paths

### DIFF
--- a/src/skillspector/nodes/analyzers/static_patterns_tool_misuse.py
+++ b/src/skillspector/nodes/analyzers/static_patterns_tool_misuse.py
@@ -708,6 +708,14 @@ def _consume_printf_invocation(
             # invocation or wrapper word. Its basename is not deterministic.
             return True, False
         command = word.casefold().rsplit("/", 1)[-1]
+        if _RUNTIME_SHELL_PARAMETER_SENTINEL in word and command in {
+            "printf",
+            "command",
+            "builtin",
+            "env",
+        }:
+            # A known basename does not make a runtime-selected executable exact.
+            return True, False
         if command == "printf":
             return True, True
         if command == "command":

--- a/tests/nodes/analyzers/test_security_reconstruction.py
+++ b/tests/nodes/analyzers/test_security_reconstruction.py
@@ -1664,15 +1664,32 @@ def test_long_quoted_command_path_still_detects_destructive_basename() -> None:
     [
         "$(printf $FORMAT) -rf /",
         "$(printf ${FORMAT}) -rf /",
+        "$($BIN/printf echo) -rf /",
+        "$(${BIN}/printf echo) -rf /",
+        '$("$BIN/printf" echo) -rf /',
+        "$($BIN/env printf echo) -rf /",
+        "$($BIN/command printf echo) -rf /",
+        "$($BIN/builtin printf echo) -rf /",
         '`"${TOOL:-$(printf rm ' + " " * 300 + ')}"` -rf /',
     ],
-    ids=["runtime-format", "braced-runtime-format", "nested-parameter-reconstruction"],
+    ids=[
+        "runtime-format",
+        "braced-runtime-format",
+        "runtime-path",
+        "braced-runtime-path",
+        "quoted-runtime-path",
+        "runtime-env-path",
+        "runtime-command-path",
+        "runtime-builtin-path",
+        "nested-parameter-reconstruction",
+    ],
 )
 def test_runtime_printf_arguments_and_nested_reconstruction_stay_partial(content: str) -> None:
     result = static_runner.run_static_patterns_with_ledger(
         {"components": ["SKILL.md"], "file_cache": {"SKILL.md": content}}, [tm_module]
     )
 
+    assert result["inspection_ledger"][0]["outcome"] is LedgerOutcome.PARTIAL
     assert result["inspection_ledger"][0]["reason_code"] is LedgerReason.STATIC_PARSE_LIMIT
 
 


### PR DESCRIPTION
This is a small follow-up stacked on #507, which already fixes the documentation parser limits and duplicate reference-accounting failures. After #507 merges, retarget this PR to `main`.

The new runtime-parameter marker can be discarded by the basename lookup, so `$($BIN/printf echo) -rf /` is reconstructed as `echo` and reported as completely inspected even though the executable path is only known at runtime. Preserve partial coverage for runtime-selected `printf`, `env`, `command`, and `builtin` paths while retaining #507’s Markdown and PowerShell fixes.

Validation:
- Six new cases failed on #507 before the fix; all pass with the guard.
- 629 tests passed across security reconstruction, reference finalization, and security end-to-end suites.
- Ruff checks, formatting, and `git diff --check` passed.
- Replayed the three minimal Markdown/PowerShell examples and both affected documents: no parser-limit exceptions from the tool-misuse analyzer.

No dependencies or gate policies changed.
