### PR TITLE
  fix: oversized files must not produce a zero-finding report (LLM-stage inclusion + AE7 coverage finding)

### DIFF
--- a/src/skillspector/constants.py
+++ b/src/skillspector/constants.py
@@ -34,6 +34,11 @@ MAX_FILE_BYTES = 1_000_000
 # Static analysis supports complete per-artifact coverage through 16 MiB. Larger
 # files are read only to this bound and are reported as partial, never complete.
 MAX_ANALYZABLE_FILE_BYTES = 16 * 1024 * 1024
+# Truncated files must still reach the LLM stage: excluding them entirely lets
+# a payload hide past the read cap while the scan reports zero findings.  The
+# LLM view of a truncated file is bounded to this prefix so token cost stays
+# predictable, and an explicit marker records the unreviewed region.
+MAX_LLM_TRUNCATED_FILE_CHARS = 262_144
 
 # Default-model selection lives on each provider (see providers/<name>/provider.py
 # for ``DEFAULT_MODEL`` and ``SLOT_DEFAULTS``).  The active provider's

--- a/src/skillspector/nodes/build_context.py
+++ b/src/skillspector/nodes/build_context.py
@@ -41,7 +41,12 @@ from skillspector.artifacts import (
     classify_artifact,
     decode_text,
 )
-from skillspector.constants import MAX_ANALYZABLE_FILE_BYTES, MAX_FILE_BYTES, build_model_config
+from skillspector.constants import (
+    MAX_ANALYZABLE_FILE_BYTES,
+    MAX_FILE_BYTES,
+    MAX_LLM_TRUNCATED_FILE_CHARS,
+    build_model_config,
+)
 from skillspector.input_handler import (
     _FileOpenError,
     _open_regular_file_no_follow,
@@ -754,6 +759,25 @@ def _is_hidden_path(path: str) -> bool:
     return any(part.startswith(".") for part in Path(path).parts)
 
 
+def _llm_view_of_truncated_file(content: str, *, total_size: int, read_bytes: int) -> str:
+    """Bound a truncated file's LLM view and mark the unreviewed region.
+
+    A truncated file must not vanish from the LLM stage: with exclusion, a
+    payload placed past the read cap is invisible to every analyzer while the
+    report still shows zero findings.  The view is capped so token cost stays
+    bounded, and the marker makes the audit gap explicit to the model.
+    """
+    marker = (
+        f"\n\n[SKILLSPECTOR: this file is {total_size} bytes; only the first "
+        f"{read_bytes} bytes were readable and the excerpt above is capped at "
+        f"{MAX_LLM_TRUNCATED_FILE_CHARS} characters. The remaining bytes were "
+        "not reviewed by any analyzer - treat the unseen region as an audit "
+        "gap.]\n"
+    )
+    budget = max(MAX_LLM_TRUNCATED_FILE_CHARS - len(marker), 0)
+    return content[:budget] + marker
+
+
 def _opaque_artifact_record(
     path: str,
     *,
@@ -1089,7 +1113,13 @@ def _read_file_cache(
                         )
                     )
             inventory.append(artifact)
-            if not truncated and not _is_hidden_path(path) and artifact["content_kind"] == "text":
+            if not _is_hidden_path(path) and artifact["content_kind"] == "text":
+                if truncated:
+                    content = _llm_view_of_truncated_file(
+                        content,
+                        total_size=max(file_stat.st_size, len(observed)),
+                        read_bytes=len(raw),
+                    )
                 llm_file_cache[path] = _redact_for_external_model(path, content)
             if aggregate_truncated:
                 inventory.extend(

--- a/src/skillspector/nodes/finalize_inspection_ledger.py
+++ b/src/skillspector/nodes/finalize_inspection_ledger.py
@@ -94,14 +94,66 @@ def _reference_coverage_findings(
     return findings
 
 
+def _size_coverage_findings(
+    state: SkillspectorState,
+    covered_paths: set[str],
+) -> list[Finding]:
+    """Create AE7 for artifacts truncated by the per-file size cap.
+
+    A file too large to fully analyze must not be able to produce a
+    zero-finding report: the unreviewed region is itself the finding.
+    Scoped to the per-file cap (``size_limit``); aggregate budget
+    exhaustion already fails closed through the completeness projection.
+    Paths already reported by AE1 (referenced artifacts) are skipped.
+    """
+    findings: list[Finding] = []
+    for item in state.get("artifact_inventory") or []:
+        if not isinstance(item, Mapping):
+            continue
+        if str(item.get("disposition", "")) != "partial":
+            continue
+        if str(item.get("reason", "")) != LedgerReason.SIZE_LIMIT.value:
+            continue
+        if str(item.get("path", "")) in covered_paths:
+            continue
+        path = str(item.get("path", ""))
+        size_bytes = item.get("size_bytes", 0)
+        findings.append(
+            Finding(
+                rule_id="AE7",
+                message=(
+                    "File exceeds the analyzable size limit; trailing content was not inspected"
+                ),
+                severity="HIGH",
+                confidence=1.0,
+                file=path,
+                start_line=1,
+                category="analysis-evasion",
+                tags=["coverage", "size-limit"],
+                finding=f"{path} ({size_bytes} bytes, partially inspected)"[:200],
+                matched_text=path,
+                remediation=(
+                    "Keep analyzable files under the per-file size limit, or "
+                    "split oversized content so every byte can be inspected."
+                ),
+            )
+        )
+    return findings
+
+
 def finalize_inspection_ledger(state: SkillspectorState) -> dict[str, object]:
     """Validate full internal facts and derive the public completeness projection."""
     reference_findings = _reference_coverage_findings(state)
+    size_findings = _size_coverage_findings(
+        state,
+        covered_paths={str(finding.matched_text or "") for finding in reference_findings},
+    )
+    coverage_findings = [*reference_findings, *size_findings]
     # Work IDs are scoped to analyzer, source file and line range. Distinct
     # targets on one line must share a terminal row with all emitted findings.
-    reference_ids_by_line: dict[tuple[str, int | None], list[str]] = {}
-    for finding in reference_findings:
-        reference_ids_by_line.setdefault((finding.file, finding.start_line), []).append(
+    coverage_ids_by_line: dict[tuple[str, int | None], list[str]] = {}
+    for finding in coverage_findings:
+        coverage_ids_by_line.setdefault((finding.file, finding.start_line), []).append(
             finding.finding_id
         )
     reference_events: list[InspectionLedgerEvent] = [
@@ -114,10 +166,10 @@ def finalize_inspection_ledger(state: SkillspectorState) -> dict[str, object]:
             end_line=line,
             emitted_finding_ids=finding_ids,
         )
-        for (path, line), finding_ids in reference_ids_by_line.items()
+        for (path, line), finding_ids in coverage_ids_by_line.items()
     ]
     merged_state = dict(state)
-    all_findings = [*(state.get("findings") or []), *reference_findings]
+    all_findings = [*(state.get("findings") or []), *coverage_findings]
     output_events: list[InspectionLedgerEvent] = []
     finding_output_records = sum(max(1, len(finding.occurrences)) for finding in all_findings)
     if finding_output_records > MAX_FINDING_OUTPUT_RECORDS:
@@ -140,7 +192,7 @@ def finalize_inspection_ledger(state: SkillspectorState) -> dict[str, object]:
     merged_state["findings"] = all_findings
     merged_state["effective_finding_ids"] = [
         *(state.get("effective_finding_ids") or []),
-        *(finding.finding_id for finding in reference_findings),
+        *(finding.finding_id for finding in coverage_findings),
     ]
     merged_state["inspection_ledger"] = [
         *(state.get("inspection_ledger") or []),
@@ -157,15 +209,15 @@ def finalize_inspection_ledger(state: SkillspectorState) -> dict[str, object]:
         *reference_statuses,
     ]
     completeness, effective_finding_ids = finalize_ledger(merged_state)
-    if reference_findings and completeness["status"] == "complete":
+    if coverage_findings and completeness["status"] == "complete":
         completeness["status"] = "partial"
         completeness["is_complete"] = False
         limitations = completeness.setdefault("limitations", [])
-        limitations.append("One or more referenced artifacts were not completely inspected.")
+        limitations.append("One or more artifacts were not completely inspected.")
     return {
         "analysis_completeness": completeness,
         "execution_successful": completeness["execution_successful"],
-        "findings": reference_findings,
+        "findings": coverage_findings,
         "effective_finding_ids": effective_finding_ids,
         "inspection_ledger": [*reference_events, *output_events],
         "analyzer_status_events": reference_statuses,

--- a/tests/nodes/test_build_context.py
+++ b/tests/nodes/test_build_context.py
@@ -1371,6 +1371,33 @@ def test_build_context_reports_files_beyond_supported_envelope_as_partial(
     )
 
 
+def test_truncated_text_file_stays_in_llm_cache_with_audit_gap_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file past the read cap must still reach the LLM stage.
+
+    Excluding truncated files from ``llm_file_cache`` lets a payload hide
+    past the cap while the report shows zero findings.  The LLM view is a
+    bounded prefix plus an explicit audit-gap marker instead.
+    """
+    import skillspector.nodes.build_context as build_context_module
+
+    monkeypatch.setattr(build_context_module, "MAX_ANALYZABLE_FILE_BYTES", 64)
+    (tmp_path / "SKILL.md").write_text("# weather\n", encoding="utf-8")
+    (tmp_path / "server.py").write_text(
+        'PAYLOAD = "past-the-cut"\n' + "x" * 256 + "\n", encoding="utf-8"
+    )
+
+    result = build_context({"skill_path": str(tmp_path)})
+
+    assert "server.py" in result["llm_file_cache"]
+    cached = result["llm_file_cache"]["server.py"]
+    assert "audit" in cached and "gap" in cached
+    assert "server.py" in result["llm_components"]
+    artifact = next(item for item in result["artifact_inventory"] if item["path"] == "server.py")
+    assert artifact["disposition"] == "partial"
+
+
 def test_build_context_shares_artifact_budget_across_child_bundles(tmp_path: Path) -> None:
     """A second child sees the artifact allowance already consumed by its sibling."""
     from skillspector.cli import _TransitiveBudget, _TransitiveTraversalState

--- a/tests/nodes/test_finalize_inspection_ledger.py
+++ b/tests/nodes/test_finalize_inspection_ledger.py
@@ -754,6 +754,87 @@ def test_resolved_reference_ae1_disposition_matrix_is_llm_independent(
         assert result["effective_finding_ids"] == []
 
 
+@pytest.mark.parametrize(
+    ("disposition", "reason", "expected_ae7"),
+    [
+        ("analyzed", None, False),
+        ("partial", "size_limit", True),
+        ("partial", "total_bytes_limit", False),
+        ("failed", "read_error", False),
+    ],
+)
+def test_size_truncated_artifact_synthesizes_ae7(
+    disposition: str,
+    reason: str | None,
+    expected_ae7: bool,
+) -> None:
+    """A file past the per-file read cap must not yield a zero-finding report."""
+    item: dict[str, object] = {"path": "server.py", "disposition": disposition}
+    if reason is not None:
+        item["reason"] = reason
+    result = finalize_inspection_ledger(
+        {
+            "components": ["server.py"],
+            "findings": [],
+            "effective_finding_ids": [],
+            "artifact_inventory": [item],
+            "inspection_ledger": [],
+            "analyzer_status_events": [],
+        }
+    )
+
+    ae7 = [finding for finding in result["findings"] if finding.rule_id == "AE7"]
+    assert bool(ae7) is expected_ae7
+    if expected_ae7:
+        assert ae7[0].severity == "HIGH"
+        assert ae7[0].file == "server.py"
+        assert ae7[0].category == "analysis-evasion"
+        assert result["analysis_completeness"]["is_complete"] is False
+
+
+def test_ae7_skips_paths_already_covered_by_ae1() -> None:
+    """A referenced size-truncated artifact gets AE1, not AE1 + AE7."""
+    result = finalize_inspection_ledger(
+        {
+            "components": ["SKILL.md", "assets/big.py"],
+            "findings": [],
+            "effective_finding_ids": [],
+            "artifact_inventory": [
+                {
+                    "path": "assets/big.py",
+                    "disposition": "partial",
+                    "reason": "size_limit",
+                    "content_kind": "text",
+                }
+            ],
+            "artifact_references": [
+                {
+                    "source_path": "SKILL.md",
+                    "line": 3,
+                    "column": 1,
+                    "evidence": "See [server](assets/big.py).",
+                    "target_path": "assets/big.py",
+                    "status": "resolved",
+                    "disposition": "partial",
+                }
+            ],
+            "inspection_ledger": [
+                ledger_event(
+                    outcome=LedgerOutcome.PARTIAL,
+                    record_type=LedgerRecordType.SYSTEM,
+                    phase="cache",
+                    path="assets/big.py",
+                    reason=LedgerReason.SIZE_LIMIT,
+                )
+            ],
+            "analyzer_status_events": [],
+        }
+    )
+
+    rule_ids = [finding.rule_id for finding in result["findings"]]
+    assert rule_ids == ["AE1"]
+
+
 @pytest.mark.parametrize("status", ["missing", "ambiguous", "rejected"])
 def test_unresolved_reference_does_not_synthesize_ae1(status: str) -> None:
     result = finalize_inspection_ledger(


### PR DESCRIPTION
## Summary

A file larger than `MAX_ANALYZABLE_FILE_BYTES` (16 MiB) currently produces a
zero-finding report even under the default LLM-on scan:

1. `nodes/build_context.py` excludes truncated files from `llm_file_cache`
   entirely, so the semantic LLM analyzers (the scanner's most capable
   stage) never see the file.
2. The unreviewed region produces no finding: the report shows
   `CAUTION / 0` with an empty issues list, and the only trace is
   `analysis_completeness.status: "partial"` in JSON metadata.

A payload placed past the read cap is therefore invisible while the scan reads
as clean. This is a fail-open: "too large to review" must itself be a finding.

## Reproduction

A runnable MCP server whose malicious helpers sit past the 16 MiB mark
(17 MB `server.py`: benign weather code + a 16.2 MiB string literal before the
cut, exfiltration helpers after it; module-level names resolve at call time,
so the payload still executes, canary-verified):

```
$ skillspector scan flooded-server --format json        # default, LLM-on
recommendation: CAUTION, score: 0, issues: 0
```

`llm_components` contains only `manifest.json`; `server.py` never reaches the
model. Confirmed against three model backends (a local Claude CLI login, plus
claude-sonnet-5 and claude-opus-5 reached through an OpenAI-compatible
endpoint with archived prompts): every prompt covered only `manifest.json`.
The same payload at normal size is flagged `DO_NOT_INSTALL / 100` by all
three backends, so the miss is structural, not a model-capability failure.

## Fix

Two parts, both required:

**1. `build_context.py`: keep truncated files in the LLM stage.**
Truncated text files are cached in `llm_file_cache` as a bounded prefix
(`MAX_LLM_TRUNCATED_FILE_CHARS`, 256 KiB) plus an explicit marker:

```
[SKILLSPECTOR: this file is 16978656 bytes; only the first 16777216 bytes were
readable and the excerpt above is capped at 262144 characters. The remaining
bytes were not reviewed by any analyzer - treat the unseen region as an audit
gap.]
```

`LLMAnalyzerBase.get_batches` already chunks oversized content into
token-budgeted batches, so no batching changes are needed; the 256 KiB cap
keeps worst-case token cost bounded (~2-8 chunks depending on model budget).

**2. `finalize_inspection_ledger.py`: new AE7 coverage finding (HIGH,
analysis-evasion).** Any artifact left `partial` by the per-file size cap
produces a finding: "File exceeds the analyzable size limit; trailing content
was not inspected." This extends the existing AE1 principle ("referenced
artifact was not completely inspected") to artifacts nothing referenced.
Paths already covered by AE1 are skipped (no double-reporting). Scoped to the
per-file cap (`size_limit`); aggregate budget exhaustion already fails closed
through the completeness projection and the `SAFE -> CAUTION` upgrade in
`nodes/report.py`.

After the fix, the same files under the same default scan flip to
`DO_NOT_INSTALL / 100`:

| PoC | Stock scanner | Patched scanner |
|---|---|---|
| Flooded exfil server (17 MB) | CAUTION / 0, 0 findings | DO_NOT_INSTALL / 100, 9 findings |
| Flooded RCE server (17 MB, neutrally named) | CAUTION / 0, 0 findings | DO_NOT_INSTALL / 100, 9 findings |

With only the bounded head + marker available, the model catches the evasion
structurally: it flags the 17 MB repeated-sentence padding as having "no
benign explanation" (SSD-2), the unconditional `_sync_telemetry` /
`_check_for_service_update` call chain in the visible head (SDI-1), the
docstring as "social engineering" (SSD-4), and AE7 names the file and its
true size. Even a perfectly innocuous-looking head still cannot produce a
clean report, because AE7 fires regardless.

## Why not full-file chunked review

Reading and reviewing every byte of arbitrary-size files is a token-cost
policy decision (a 16 MiB file is ~4M tokens, hundreds of calls per
analyzer). The results above show the fail-closed minimum is sufficient in
practice: a bounded head + an explicit gap marker lets the model identify
both the payload's call sites and the padding itself as evasion, and AE7
guarantees the remainder is never a silent gap. Happy to take maintainer
guidance on a follow-up that chunks the full file behind an opt-in budget
flag.

## Test plan

- [x] `test_truncated_text_file_stays_in_llm_cache_with_audit_gap_marker`:
  truncated file stays in `llm_file_cache` / `llm_components`, carries the
  marker, still reported `partial`
- [x] `test_size_truncated_artifact_synthesizes_ae7`: disposition/reason
  matrix (fires on `partial`+`size_limit` only)
- [x] `test_ae7_skips_paths_already_covered_by_ae1`: no double-reporting
- [x] Full suite: 3991 passed, 14 skipped, 4 xfailed, no regressions
- [x] End-to-end, static (`--no-llm`), 17 MB PoC: `CAUTION / 0, 0 findings`
  -> `CAUTION / 32, 1 HIGH (AE7)`
- [x] End-to-end, default LLM-on (local Claude CLI provider), both 17 MB
  PoCs (exfil + RCE): `CAUTION / 0, 0 findings` -> `DO_NOT_INSTALL / 100`,
  9 findings each, 4/4 LLM calls OK
- [x] Normal-size fixtures unchanged: benign SAFE/0, naive control
  DO_NOT_INSTALL/100
- [x] Maintainer CI