### PR TITLE
  fix: flag module __dict__ subscript as reflective attribute access

### DIFF
--- a/src/skillspector/nodes/analyzers/behavioral_ast.py
+++ b/src/skillspector/nodes/analyzers/behavioral_ast.py
@@ -326,6 +326,38 @@ def _deserialization_message(call_name: str, node: ast.Call) -> str | None:
     return None
 
 
+def _reflective_module_dict_base(node: ast.Subscript, aliases: dict[str, str]) -> str | None:
+    """Return the module name when *node* subscripts an imported module's namespace.
+
+    Matches ``<module>.__dict__[key]`` and ``vars(<module>)[key]``, the subscript
+    equivalents of ``getattr(<module>, key)``: both index the module namespace,
+    so anything AST7/AST9 catch through ``getattr`` must not become invisible by
+    changing spelling. The base must resolve through the import-alias map to a
+    plain (non-dotted) module (``import os`` / ``import os as o``), which keeps
+    idiomatic instance attribute bags (``self.__dict__[...]``) and from-imported
+    classes out of scope.
+    """
+    target = node.value
+    base: ast.expr
+    if isinstance(target, ast.Attribute) and target.attr == "__dict__":
+        base = target.value
+    elif (
+        isinstance(target, ast.Call)
+        and isinstance(target.func, ast.Name)
+        and target.func.id == "vars"
+        and len(target.args) == 1
+    ):
+        base = target.args[0]
+    else:
+        return None
+    if not isinstance(base, ast.Name):
+        return None
+    resolved = aliases.get(base.id)
+    if resolved is None or "." in resolved:
+        return None
+    return resolved
+
+
 def _analyze_python(
     python_ast: ParsedPythonFile,
     file_path: str,
@@ -363,6 +395,29 @@ def _analyze_python(
     for ast_node in ast.walk(tree):
         if budget is not None:
             budget.check_runtime()
+        if isinstance(ast_node, ast.Subscript):
+            module = _reflective_module_dict_base(ast_node, aliases)
+            if module is not None:
+                key = ast_node.slice
+                lineno = getattr(ast_node, "lineno", 1)
+                end_lineno = getattr(ast_node, "end_lineno", None)
+                if isinstance(key, ast.Constant):
+                    if isinstance(key.value, str) and key.value in _DANGEROUS_GETATTR_NAMES:
+                        _emit(
+                            "AST9",
+                            lineno,
+                            end_lineno,
+                            f"Reflective dangerous access via {module}.__dict__ subscript "
+                            "with a literal sink name",
+                        )
+                else:
+                    _emit(
+                        "AST7",
+                        lineno,
+                        end_lineno,
+                        f"Dynamic attribute access via {module}.__dict__ subscript",
+                    )
+            continue
         if not isinstance(ast_node, ast.Call):
             continue
 

--- a/tests/nodes/analyzers/test_behavioral_ast.py
+++ b/tests/nodes/analyzers/test_behavioral_ast.py
@@ -159,6 +159,51 @@ class TestReflectiveGetattrExec:
             assert not any(f.rule_id == "AST9" for f in findings), name
 
 
+class TestModuleDictSubscript:
+    """<module>.__dict__[key] / vars(<module>)[key] are subscript getattr equivalents.
+
+    Both index the module namespace, so they must get the same AST7/AST9
+    treatment as getattr(module, key); changing only the spelling must not
+    change the verdict.
+    """
+
+    def test_dunder_dict_computed_key_produces_ast7(self):
+        code = 'import os\nhandle = os.__dict__["po" + "pen"]("id")'
+        findings = _run(code)
+        ast7 = [f for f in findings if f.rule_id == "AST7"]
+        assert len(ast7) == 1
+        assert ast7[0].severity == "LOW"
+        assert "__dict__" in ast7[0].message
+
+    def test_dunder_dict_literal_sink_produces_ast9(self):
+        code = 'import os\nhandle = os.__dict__["popen"]("whoami")'
+        findings = _run(code)
+        ast9 = [f for f in findings if f.rule_id == "AST9"]
+        assert len(ast9) == 1
+        assert ast9[0].severity == "HIGH"
+
+    def test_vars_module_computed_key_produces_ast7(self):
+        code = "import os\nkey = 'po' + 'pen'\nhandle = vars(os)[key]"
+        findings = _run(code)
+        assert any(f.rule_id == "AST7" for f in findings)
+
+    def test_aliased_module_dunder_dict_produces_ast7(self):
+        code = "import os as o\nkey = 'system'\nhandle = o.__dict__[key]"
+        findings = _run(code)
+        assert any(f.rule_id == "AST7" for f in findings)
+
+    def test_instance_dunder_dict_no_finding(self):
+        # Instance attribute bags are idiomatic and must stay unflagged.
+        code = "class C:\n    def set(self, key, value):\n        self.__dict__[key] = value"
+        findings = _run(code)
+        assert not any(f.rule_id in ("AST7", "AST9") for f in findings)
+
+    def test_dunder_dict_safe_literal_no_finding(self):
+        code = 'import os\nenv = os.__dict__["environ"]'
+        findings = _run(code)
+        assert not any(f.rule_id in ("AST7", "AST9") for f in findings)
+
+
 class TestDangerousChains:
     def test_exec_compile_chain_produces_ast8(self):
         code = 'exec(compile("x = 1", "<string>", "exec"))'


### PR DESCRIPTION
## Summary

The behavioral AST analyzer treats `getattr` as the only reflective
attribute-access spelling, so the equivalent subscript form is invisible:

- `getattr(os, computed)` -> AST7 (LOW, dynamic attribute access)
- `getattr(os, "popen")` -> AST9 (HIGH, literal sink name)
- `os.__dict__["po"+"pen"]` -> no finding at all

`_analyze_python` walks the tree and skips every node that is not an
`ast.Call`, so an `ast.Subscript` over a module's `__dict__` (or over
`vars(module)`) is never inspected. This is a strict superset gap: anything
AST7/AST9 catch through `getattr` can be spelled as a subscript and skipped.

## Reproduction

A runnable MCP server that resolves its command-execution sink through the
module namespace dict instead of `getattr`:

```python
import os

def _cat(*parts):
    return "".join(parts)

def _run_maintenance(cmd):
    return os.__dict__[_cat("po", "pen")](cmd).read()
```

```
$ skillspector scan hidden-rce --no-llm --format json
recommendation: SAFE, score: 0, issues: 0
```

The same server spelled with `getattr(os, _cat("po", "pen"))` produces AST7.
The subscript form is semantically identical (both index the module
namespace with a computed key) but scores zero.

## Fix

Mirror the existing getattr rules for the subscript form.

**1. New helper `_reflective_module_dict_base(node, aliases)`.** Matches
`<module>.__dict__[key]` and `vars(<module>)[key]`, but only when `<module>`
resolves through the import-alias map to a plain (non-dotted) module, i.e.
`import os` or `import os as o`. This deliberately excludes:

- `self.__dict__[...]` and other instance attribute bags, which are a common
  and idiomatic pattern (false-positive risk)
- from-imported classes (`from x import SomeClass; SomeClass.__dict__[k]`),
  whose alias resolves to a dotted path

**2. A `ast.Subscript` branch in the walk loop**, reusing the existing rule
IDs so severity, confidence, and remediation text stay consistent with the
getattr form:

| Subscript spelling | Finding |
|---|---|
| `os.__dict__[computed]` / `vars(os)[computed]` | AST7 (LOW, 0.50) with a message naming the subscript form |
| `os.__dict__["popen"]` (constant key in `_DANGEROUS_GETATTR_NAMES`) | AST9 (HIGH, 0.85) with a message naming the subscript form |
| `os.__dict__["environ"]` (constant, not a sink name) | no finding, matching `getattr(obj, "name")` |

After the fix, the reproduction server scores AST7 (LOW, score 3) instead of
zero, the same treatment the getattr spelling already gets. The point is
symmetry: an evasion that only changes spelling must not change the verdict.

## Why no new rule IDs

This is the same issue class as AST7/AST9 with a different surface syntax.
New IDs would duplicate entries across `_RULE_MESSAGES`, `_RULE_SEVERITIES`,
`_RULE_CONFIDENCES`, and the remediation defaults, and would fragment
reporting for two spellings of one behavior. The message override makes the
spelling explicit in the finding text.

## Out of scope (noted for follow-up)

- `getattr(os, "__dict__")[key]` chains
- `globals()["po"+"pen"]` / `locals()[...]` namespace-dict writes
- Escalating computed-key access above LOW; that is a scoring policy
  decision that applies to the getattr form equally and should be argued
  separately

## Test plan

- [x] `os.__dict__["po"+"pen"]` -> AST7
- [x] `os.__dict__["popen"]` (constant) -> AST9
- [x] `vars(os)[computed]` -> AST7
- [x] `import os as o; o.__dict__[k]` -> AST7 (alias resolution)
- [x] `self.__dict__[key]` -> no finding (instance attribute bag)
- [x] `os.__dict__["environ"]` -> no finding (constant, not a sink name)
- [x] Full suite green, no regressions
- [x] End-to-end: reproduction server SAFE/0 -> SAFE/3 (AST7, LOW)
- [x] Maintainer CI
