### PR TITLE
fix(providers): treat an env-selected Bedrock provider as an available LLM

### DIFF
--- a/src/skillspector/llm_utils.py
+++ b/src/skillspector/llm_utils.py
@@ -54,6 +54,7 @@ from skillspector.providers import (
     get_metadata_provider,
     has_cli_capability,
     has_provider_binding,
+    provider_is_authoritative,
     raise_no_llm_api_key_configured,
     resolve_chat_model_credentials,
     resolve_provider_credentials,
@@ -110,7 +111,7 @@ def _resolve_llm_credentials() -> tuple[str, str | None]:
 
 def _resolve_default_chat_model() -> str:
     """Return the default chat model for the endpoint that will be used."""
-    if has_provider_binding():
+    if provider_is_authoritative(get_metadata_provider()):
         return get_metadata_provider().resolve_model()
 
     if resolve_provider_credentials() is not None:
@@ -135,7 +136,7 @@ def is_llm_available() -> tuple[bool, str | None]:
     if has_cli_capability(provider):
         return provider.is_available()  # type: ignore[attr-defined]
 
-    if has_provider_binding():
+    if provider_is_authoritative(provider):
         try:
             model = provider.resolve_model()
             create_chat_model(

--- a/src/skillspector/llm_utils.py
+++ b/src/skillspector/llm_utils.py
@@ -53,7 +53,6 @@ from skillspector.providers import (
     get_active_provider,
     get_metadata_provider,
     has_cli_capability,
-    has_provider_binding,
     provider_is_authoritative,
     raise_no_llm_api_key_configured,
     resolve_chat_model_credentials,

--- a/src/skillspector/providers/__init__.py
+++ b/src/skillspector/providers/__init__.py
@@ -213,6 +213,28 @@ def resolve_chat_model_credentials() -> tuple[str, str | None] | None:
     return _openai_fallback_provider().resolve_credentials()
 
 
+def provider_is_authoritative(provider: object) -> bool:
+    """Return whether *provider* can be trusted without OpenAI-style credentials.
+
+    True for an explicitly bound provider, for CLI providers, and for Bedrock —
+    which authenticates through the boto3 credential chain and so returns
+    ``None`` from ``resolve_credentials()`` by design.
+
+    Callers that ask "is an API key configured?" to decide whether to trust the
+    active provider should ask this instead. ``SKILLSPECTOR_PROVIDER=bedrock``
+    with working AWS credentials is a configured provider, but it has no API
+    key, and treating that as "no LLM available" silently disables the
+    analyzers that require one.
+    """
+    from .bedrock import BedrockProvider
+
+    return (
+        has_provider_binding()
+        or has_cli_capability(provider)
+        or isinstance(provider, BedrockProvider)
+    )
+
+
 def get_model_config_provider() -> ModelMetadataProvider:
     """Return the provider whose model defaults match graph chat-model routing.
 
@@ -221,13 +243,8 @@ def get_model_config_provider() -> ModelMetadataProvider:
     when their own credentials are absent and the OpenAI fallback is configured.
     """
     provider = _select_active_provider()
-    from .bedrock import BedrockProvider
 
-    if (
-        has_provider_binding()
-        or has_cli_capability(provider)
-        or isinstance(provider, BedrockProvider)
-    ):
+    if provider_is_authoritative(provider):
         return provider
     if provider.resolve_credentials() is not None:
         return provider
@@ -310,6 +327,7 @@ __all__ = [
     "get_metadata_provider",
     "has_cli_capability",
     "has_provider_binding",
+    "provider_is_authoritative",
     "reset_provider",
     "raise_no_llm_api_key_configured",
     "resolve_chat_model_credentials",

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -51,11 +51,14 @@ from skillspector.llm_utils import (
 )
 from skillspector.providers import (
     NO_LLM_API_KEY_MESSAGE,
+    get_metadata_provider,
+    provider_is_authoritative,
     reset_provider,
     resolve_chat_model_credentials,
     resolve_provider_credentials,
     use_provider,
 )
+from skillspector.providers.bedrock import BEDROCK_DEFAULT_MODEL
 from skillspector.providers.nv_build import NvBuildProvider
 from skillspector.providers.openai import OpenAIProvider
 
@@ -739,3 +742,63 @@ class TestRunAsync:
         """Test run_async correctly handles async functions with await calls."""
         result = run_async(self._test_async_function(5, delay=0.01))
         assert result == 10
+
+
+class TestBedrockAvailabilityWithoutApiKey:
+    """Bedrock selected by env var must count as an available LLM.
+
+    Bedrock authenticates through the boto3 credential chain and returns
+    ``None`` from ``resolve_credentials()`` by design, so the API-key path
+    cannot see it. Before ``provider_is_authoritative`` was consulted here,
+    ``is_llm_available()`` fell through to that path and reported
+    ``NO_LLM_API_KEY_MESSAGE`` for a working Bedrock configuration — which
+    made ``create_graph()`` drop every analyzer with ``requires_api_key``.
+    """
+
+    def test_provider_is_authoritative_for_bedrock(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "bedrock")
+        assert provider_is_authoritative(get_metadata_provider()) is True
+
+    def test_provider_is_not_authoritative_for_unbound_api_key_provider(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The fallback behaviour this must not disturb: an unbound API-key
+        # provider is still judged on its credentials.
+        monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "anthropic")
+        assert provider_is_authoritative(get_metadata_provider()) is False
+
+    def test_is_llm_available_true_for_bedrock_with_no_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "bedrock")
+        with patch(
+            "skillspector.llm_utils.create_chat_model", return_value=MagicMock()
+        ) as create:
+            ok, msg = is_llm_available()
+        assert ok is True
+        assert msg is None
+        # It must have probed the real chat-model path rather than asking for
+        # an API key.
+        assert create.call_count == 1
+
+    def test_is_llm_available_false_when_bedrock_cannot_build_a_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No AWS credentials: the probe fails, and the reported reason is the
+        # provider's own rather than a misleading "no API key".
+        monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "bedrock")
+        with patch(
+            "skillspector.llm_utils.create_chat_model",
+            side_effect=ValueError("boto3 chain resolved nothing"),
+        ):
+            ok, msg = is_llm_available()
+        assert ok is False
+        assert msg == "boto3 chain resolved nothing"
+
+    def test_default_chat_model_resolves_for_bedrock_with_no_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "bedrock")
+        assert llm_utils._resolve_default_chat_model() == BEDROCK_DEFAULT_MODEL

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -755,9 +755,7 @@ class TestBedrockAvailabilityWithoutApiKey:
     made ``create_graph()`` drop every analyzer with ``requires_api_key``.
     """
 
-    def test_provider_is_authoritative_for_bedrock(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_provider_is_authoritative_for_bedrock(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "bedrock")
         assert provider_is_authoritative(get_metadata_provider()) is True
 
@@ -773,9 +771,7 @@ class TestBedrockAvailabilityWithoutApiKey:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("SKILLSPECTOR_PROVIDER", "bedrock")
-        with patch(
-            "skillspector.llm_utils.create_chat_model", return_value=MagicMock()
-        ) as create:
+        with patch("skillspector.llm_utils.create_chat_model", return_value=MagicMock()) as create:
             ok, msg = is_llm_available()
         assert ok is True
         assert msg is None


### PR DESCRIPTION
## The problem

With `SKILLSPECTOR_PROVIDER=bedrock` and working AWS credentials, the three `semantic_*` analyzers are silently dropped from the graph:

```
WARNING [skillspector.graph] Skipping analyzer semantic_developer_intent: required API key is missing
WARNING [skillspector.graph] Skipping analyzer semantic_quality_policy: required API key is missing
WARNING [skillspector.graph] Skipping analyzer semantic_security_discovery: required API key is missing
```

…while `meta_analyzer` and `mcp_tool_poisoning` run on Bedrock in the same process and bill real tokens. The scan still exits successfully, so the only sign that detection was halved is a warning on stderr.

## Root cause

`create_graph()` drops any analyzer with `requires_api_key = True` unless `is_llm_available()` is true. That function probes the real chat model only when `has_provider_binding()` is true — and that reports whether a provider was injected through `use_provider()`, which only the programmatic/MCP path does. Choosing a provider with `SKILLSPECTOR_PROVIDER`, the only way available from the CLI, leaves the ContextVar empty, so the check falls through to `_resolve_llm_credentials()`, which understands API keys and knows nothing about the boto3 credential chain.

Reproduced directly:

```python
>>> os.environ["SKILLSPECTOR_PROVIDER"] = "bedrock"
>>> type(get_active_provider()).__name__
'BedrockProvider'
>>> has_provider_binding()
False
>>> is_llm_available()
(False, 'No LLM API key configured. ...')
```

`BedrockProvider.resolve_credentials()` returns `None` by design — its own docstring notes that the OpenAI fallback "is irrelevant for Bedrock" — so no API-key path can ever see it.

`_resolve_default_chat_model()` has the same shape and falls through to OpenAI for the same reason.

## The fix

`get_model_config_provider()` already gets this right: it treats an explicit binding, a CLI provider, or Bedrock as authoritative, and its docstring says as much. This extracts that predicate as `provider_is_authoritative()` and uses it at the two sites in `llm_utils.py` that lack it, so the three cannot drift apart.

Nothing changes for other providers: CLI providers are still short-circuited earlier, and an unbound API-key provider is still judged on its credentials. A Bedrock setup with *no* working credentials now fails the model probe rather than the API-key lookup, so the reported reason is the provider's own instead of a misleading "no API key".

## Verification

On a real scan of the same skill, `SKILLSPECTOR_PROVIDER=bedrock`:

| | before | after |
| --- | --- | --- |
| `semantic_*` in `analyzer_statuses` | none | all three |
| `metadata.llm_available` | `false` | `true` |
| `metadata.llm_calls_succeeded` | 2/2 | 5/5 |
| `metadata.meta_analysis_applied` | `false` | `true` |
| findings | 8 | 16 |

Five unit tests added in `tests/unit/test_llm_utils.py`, covering both directions — that Bedrock is authoritative without an API key, that an unbound API-key provider still is not, and that a Bedrock provider which cannot build a model reports its own error.

`tests/unit tests/provider tests/nodes` run identically before and after (12 pre-existing environment-dependent failures in both; 3803 → 3808 passing, the five new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)