### PR TITLE
fix(llm): retarget the deadline on the existing client instead of rebuilding it

### DIFF
--- a/src/skillspector/llm_analyzer_base.py
+++ b/src/skillspector/llm_analyzer_base.py
@@ -52,6 +52,7 @@ from skillspector.inspection_ledger import (
     outcome_for_llm_batch_failure,
 )
 from skillspector.llm_utils import (
+    AgentCLIChatModel,
     StructuredOutputParseError,
     _AgentCLIMessage,
     _ainvoke_with_usage,
@@ -132,6 +133,33 @@ def _uses_native_connection_retries(
     if isinstance(chat_model, ChatAnthropic):
         chat_model.max_retries = max_retries
         return max_retries > 0
+    return False
+
+
+def _retarget_request_timeout(chat_model: object, timeout: float | None) -> bool:
+    """Point an existing chat model at *timeout* and report whether it took effect.
+
+    Returns ``False`` for transports that keep no mutable deadline, so the caller can
+    fall back to constructing a replacement model for that call.
+    """
+    if isinstance(chat_model, ChatOpenAI):
+        clients = (chat_model.root_client, chat_model.root_async_client)
+        if any(client is None for client in clients):
+            return False
+        for client in clients:
+            client.timeout = timeout
+        chat_model.request_timeout = timeout
+        return True
+    if isinstance(chat_model, ChatAnthropic):
+        # ``timeout <= 0`` is how ChatAnthropic spells "leave the SDK default alone"; an
+        # expired deadline never reaches here because ``_require_time_remaining`` raises first.
+        for client in (chat_model._client, chat_model._async_client):
+            client.timeout = timeout
+        chat_model.default_request_timeout = timeout
+        return True
+    if isinstance(chat_model, AgentCLIChatModel):
+        chat_model.set_timeout(timeout)
+        return True
     return False
 
 
@@ -689,6 +717,10 @@ class LLMAnalyzerBase:
     def _model_for_call(self) -> tuple[object, object | None]:
         remaining = self._require_time_remaining()
         if not self._dynamic_timeout:
+            return self._llm, self._structured_llm
+        if _retarget_request_timeout(self._llm, remaining):
+            # Native retries were already disabled for the dynamic-deadline case in
+            # ``__init__``, and the structured runnable wraps this same model instance.
             return self._llm, self._structured_llm
         llm = get_chat_model(model=self.model, timeout=remaining)
         _uses_native_connection_retries(llm, max_retries=0)

--- a/src/skillspector/llm_utils.py
+++ b/src/skillspector/llm_utils.py
@@ -252,19 +252,11 @@ class _StructuredAgentCLIModel:
     ``complete()``, then parses and validates the response into *schema*.
     """
 
-    def __init__(
-        self,
-        provider: object,
-        model: str,
-        max_output_tokens: int,
-        schema: type,
-        timeout: float | None = None,
-    ) -> None:
-        self._provider = provider
-        self._model = model
-        self._max_output_tokens = max_output_tokens
+    def __init__(self, owner: AgentCLIChatModel, schema: type) -> None:
+        # Read transport settings through the owner so a structured wrapper does not pin the
+        # deadline it happened to be created with.
+        self._owner = owner
         self._schema = schema
-        self._timeout = timeout
 
     def _augment(self, prompt: str) -> str:
         schema_json = json.dumps(self._schema.model_json_schema(), indent=2)
@@ -278,11 +270,11 @@ class _StructuredAgentCLIModel:
     def _complete(self, prompt: str) -> str:
         """Return provider output before structured parsing begins."""
         return _complete_agent_cli(
-            self._provider,
+            self._owner._provider,
             self._augment(prompt),
-            model=self._model,
-            max_output_tokens=self._max_output_tokens,
-            timeout=self._timeout,
+            model=self._owner._model,
+            max_output_tokens=self._owner._max_output_tokens,
+            timeout=self._owner._timeout,
         )
 
     def invoke(self, prompt: str) -> object:
@@ -356,9 +348,11 @@ class AgentCLIChatModel:
         return await asyncio.to_thread(self.invoke, prompt)
 
     def with_structured_output(self, schema: type) -> _StructuredAgentCLIModel:
-        return _StructuredAgentCLIModel(
-            self._provider, self._model, self._max_output_tokens, schema, self._timeout
-        )
+        return _StructuredAgentCLIModel(self, schema)
+
+    def set_timeout(self, timeout: float | None) -> None:
+        """Retarget this adapter, and its structured wrappers, at a new deadline."""
+        self._timeout = timeout
 
 
 def get_chat_model(

--- a/tests/nodes/test_llm_analyzer_base.py
+++ b/tests/nodes/test_llm_analyzer_base.py
@@ -29,6 +29,7 @@ import pytest
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import AIMessage
 from langchain_openai import ChatOpenAI
+from langchain_openai.chat_models._client_utils import _cached_async_httpx_client
 from pydantic import ValidationError
 
 from skillspector.inspection_ledger import LedgerOutcome, LedgerReason, finalize_ledger
@@ -884,6 +885,47 @@ class TestDynamicTimeout:
             )
 
         get_chat_model.assert_not_called()
+
+    def test_dynamic_deadline_retargets_one_transport_instead_of_building_more(self) -> None:
+        """A shrinking deadline must not open a connection pool per LLM call.
+
+        Evicted pools belong to event loops that earlier analyzer nodes already closed, so
+        finalizing them raises an unobservable ``RuntimeError: Event loop is closed``.
+        """
+        built: list[ChatOpenAI] = []
+
+        def _factory(*, model: str, timeout: float | None = None) -> ChatOpenAI:
+            chat_model = ChatOpenAI(model=model, api_key="sk-test", timeout=timeout)
+            built.append(chat_model)
+            return chat_model
+
+        calls = 200
+        countdown = iter(float(seconds) for seconds in range(calls + 1, 0, -1))
+        with patch(MOCK_PATCH_TARGET, side_effect=_factory):
+            analyzer = LLMAnalyzerBase(
+                base_prompt="test",
+                model="nvidia/openai/gpt-oss-120b",
+                timeout=lambda: next(countdown),
+            )
+
+            cache_misses_before = _cached_async_httpx_client.cache_info().misses
+            sync_client = analyzer._llm.root_client
+            async_client = analyzer._llm.root_async_client
+            applied: list[float | None] = []
+
+            for _ in range(calls):
+                llm, structured = analyzer._model_for_call()
+                assert llm is analyzer._llm
+                assert structured is analyzer._structured_llm
+                assert llm.root_client is sync_client
+                assert llm.root_async_client is async_client
+                applied.append(llm.root_async_client.timeout)
+
+        assert len(built) == 1
+        assert applied == [float(seconds) for seconds in range(calls, 0, -1)]
+        assert async_client.timeout == 1.0
+        assert sync_client.timeout == 1.0
+        assert _cached_async_httpx_client.cache_info().misses == cache_misses_before
 
     def test_run_batches_resolves_timeout_per_batch(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Dynamic timeout providers are called again before every LLM call."""

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -530,6 +530,22 @@ class TestGetChatModelCLIAdapter:
                     "x"
                 )
 
+    def test_set_timeout_reaches_structured_wrapper(self) -> None:
+        """A retargeted deadline applies to structured wrappers made earlier."""
+
+        class _Schema(BaseModel):
+            verdict: str
+
+        provider = MagicMock()
+        provider.complete.return_value = '{"verdict": "ok"}'
+        model = AgentCLIChatModel(provider, "claude-sonnet-4-6", 1024, timeout=30.0)
+        runnable = model.with_structured_output(_Schema)
+
+        model.set_timeout(4.5)
+        runnable.invoke("prompt")
+
+        assert provider.complete.call_args.kwargs["timeout"] == 4.5
+
     def test_structured_usage_marks_response_before_sync_parse_failure(self) -> None:
         class _Schema(BaseModel):
             verdict: str


### PR DESCRIPTION
Fixes #519

## Problem

Under a workflow deadline (`SKILLSPECTOR_MAX_WORKFLOW_SECONDS`), large scans emitted a stream of:

```
Task exception was never retrieved
RuntimeError: Event loop is closed
```

## Root cause

Every batch has to be sent with whatever time is left, and `_model_for_call()` expressed that by building a **fresh chat model per call**. LangChain caches the underlying `httpx` client in an `lru_cache` keyed on `(base_url, timeout, socket_options)`, so a deadline shrinking by a few milliseconds per call is a **new cache key every call**. A long scan opened one connection pool per LLM request and began evicting the oldest once it passed 128.

Eviction is what crashed. Each analyzer node is synchronous and reaches `run_async()` → `asyncio.run()`, so it owns its event loop. A pool evicted while a later analyzer is running belongs to an earlier, already-closed loop, and the OpenAI SDK's finaliser reacts to garbage collection with `asyncio.get_running_loop().create_task(self.aclose())` — closing the earlier analyzer's sockets from the current analyzer's loop. Nothing awaits that task, so it surfaced only as "Task exception was never retrieved", once per eviction.

## Fix

Apply the deadline to the client that **already exists** instead of baking it into a new one.

- New `_retarget_request_timeout()` in `llm_analyzer_base.py` mutates `client.timeout` on the live client for `ChatOpenAI`, `ChatAnthropic`, and `AgentCLIChatModel`. Both SDKs read `client.timeout` when building each request — the same in-place mutation `_uses_native_connection_retries` already relies on for `max_retries`.
- `_model_for_call()` retargets first and only falls back to constructing a replacement model for transports that keep no mutable deadline, so behaviour is unchanged for them.
- `_StructuredAgentCLIModel` now reads transport settings through its owner rather than copying them at construction, so a structured wrapper no longer pins the deadline it happened to be created with. `with_structured_output` wraps that same model instance.

Dynamic timeouts, the explicit retry loop, the global concurrency limiter, and the one-loop-per-analyzer execution model are all untouched.

Result: one pool per analyzer, one cache key, nothing to evict, and no cleanup that can outlive its loop.

## Validation

- A 200-call reproduction against the `openai` 3.11 / `httpx` 2 combination that reported the failure goes from **75 unretrieved `Event loop is closed` tasks and 220 httpx clients → 0 and 20** (one per analyzer).
- Regression tests added in `tests/nodes/test_llm_analyzer_base.py` and `tests/unit/test_llm_utils.py`.
- `make test` (unit): **4015 passed, 14 skipped, 4 xfailed**.
- `make lint`: clean. `make format` / `ruff format --check`: no changes (198 files already formatted).
- A real scan over an internal skills root produced zero `Event loop is closed` / `Task exception was never retrieved` messages.

Note: `tests/integration/test_graph.py::test_graph_surfaces_degraded_llm_stage` fails in my local environment, but it fails **identically on unmodified `main`** (verified by reverting only the two source files) — it is pre-existing and unrelated to this change.
