### PR TITLE
test(build-context): read the nested OMS fixture without newline translation

### DIFF
--- a/tests/nodes/test_build_context.py
+++ b/tests/nodes/test_build_context.py
@@ -701,7 +701,7 @@ def test_build_context_scans_nested_oms_signature(tmp_path: Path) -> None:
 
     result = build_context({"skill_path": str(tmp_path)})
 
-    assert result["file_cache"]["nested/skill.oms.sig"] == nested.read_text(encoding="utf-8")
+    assert result["file_cache"]["nested/skill.oms.sig"] == nested.read_bytes().decode("utf-8")
     signature_meta = next(
         item for item in result["component_metadata"] if item["path"] == "nested/skill.oms.sig"
     )


### PR DESCRIPTION
`test_build_context_scans_nested_oms_signature` fails on Windows and passes on Linux.

The fixture is written byte-exact, so it keeps its CRLF endings and `build_context` caches it verbatim. The assertion compared that against `Path.read_text()`, which applies universal-newline translation and returns LF, so the two never match on Windows.

Reading the fixture back as bytes and decoding matches how it is written. `Path.read_text(newline="")` would also work, but that parameter is 3.13+ and `pyproject.toml` sets `requires-python = ">=3.12,<3.15"`.

Measured on Windows 11, uv-managed CPython 3.14.0, `-p no:randomly`:

```
before  1 failed   AssertionError: '...}}\r\n' == '...}}\n'
after   1 passed
```

Verified in the full-file run as well, not only in isolation. Also verified on top of #505, which fixes the write side of the same file: this change is independent of it and both orderings pass.

The other failures in this file on Windows are unrelated. #501, #502 and #503 cover the symlink, FIFO and secure-open cases; the remaining two are timing-sensitive and flake on `main` as well.
